### PR TITLE
Fix tab click in launchpad storybook

### DIFF
--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -34,6 +34,7 @@ const LandingPage = React.createClass({
     title: React.PropTypes.string.isRequired,
     filterString: React.PropTypes.string,
     onFilterChange: React.PropTypes.func.isRequired,
+    onTabClick: React.PropTypes.func.isRequired,
   },
 
   displayName: "LandingPage",
@@ -65,9 +66,7 @@ const LandingPage = React.createClass({
         tabs.valueSeq().map(tab => dom.li(
           { "className": "tab",
             "key": tab.get("id"),
-            "onClick": () => {
-              window.location = getTabURL(tab, paramName);
-            }
+            "onClick": () => this.props.onTabClick(getTabURL(tab, paramName))
           },
           dom.div({ className: "tab-title" }, tab.get("title")),
           dom.div({ className: "tab-url" }, tab.get("url"))

--- a/packages/devtools-launchpad/src/components/LaunchpadApp.js
+++ b/packages/devtools-launchpad/src/components/LaunchpadApp.js
@@ -23,7 +23,10 @@ const LaunchpadApp = React.createClass({
       supportsChrome: !!getValue("chrome"),
       title: getValue("title"),
       filterString: this.props.filterString,
-      onFilterChange: this.props.actions.filterTabs
+      onFilterChange: this.props.actions.filterTabs,
+      onTabClick: (url) => {
+        window.location = url;
+      }
     });
   }
 });

--- a/packages/devtools-launchpad/stories/index.js
+++ b/packages/devtools-launchpad/stories/index.js
@@ -36,7 +36,8 @@ const getTabs = (tabs, state) => {
 
 const renderLandingPage = (props) => {
   return React.DOM.div({}, React.createElement(LandingPage, Object.assign({
-    onFilterChange: action("FILTER_TABS")
+    onFilterChange: action("FILTER_TABS"),
+    onTabClick: action("onTabClick")
   }, props)));
 };
 


### PR DESCRIPTION
Pass the actual onClick handler as a props from LaunchpadApp to LandingPage so the current behavior
still works.
In storybook, when creating the LandingPage, pass an action logger so we don't have story inception anymore

Fixes #29 