### PR TITLE
Add a tab filter input

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-react": "^6.7.1",
     "express": "^4.13.4",
     "extract-text-webpack-plugin": "^1.0.1",
+    "fuzzaldrin-plus": "^0.4.0",
     "immutable": "^3.7.6",
     "json-loader": "^0.5.4",
     "minimist": "^1.2.0",

--- a/packages/devtools-launchpad/src/actions/tabs.js
+++ b/packages/devtools-launchpad/src/actions/tabs.js
@@ -44,7 +44,22 @@ function selectTab({ id }) {
   };
 }
 
+/**
+ * @memberof actions/tabs
+ * @static
+ * @param {String} value String which should be used to filter tabs
+ * @returns {TabAction} with type constants.FILTER_TABS
+ *          and filter string as value
+ */
+function filterTabs(value) {
+  return {
+    type: constants.FILTER_TABS,
+    value
+  };
+}
+
 module.exports = {
   newTabs,
-  selectTab
+  selectTab,
+  filterTabs
 };

--- a/packages/devtools-launchpad/src/components/LandingPage.css
+++ b/packages/devtools-launchpad/src/components/LandingPage.css
@@ -66,18 +66,35 @@
   justify-content: space-between;
 }
 
-.landing-page .panel .title {
+.landing-page .panel header {
+  display: flex;
+  align-items: baseline;
+  font-size: var(--title-font-size);
   margin: calc(2 * var(--base-spacing)) 0 0;
   padding-bottom: var(--base-spacing);
-  font-size: var(--title-font-size);
   border-bottom: 1px solid var(--theme-splitter-color);
+}
+
+.landing-page .panel header .title {
   color: var(--theme-body-color);
   font-weight: normal;
+  font-size: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+.landing-page .panel header input {
+  flex: 1;
+  color: var(--theme-body-color);
+  font-size: inherit;
+  border: 1px solid var(--theme-splitter-color);
+  margin-left: var(--base-spacing);
+  padding: calc(var(--base-spacing) / 4);
 }
 
 .landing-page .panel .center-message {
   font-size: var(--ui-element-font-size);
-  line-height: var(--secondary-line-height-line-height);
+  line-height: var(--secondary-line-height);
   padding: calc(var(--base-spacing) / 2);
 }
 
@@ -109,7 +126,7 @@
 }
 
 .landing-page .tab-title {
-  line-height: var(--secondary-line-height-line-height);
+  line-height: var(--secondary-line-height);
   font-size: var(--ui-element-font-size);
   color: var(--theme-highlight-bluegrey);
   word-break: break-all;

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -32,6 +32,8 @@ const LandingPage = React.createClass({
     supportsFirefox: React.PropTypes.bool.isRequired,
     supportsChrome: React.PropTypes.bool.isRequired,
     title: React.PropTypes.string.isRequired,
+    filterString: React.PropTypes.string,
+    onFilterChange: React.PropTypes.func.isRequired,
   },
 
   displayName: "LandingPage",
@@ -40,6 +42,15 @@ const LandingPage = React.createClass({
     return {
       selectedPane: "Firefox"
     };
+  },
+
+  onFilterChange(newFilterString) {
+    this.props.onFilterChange(newFilterString);
+  },
+
+  onSideBarItemClick(itemTitle) {
+    this.setState({ selectedPane: itemTitle });
+    this.onFilterChange("");
   },
 
   renderTabs(tabs, paramName) {
@@ -94,10 +105,23 @@ const LandingPage = React.createClass({
       docsUrlPart
     } = configMap[this.state.selectedPane];
 
-    const targets = getTabsByClientType(this.props.tabs, clientType);
+    let {
+      tabs,
+      filterString = ""
+    } = this.props;
+
+    const targets = getTabsByClientType(tabs, clientType);
 
     return dom.main({ className: "panel" },
-      dom.h2({ className: "title" }, name),
+      dom.header(
+        {},
+        dom.h2({ className: "title" }, name),
+        dom.input({
+          placeholder: "Filter tabs",
+          value: filterString,
+          onChange: e => this.onFilterChange(e.target.value)
+        })
+      ),
       this.renderTabs(targets, paramName),
       firstTimeMessage(name, docsUrlPart)
     );
@@ -128,7 +152,7 @@ const LandingPage = React.createClass({
             }),
             key: title,
 
-            onClick: () => this.setState({ selectedPane: title })
+            onClick: () => this.onSideBarItemClick(title)
           },
           dom.a({}, title)
       )))

--- a/packages/devtools-launchpad/src/components/LaunchpadApp.js
+++ b/packages/devtools-launchpad/src/components/LaunchpadApp.js
@@ -1,13 +1,16 @@
 const React = require("react");
 const { PropTypes } = React;
 const { connect } = require("react-redux");
-const { getTabs } = require("../selectors");
+const { bindActionCreators } = require("redux");
+const { getTabs, getFilterString } = require("../selectors");
 const { getValue } = require("devtools-config");
 const LandingPage = React.createFactory(require("./LandingPage"));
 
 const LaunchpadApp = React.createClass({
   propTypes: {
-    tabs: PropTypes.array
+    tabs: PropTypes.array,
+    filterString: PropTypes.string,
+    actions: PropTypes.array
   },
 
   displayName: "LaunchpadApp",
@@ -17,13 +20,27 @@ const LaunchpadApp = React.createClass({
       tabs: this.props.tabs,
       supportsFirefox: !!getValue("firefox"),
       supportsChrome: !!getValue("chrome"),
-      title: getValue("title")
+      title: getValue("title"),
+      filterString: this.props.filterString,
+      onFilterChange: this.props.actions.filterTabs
     });
   }
 });
 
+function mapStateToProps(state) {
+  return {
+    tabs: getTabs(state),
+    filterString: getFilterString(state)
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(require("../actions"), dispatch)
+  };
+}
+
 module.exports = connect(
-  state => ({
-    tabs: getTabs(state)
-  })
+  mapStateToProps,
+  mapDispatchToProps
 )(LaunchpadApp);

--- a/packages/devtools-launchpad/src/constants.js
+++ b/packages/devtools-launchpad/src/constants.js
@@ -4,5 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-exports.ADD_TABS = "ADD_TABS";
-exports.SELECT_TAB = "SELECT_TAB";
+module.exports = {
+  ADD_TABS: "ADD_TABS",
+  SELECT_TAB: "SELECT_TAB",
+  FILTER_TABS: "FILTER_TABS"
+};

--- a/packages/devtools-launchpad/src/reducers/tabs.js
+++ b/packages/devtools-launchpad/src/reducers/tabs.js
@@ -9,6 +9,7 @@ const fromJS = require("../utils/fromJS");
 const initialState = fromJS({
   tabs: {},
   selectedTab: null,
+  filterString: "",
 });
 
 function update(state = initialState, action) {
@@ -26,9 +27,13 @@ function update(state = initialState, action) {
           return [tab.id, Immutable.Map(tab)];
         }))
       );
