### PR TITLE
Better keyboard navigation

### DIFF
--- a/packages/devtools-launchpad/src/components/LandingPage.css
+++ b/packages/devtools-launchpad/src/components/LandingPage.css
@@ -65,7 +65,7 @@
 
 .landing-page .sidebar li:hover a,
 .landing-page .sidebar li:focus a {
-color: inherit;
+  color: inherit;
 }
 
 .landing-page .panel {

--- a/packages/devtools-launchpad/src/components/LandingPage.css
+++ b/packages/devtools-launchpad/src/components/LandingPage.css
@@ -136,18 +136,21 @@ color: inherit;
   word-break: break-all;
 }
 
-.landing-page .tab:focus {
+.landing-page .tab:focus,
+.landing-page .tab.active {
   background: var(--theme-selection-background);
   color: var(--theme-selection-color);
   cursor: pointer;
   transition: var(--base-transition);
 }
 
-.landing-page .tab:focus .tab-title {
+.landing-page .tab:focus .tab-title,
+.landing-page .tab.active .tab-title {
   color: inherit;
 }
 
-.landing-page .tab:focus .tab-url {
+.landing-page .tab:focus .tab-url,
+.landing-page .tab.active .tab-url {
   color: var(--theme-highlight-gray);
 }
 

--- a/packages/devtools-launchpad/src/components/LandingPage.css
+++ b/packages/devtools-launchpad/src/components/LandingPage.css
@@ -11,6 +11,7 @@
   --primary-line-height: 30px;
   --secondary-line-height: 25px;
   --base-spacing: 20px;
+  --base-transition: all 0.25s ease;
 }
 
 .landing-page .sidebar {
@@ -41,34 +42,36 @@
   padding: calc(var(--base-spacing) / 4) var(--base-spacing);
 }
 
+.landing-page .sidebar li a {
+  color: var(--theme-body-color);
+}
+
 .landing-page .sidebar li.selected {
   background: var(--theme-highlight-bluegrey);
   color: var(--theme-selection-color);
-  transition: all 0.25s ease;
+  transition: var(--base-transition);
 }
 
 .landing-page .sidebar li.selected a {
   color: inherit;
 }
 
-.landing-page .sidebar li:hover {
+.landing-page .sidebar li:hover,
+.landing-page .sidebar li:focus {
   background: var(--theme-selection-background);
+  color: var(--theme-selection-color);
   cursor: pointer;
 }
 
-.landing-page .sidebar li a {
-  color: var(--theme-body-color);
-}
-
-.landing-page .sidebar li:hover a {
-  color: var(--theme-selection-color);
+.landing-page .sidebar li:hover a,
+.landing-page .sidebar li:focus a {
+color: inherit;
 }
 
 .landing-page .panel {
   display: flex;
   flex: 1;
   flex-direction: column;
-  padding: 0 var(--base-spacing);
   justify-content: space-between;
 }
 
@@ -85,6 +88,12 @@
   font-size: var(--ui-element-font-size);
   border: 1px solid var(--theme-splitter-color);
   padding: calc(var(--base-spacing) / 2);
+  margin: 0 var(--base-spacing);
+  transition: var(--base-transition);
+}
+
+.landing-page .panel header input:focus {
+  border: 1px solid var(--theme-selection-background);
 }
 
 .landing-page .panel .center-message {
@@ -111,13 +120,8 @@
 
 .landing-page .tab {
   border-bottom: 1px solid var(--theme-splitter-color);
-  padding: calc(var(--base-spacing) / 2) 0;
+  padding: calc(var(--base-spacing) / 2) var(--base-spacing);
   font-family: sans-serif;
-}
-
-.landing-page .tab:hover {
-  background-color: var(--theme-toolbar-background);
-  cursor: pointer;
 }
 
 .landing-page .tab-title {
@@ -130,6 +134,21 @@
 .landing-page .tab-url {
   color: var(--theme-comment);
   word-break: break-all;
+}
+
+.landing-page .tab:focus {
+  background: var(--theme-selection-background);
+  color: var(--theme-selection-color);
+  cursor: pointer;
+  transition: var(--base-transition);
+}
+
+.landing-page .tab:focus .tab-title {
+  color: inherit;
+}
+
+.landing-page .tab:focus .tab-url {
+  color: var(--theme-highlight-gray);
 }
 
 .landing-page .panel .footer-note {

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -63,13 +63,20 @@ const LandingPage = React.createClass({
       return dom.div({}, "");
     }
 
+    let tabClassNames = ["tab"];
+    if (tabs.size === 1) {
+      tabClassNames.push("active");
+    }
+
     return dom.div(
       { className: "tab-group" },
       dom.ul(
         { className: "tab-list" },
         tabs.valueSeq().map(
           tab => dom.li({
-            className: "tab",
+            className: classnames("tab", {
+              active: tabs.size === 1
+            }),
             key: tab.get("id"),
             tabIndex: 0,
             role: "link",
@@ -132,7 +139,12 @@ const LandingPage = React.createClass({
           value: filterString,
           autoFocus: true,
           type: "search",
-          onChange: e => this.onFilterChange(e.target.value)
+          onChange: e => this.onFilterChange(e.target.value),
+          onKeyDown: e => {
+            if (targets.size === 1 && e.keyCode === 13) {
+              this.onTabClick(targets.first(), paramName);
+            }
+          }
         })
       ),
       this.renderTabs(targets, paramName),

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -54,6 +54,10 @@ const LandingPage = React.createClass({
     this.onFilterChange("");
   },
 
+  onTabClick(tab, paramName) {
+    this.props.onTabClick(getTabURL(tab, paramName));
+  },
+
   renderTabs(tabs, paramName) {
     if (!tabs || tabs.count() == 0) {
       return dom.div({}, "");
@@ -63,14 +67,23 @@ const LandingPage = React.createClass({
       { className: "tab-group" },
       dom.ul(
         { className: "tab-list" },
-        tabs.valueSeq().map(tab => dom.li(
-          { "className": "tab",
-            "key": tab.get("id"),
-            "onClick": () => this.props.onTabClick(getTabURL(tab, paramName))
+        tabs.valueSeq().map(
+          tab => dom.li({
+            className: "tab",
+            key: tab.get("id"),
+            tabIndex: 0,
+            role: "link",
+            onClick: () => this.onTabClick(tab, paramName),
+            onKeyDown: e => {
+              if (e.keyCode === 13) {
+                this.onTabClick(tab, paramName);
+              }
+            }
           },
           dom.div({ className: "tab-title" }, tab.get("title")),
           dom.div({ className: "tab-url" }, tab.get("url"))
-        ))
+          )
+        )
       )
     );
   },
@@ -117,6 +130,8 @@ const LandingPage = React.createClass({
         dom.input({
           placeholder: "Filter tabs",
           value: filterString,
+          autoFocus: true,
+          type: "search",
           onChange: e => this.onFilterChange(e.target.value)
         })
       ),
@@ -149,8 +164,14 @@ const LandingPage = React.createClass({
               selected: title == this.state.selectedPane
             }),
             key: title,
-
-            onClick: () => this.onSideBarItemClick(title)
+            tabIndex: 0,
+            role: "button",
+            onClick: () => this.onSideBarItemClick(title),
+            onKeyDown: e => {
+              if (e.keyCode === 13) {
+                this.onSideBarItemClick(title);
+              }
+            }
           },
           dom.a({}, title)
       )))

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -45,13 +45,19 @@ const LandingPage = React.createClass({
     };
   },
 
+  componentDidUpdate() {
+    this.refs.filterInput.focus();
+  },
+
   onFilterChange(newFilterString) {
     this.props.onFilterChange(newFilterString);
   },
 
   onSideBarItemClick(itemTitle) {
-    this.setState({ selectedPane: itemTitle });
-    this.onFilterChange("");
+    if (itemTitle !== this.state.selectedPane) {
+      this.setState({ selectedPane: itemTitle });
+      this.onFilterChange("");
+    }
   },
 
   onTabClick(tab, paramName) {
@@ -135,6 +141,7 @@ const LandingPage = React.createClass({
       dom.header(
         {},
         dom.input({
+          ref: "filterInput",
           placeholder: "Filter tabs",
           value: filterString,
           autoFocus: true,

--- a/packages/devtools-launchpad/stories/index.js
+++ b/packages/devtools-launchpad/stories/index.js
@@ -118,4 +118,18 @@ storiesOf("LandingPage", module)
       supportsChrome: true,
       title: "Storybook test"
     });
+  })
+  .add("One of each", () => {
+    let tabs = [
+      getTab(1, "Page 1", "firefox"),
+      getTab(2, "Page 2", "chrome"),
+      getTab(3, "process 1", "node"),
+    ];
+
+    return renderLandingPage({
+      tabs: getTabs(tabs),
+      supportsFirefox: true,
+      supportsChrome: true,
+      title: "Storybook test"
+    });
   });

--- a/packages/devtools-launchpad/stories/index.js
+++ b/packages/devtools-launchpad/stories/index.js
@@ -36,7 +36,7 @@ const getTabs = (tabs, state) => {
 
 const renderLandingPage = (props) => {
   return React.DOM.div({}, React.createElement(LandingPage, Object.assign({
-    onFilterChange: action("FILTER_TABS"),
+    onFilterChange: action("onFilterChange"),
     onTabClick: action("onTabClick")
   }, props)));
 };


### PR DESCRIPTION
Add autoFocus on filter tab to make it faster to search for a specific tab.
Add tabIndex and :focus styling  on the relevant items (sidebar items, tab items) to make it easy to navigate with the keyboard in the app.

If there is only one tab (either because there is really only one, or because we filtered them out, pressing
<kbd>Enter</kbd> starts the debugging on the tab.

I'm not sure about https://github.com/devtools-html/devtools-core/commit/761e75789efcdd796bc86862a0944a7b3963c871 , which automatically focus the filter bar when clicking on a sidebar element, tell me what you think about this @jasonLaster & @juliandescottes 

Here's how keyboard navigation looks : 

![kbd-nav](https://cloud.githubusercontent.com/assets/578107/21529329/e45b3f6a-cd38-11e6-932d-c723feaf846e.gif)

And navigationg when there is only one tab : 

![kbd-nav-single-tab](https://cloud.githubusercontent.com/assets/578107/21529332/f13d560a-cd38-11e6-8be4-77b499a7c022.gif)

