### PR TITLE
Multiple style bundles

### DIFF
--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -113,7 +113,7 @@ module.exports = (webpackConfig, envConfig) => {
       loader: ExtractTextPlugin.extract("style-loader", "css-loader", "postcss-loader")
     });
 
-    webpackConfig.plugins.push(new ExtractTextPlugin("styles.css"));
+    webpackConfig.plugins.push(new ExtractTextPlugin("[name].css"));
   }
 
   webpackConfig.postcss = () => [require("postcss-bidirection")];

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -106,6 +106,10 @@ module.exports = (webpackConfig, envConfig) => {
   // Extract CSS into a single file
     webpackConfig.module.loaders.push({
       test: /\.css$/,
+      exclude: request => {
+        // If the tool defines an exclude regexp for CSS files.
+        return webpackConfig.cssExcludes && request.match(webpackConfig.cssExcludes);
+      },
       loader: ExtractTextPlugin.extract("style-loader", "css-loader", "postcss-loader")
     });
 


### PR DESCRIPTION
cf. https://github.com/devtools-html/debugger.html/pull/1445#issuecomment-269310411 

If a tool using launchpad is requiring css files from several bundles, only one styles.css will be created, containing the CSS files from the last entry that got loaded.

I think we should both
* allow tools to provide an exclude regexp, to avoid including unnecessary styles in the bundle
* add the bundle name to the styles bundle, to avoid losing time investigating this kind of issues

cc @jasonLaster 
