### PR TITLE
fix wrong calculation when panels are open

### DIFF
--- a/packages/devtools-modules/client/shared/components/splitter/SplitBox.js
+++ b/packages/devtools-modules/client/shared/components/splitter/SplitBox.js
@@ -101,13 +101,13 @@ const SplitBox = React.createClass({
   },
 
   screenX() {
-    const borderWidth = (window.outerWidth - window.innerWidth) / 2;
-    return window.screenX + borderWidth;
+    // NOTE: in practice the window might have a border which calls for comparing window.outerWidth and window.innerWidth
+    return window.screenX;
   },
 
   screenY() {
-    const borderHeignt = (window.outerHeight - window.innerHeight);
-    return window.screenY + borderHeignt;
+    // NOTE: in practice the window might have a border which calls for comparing window.outerHeight and window.innerHeight
+    return window.screenY;
   },
 
   /**


### PR DESCRIPTION
In split box, we calculate screenX and screenY with a consideration of the window's border. This is done by comparing window.outerWidth and window.innerWidth (or height).
When there are panels (e.g. devtools :) or bookmarks) the difference between outer and inner size is very large. So the split box breaks.

Neglecting the window's border is a small price to pay since it's around 5px (in Windows) compared to not being about to dock right (or dock bottom with a vertical flow).
The ideal solution would be to not use screenX and screenY, but I realize the tradeoff with not having to calculate relative coordinates of iframes.