### PR TITLE
use smaller footer for landing page

### DIFF
--- a/packages/devtools-launchpad/src/components/LandingPage.css
+++ b/packages/devtools-launchpad/src/components/LandingPage.css
@@ -94,7 +94,7 @@
 .landing-page .tab-group {
   position: absolute;
   margin: 40px;
-  height: calc(100% - 250px);
+  height: calc(100% - 100px);
   width: calc(100% - 80px);
   overflow: auto;
 }
@@ -128,7 +128,7 @@
 
 .landing-page .panel .center .footer-note {
   flex: 1;
-  padding: 50px;
+  padding: 20px 50px;
   font-size: 14px;
   color: var(--theme-comment);
   position: absolute;


### PR DESCRIPTION
The current footer of the landing page is too big and makes it hard to use when there are many tabs.

Before: 

![image](https://cloud.githubusercontent.com/assets/1141550/21282181/e879cc32-c3f2-11e6-9728-2beb9503bef2.png)

After 

![image](https://cloud.githubusercontent.com/assets/1141550/21282187/f73268e2-c3f2-11e6-8814-175e8d1d9404.png)
