### PR TITLE
  [DarkMode] fix text selection #1622 from debugger.html

### DIFF
--- a/packages/devtools-launchpad/src/lib/themes/dark-theme.css
+++ b/packages/devtools-launchpad/src/lib/themes/dark-theme.css
@@ -208,11 +208,11 @@ body {
 }
 
 .cm-s-mozilla.CodeMirror-focused .CodeMirror-selected { /* selected text (focused) */
-  background: rgb(185, 215, 253);
+  background: rgb(77, 86, 103);
 }
 
 .cm-s-mozilla .CodeMirror-selected { /* selected text (unfocused) */
-  background: rgb(255, 255, 0);
+  background: rgb(77, 86, 103);
 }
 
 .cm-s-mozilla .CodeMirror-activeline-background { /* selected color with alpha */


### PR DESCRIPTION
Fixing this issue https://github.com/devtools-html/debugger.html/issues/1622

before focused
![before_focused](https://cloud.githubusercontent.com/assets/922368/21695206/b7ae59cc-d380-11e6-96fe-b4563a49c975.png)

before unfocused
![before_unfocused](https://cloud.githubusercontent.com/assets/922368/21695207/b7b29e60-d380-11e6-8b25-56ffb4ef120d.png)

after focused or unfocused
![after_focused_or_unfocused](https://cloud.githubusercontent.com/assets/922368/21695208/b7b8ceca-d380-11e6-95bd-c8405e026960.png)

I think both focused or unfocused should be the same