### PR TITLE
add unmountRoot in devtools-launchpad

### DIFF
--- a/packages/devtools-launchpad/src/components/Root.js
+++ b/packages/devtools-launchpad/src/components/Root.js
@@ -10,9 +10,9 @@ function themeClass() {
 
 const rootClass = classnames("theme-body", { [themeClass()]: isDevelopment() });
 
-module.exports = function() {
+module.exports = function(className) {
   const root = document.createElement("div");
-  root.className = rootClass;
+  root.className = classnames(rootClass, className);
   root.style.setProperty("flex", 1);
   return root;
 };

--- a/packages/devtools-launchpad/src/index.js
+++ b/packages/devtools-launchpad/src/index.js
@@ -63,7 +63,7 @@ function renderRoot(_React, _ReactDOM, component, _store) {
     return;
   }
 
-  const root = Root();
+  const root = Root("launchpad-root");
   mount.appendChild(root);
 
   if (component.props || component.propTypes) {
@@ -74,6 +74,11 @@ function renderRoot(_React, _ReactDOM, component, _store) {
   } else {
     root.appendChild(component);
   }
+}
+
+function unmountRoot(_ReactDOM) {
+  const mount = document.querySelector("#mount .launchpad-root");
+  _ReactDOM.unmountComponentAtNode(mount);
 }
 
 function getTargetFromQuery() {
@@ -125,6 +130,7 @@ function bootstrap(React, ReactDOM, App, appActions, appStore) {
 module.exports = {
   bootstrap,
   renderRoot,
+  unmountRoot,
   debugGlobal,
   L10N
 };


### PR DESCRIPTION
Related to the memory leak we found yesterday, I think it makes sense to leave the responsibility to launchpad to unmount the proper node, since launchpad is the one that decides to create a child in #mount.