### PR TITLE
fix externals require mapping

### DIFF
--- a/packages/devtools-launchpad/webpack.config.devtools.js
+++ b/packages/devtools-launchpad/webpack.config.devtools.js
@@ -48,7 +48,7 @@ module.exports = (webpackConfig, envConfig) => {
         // all require to external dependencies with a call to the tool's
         // externalRequire method.
         let reqMethod = webpackConfig.externalsRequire;
-        callback(null, `var ${reqMethod}("${mapping[0]}")`);
+        callback(null, `var ${reqMethod}("${mapping}")`);
       } else {
         callback(null, mapping);
       }
@@ -61,7 +61,9 @@ module.exports = (webpackConfig, envConfig) => {
   webpackConfig.externals.push(externalsTest);
 
   // Remove the existing DefinePlugin so we can override it.
-  const plugins = webpackConfig.plugins.filter(p => !(p instanceof DefinePlugin));
+  const plugins = webpackConfig.plugins.filter(
+    p => !(p instanceof DefinePlugin)
+  );
   webpackConfig.plugins = plugins.concat([
     new webpack.DefinePlugin({
       "process.env": {


### PR DESCRIPTION
I missed this while testing the later externalsRequire patch.

The issue is that `[0]` gets the first character of the mapping.