### PR TITLE
Fix line length so linting passes.

### DIFF
--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -16,7 +16,9 @@ function firstTimeMessage(title, urlPart) {
   return dom.div(
     { className: "footer-note" },
     `First time connecting to ${title}? Checkout out the `,
-    dom.a({ href: `${githubUrl}/docs/getting-setup.md#starting-${urlPart}` }, "docs"),
+    dom.a({
+      href: `${githubUrl}/docs/getting-setup.md#starting-${urlPart}`
+    }, "docs"),
     "."
   );
 }


### PR DESCRIPTION
The current line length for 19 is over 80 chars causing the pre-commit linting to fail. A quick reformat of the anchor creation fixes this so linting passes without issue.