### PR TITLE
condensing output from log on yarn run command to save space

### DIFF
--- a/packages/devtools-launchpad/bin/firefox-proxy
+++ b/packages/devtools-launchpad/bin/firefox-proxy
@@ -6,8 +6,8 @@ const ws = require("ws");
 const net = require("net");
 
 function proxy(webSocketPort, tcpPort, logging) {
-  console.log("Listening for WS on *:" + webSocketPort);
-  console.log("Will proxy to TCP on *:" + tcpPort + " on first WS connection");
+  console.log("Listening for WS on *:" + webSocketPort + ". " +
+      "Will proxy to TCP on *:" + tcpPort + " on first WS connection");
   if (!logging) {
     console.log("Protocol messages can be logged by enabling " +
     "logging.firefoxProtocol in your local.json config");


### PR DESCRIPTION
This is an outstanding issue 1782 in repo:
https://github.com/debugger-tools/debugger-html.git

This is an example for a meetup so people can see the whole contribution
cycle via, forking and creating pull requests using up-for-grabs issues.