### PR TITLE
Fix tab filter background and text color

### DIFF
--- a/packages/devtools-launchpad/src/components/LandingPage.css
+++ b/packages/devtools-launchpad/src/components/LandingPage.css
@@ -84,12 +84,17 @@
 
 .landing-page .panel header input {
   flex: 1;
-  color: var(--theme-body-color);
+  background-color: var(--theme-tab-toolbar-background);
+  color: var(--theme-comment);
   font-size: var(--ui-element-font-size);
   border: 1px solid var(--theme-splitter-color);
   padding: calc(var(--base-spacing) / 2);
   margin: 0 var(--base-spacing);
   transition: var(--base-transition);
+}
+
+.landing-page .panel header input::placeholder {
+  color: var(--theme-body-color-inactive);
 }
 
 .landing-page .panel header input:focus {


### PR DESCRIPTION
The tab filter background wasn't set so it remained white. It now respects the theme and the text color was set to match the colors used in the EditorSearch in the debugger.

Screenshot
![screenshot_20170105_182033](https://cloud.githubusercontent.com/assets/580982/21704057/a8f543a8-d373-11e6-9ed6-2fe5916909b2.png)
