### PR TITLE
Version bump to be able to publish readme changes on npm

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "license": "MPL-2.0",
   "repository": {
     "url": "git://github.com/devtools-html/devtools-core.git",


### PR DESCRIPTION
npm needed a version bump to take changes from https://github.com/devtools-html/devtools-core/pull/124 into account