### PR TITLE
Fix lerna version in config.

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "lerna": "2.0.0-beta.30",
+  "lerna": "2.0.0-beta.31",
   "version": "independent"
 }


### PR DESCRIPTION
The lerna version was updated in commit 9f1429d857af014aa5f0c0e7dd717698f0f69d8e however the lerna configuration was not updated. This makes it fail when re-running the bootstrap process. This patch addresses the problem by updating the lerna config to use the currently depended upon version.