+
     case constants.SELECT_TAB:
-      const tab = state.getIn(["tabs", action.id]);
-      return state.setIn(["selectedTab"], tab);
+      const tabToSelect = state.getIn(["tabs", action.id]);
+      return state.setIn(["selectedTab"], tabToSelect);
+
+    case constants.FILTER_TABS:
+      return state.setIn(["filterString"], action.value);
   }
 
   return state;

--- a/packages/devtools-launchpad/src/selectors.js
+++ b/packages/devtools-launchpad/src/selectors.js
@@ -1,12 +1,29 @@
+const { score } = require("fuzzaldrin-plus");
+
 function getTabs(state) {
-  return state.tabs.get("tabs");
+  let tabs = state.tabs.get("tabs");
+  let filterString = getFilterString(state);
+
+  if (filterString === "") {
+    return tabs;
+  }
+
+  return tabs.filter(tab => (
+    score(tab.get("title"), filterString) +
+    score(tab.get("url"), filterString) > 0
+  ));
 }
 
 function getSelectedTab(state) {
   return state.tabs.get("selectedTab");
 }
 
+function getFilterString(state) {
+  return state.tabs.get("filterString");
+}
+
 module.exports = {
   getTabs,
-  getSelectedTab
+  getSelectedTab,
+  getFilterString
 };

