### PR TITLE
support linking for all devtools-* modules

### DIFF
--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = (webpackConfig, envConfig) => {
     test: /\.js$/,
     exclude: request => {
       let excluded = request.match(
-        /(node_modules|bower_components|fs|devtools-config)/
+        /(node_modules|bower_components|fs|devtools-)/
       );
       if (webpackConfig.babelExcludes) {
         // If the tool defines an additional exclude regexp for Babel.


### PR DESCRIPTION
Fix for #69 

With this simple change I am able to use linking for all devtools-core packages with the debugger.
In the long run,  webpack2 should also improve the situation here.

Please note that when using linking, the "debugger.js" bundle goes from ~700 files to ~1200 files.

cc @jasonLaster 