### PR TITLE
Fix devtools-core for reps (linking & ff client)

### DIFF
--- a/packages/devtools-client-adapters/src/firefox.js
+++ b/packages/devtools-client-adapters/src/firefox.js
@@ -102,7 +102,7 @@ function initPage(actions: Actions) {
   tabTarget = getTabTarget();
   threadClient = getThreadClient();
 
-  if (!threadClient || !tabTarget || !actions) {
+  if (!threadClient || !tabTarget) {
     return;
   }
 

--- a/packages/devtools-launchpad/webpack.config.devtools.js
+++ b/packages/devtools-launchpad/webpack.config.devtools.js
@@ -42,11 +42,15 @@ module.exports = (webpackConfig, envConfig) => {
       return;
     } else if (nativeMapping[mod]) {
       const mapping = nativeMapping[mod];
-      if (Array.isArray(mapping)) {
-        callback(null, `var devtoolsRequire("${mapping[0]}")["${mapping[1]}"]`);
-      }
-      else {
-        callback(null, `var devtoolsRequire("${mapping}")`);
+
+      if (webpackConfig.externalsRequire) {
+        // If the tool defines "externalsRequire" in the webpack config, wrap
+        // all require to external dependencies with a call to the tool's
+        // externalRequire method.
+        let reqMethod = webpackConfig.externalsRequire;
+        callback(null, `var ${reqMethod}("${mapping[0]}")`);
+      } else {
+        callback(null, mapping);
       }
       return;
     }

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -27,9 +27,21 @@ module.exports = (webpackConfig, envConfig) => {
   webpackConfig.module.loaders.push({
     test: /\.js$/,
     exclude: request => {
-      let excluded = request.match(
-        /(node_modules|bower_components|fs|devtools-)/
-      );
+      let excludedPaths = [
+        "bower_components",
+        "fs",
+        "node_modules",
+        // All devtools-core packages should be excluded from babel translation,
+        // except devtools-client-adapters and devtools-launchpad.
+        "devtools-config",
+        "devtools-modules",
+        "devtools-network-request",
+        "devtools-sham-modules",
+      ];
+      // Create a regexp matching any of the paths in excludedPaths
+      let excludedRe = new RegExp(`(${ excludedPaths.join("|") })`);
+      let excluded = request.match(excludedRe);
+
       if (webpackConfig.babelExcludes) {
         // If the tool defines an additional exclude regexp for Babel.
         excluded = excluded || request.match(webpackConfig.babelExcludes);


### PR DESCRIPTION
This should fix the issues mentioned in https://github.com/devtools-html/devtools-reps/issues/43

The webpack config now explicitly excludes all devtools-core module (except for launchpad & client-adapters, which were "unexcluded" afterwards).

Also fixed a small bug with the ff client adapters which makes the actions argument of the launchpad bootstrap method mandatory, while reps is not providing any action.