--- a/packages/devtools-launchpad/stories/index.js
+++ b/packages/devtools-launchpad/stories/index.js
@@ -1,7 +1,12 @@
 const React = require("react");
-const { storiesOf } = require("@kadira/storybook");
+const { storiesOf, action } = require("@kadira/storybook");
 const LandingPage = require("../src/components/LandingPage");
-const { Map } = require("immutable");
+
+const { combineReducers } = require("redux");
+let reducers = require("../src/reducers");
+let constants = require("../src/constants");
+let getState = combineReducers(reducers);
+const selectors = require("../src/selectors");
 
 // Add devtools theme styles
 require("../src/lib/themes/light-theme.css");
@@ -11,69 +16,103 @@ const getTab = (id, title, clientType, url) => {
   if (!url) {
     url = `/test/${id}`;
   }
-  return [id, Map({
+
+  return {
     url,
     clientType,
-    id,
+    id: `${id}`,
     title
-  })];
+  };
+};
+
+const getTabs = (tabs, state) => {
+  let newState = getState(state, {
+    type: constants.ADD_TABS,
+    value: tabs
+  });
+
+  return selectors.getTabs(newState);
 };
 
 const renderLandingPage = (props) => {
-  return React.DOM.div({}, React.createElement(LandingPage, props));
+  return React.DOM.div({}, React.createElement(LandingPage, Object.assign({
+    onFilterChange: action("FILTER_TABS")
+  }, props)));
 };
 
 storiesOf("LandingPage", module)
   .add("six firefox tabs", () => {
-    let tabs = Map([
+    let tabs = [
       getTab(1, "Page 1", "firefox"),
       getTab(2, "Page 2", "firefox"),
       getTab(3, "Page 3", "firefox"),
       getTab(4, "Page 4", "firefox"),
       getTab(5, "Page 5", "firefox"),
       getTab(6, "Page 6", "firefox"),
-    ]);
+    ];
 
     return renderLandingPage({
-      tabs,
+      tabs: getTabs(tabs),
       supportsFirefox: true,
       supportsChrome: true,
       title: "Storybook test"
     });
   })
   .add("two of each", () => {
-    let tabs = Map([
+    let tabs = [
       getTab(1, "Page 1", "firefox"),
       getTab(2, "Page 2", "firefox"),
       getTab(3, "Page 3", "chrome"),
       getTab(4, "Page 4", "chrome"),
       getTab(5, "process 1", "node"),
       getTab(6, "process 2", "node"),
-    ]);
+    ];
 
     return renderLandingPage({
-      tabs,
+      tabs: getTabs(tabs),
       supportsFirefox: true,
       supportsChrome: true,
       title: "Storybook test"
     });
   })
   .add("one hundred firefox tabs with long titles and URLs", () => {
-    let tabs = Map(
-      Array(100)
-        .fill()
-        .map((_, i) =>
-          getTab(
-            i + 1,
-            `My very long title ${(`${i + 1}-`).repeat(50)}`,
-            "firefox",
-            `this/is/a/very/long/url/${(`${i + 1}/`).repeat(50)}`,
-          )
+    let tabs = Array(100)
+      .fill()
+      .map((_, i) =>
+        getTab(
+          i + 1,
+          `My very long title ${(`${i + 1}-`).repeat(50)}`,
+          "firefox",
+          `this/is/a/very/long/url/${(`${i + 1}/`).repeat(50)}`,
         )
-    );
+      );
 
     return renderLandingPage({
-      tabs,
+      tabs: getTabs(tabs),
+      supportsFirefox: true,
+      supportsChrome: true,
+      title: "Storybook test"
+    });
+  })
+  .add("six firefox tabs, filtered with \"MoZ\" (two tabs match)", () => {
+    let filterString = "MoZ";
+    let tabs = [
+      getTab(1, "Mozilla", "firefox"),
+      getTab(2, "Page 2", "firefox", "https://mozilla.com"),
+      getTab(3, "Page 3", "firefox"),
+      getTab(4, "Page 4", "firefox"),
+      getTab(5, "Page 5", "firefox"),
+      getTab(6, "Page 6", "firefox"),
+    ];
+
+    let state = getState(undefined, {
+      type: constants.FILTER_TABS,
+      value: filterString
+    });
+
+    return renderLandingPage({
+      tabs: getTabs(tabs, state),
+      filterString: selectors.getFilterString(state),
       supportsFirefox: true,
       supportsChrome: true,
       title: "Storybook test"

--- a/packages/devtools-launchpad/stories/index.js
+++ b/packages/devtools-launchpad/stories/index.js
@@ -19,6 +19,10 @@ const getTab = (id, title, clientType, url) => {
   })];
 };
 
+const renderLandingPage = (props) => {
+  return React.DOM.div({}, React.createElement(LandingPage, props));
+};
+
 storiesOf("LandingPage", module)
   .add("six firefox tabs", () => {
     let tabs = Map([
@@ -30,16 +34,14 @@ storiesOf("LandingPage", module)
       getTab(6, "Page 6", "firefox"),
     ]);
 
-    return React.DOM.div(
-      {},
-      React.createElement(LandingPage, {
-        tabs,
-        supportsFirefox: true,
-        supportsChrome: true,
-        title: "Storybook test"
-      })
-    );
-  }).add("two of each", () => {
+    return renderLandingPage({
+      tabs,
+      supportsFirefox: true,
+      supportsChrome: true,
+      title: "Storybook test"
+    });
+  })
+  .add("two of each", () => {
     let tabs = Map([
       getTab(1, "Page 1", "firefox"),
       getTab(2, "Page 2", "firefox"),
@@ -49,15 +51,12 @@ storiesOf("LandingPage", module)
       getTab(6, "process 2", "node"),
     ]);
 
-    return React.DOM.div(
-      { },
-      React.createElement(LandingPage, {
-        tabs,
-        supportsFirefox: true,
-        supportsChrome: true,
-        title: "Storybook test"
-      })
-    );
+    return renderLandingPage({
+      tabs,
+      supportsFirefox: true,
+      supportsChrome: true,
+      title: "Storybook test"
+    });
   })
   .add("one hundred firefox tabs with long titles and URLs", () => {
     let tabs = Map(
@@ -66,20 +65,17 @@ storiesOf("LandingPage", module)
         .map((_, i) =>
           getTab(
             i + 1,
-            `My very long title ${("-" + i + 1).repeat(50)}`,
+            `My very long title ${(`${i + 1}-`).repeat(50)}`,
             "firefox",
-            `this/is/a/very/long/url/${("" + i + 1).repeat(100)}`
+            `this/is/a/very/long/url/${(`${i + 1}/`).repeat(50)}`,
           )
         )
     );
 
-    return React.DOM.div(
-      {},
-      React.createElement(LandingPage, {
-        tabs,
-        supportsFirefox: true,
-        supportsChrome: true,
-        title: "Storybook test"
-      })
-    );
+    return renderLandingPage({
+      tabs,
+      supportsFirefox: true,
+      supportsChrome: true,
+      title: "Storybook test"
+    });
   });


### PR DESCRIPTION
Fixes #25 

This patch adds an input aside to the "target" label and allow the user to filter out the tabs shown.
That's done the Redux way, hence the patch adds constant, selector and reducer to handle the filtering.
It uses the fuzzaldrin-plus package to handle the filtering (same as the debugger).

This is how it looks : 
![capture du 2016-12-27 12-03-57](https://cloud.githubusercontent.com/assets/578107/21498444/b4d9a77a-cc2c-11e6-90c9-f4e8dedcff7b.png)

The thing I'm not confident with is the change in stories. I added a way to create the redux state as the app does and get the tabs and the filteringText from there. I did this to make sure the filtering was working, but maybe there's a better way I didn't thought about ?


