### PR TITLE
Fix to enable tracking of navigation events in chrome

### DIFF
--- a/packages/devtools-client-adapters/src/chrome.js
+++ b/packages/devtools-client-adapters/src/chrome.js
@@ -4,7 +4,7 @@ const CDP = require("chrome-remote-interface");
 const { getValue } = require("devtools-config");
 const networkRequest = require("devtools-network-request");
 const { setupCommands, clientCommands } = require("./chrome/commands");
-const { setupEvents, clientEvents } = require("./chrome/events");
+const { setupEvents, clientEvents, pageEvents } = require("./chrome/events");
 
 import type { Tab } from "./types";
 
@@ -106,6 +106,9 @@ function initPage(actions: any, { clientType }: any) {
 
   if (clientType == "chrome") {
     Page.enable();
+    Page.frameNavigated(pageEvents.frameNavigated);
+    Page.frameStartedLoading(pageEvents.frameStartedLoading);
+    Page.frameStoppedLoading(pageEvents.frameStoppedLoading);
   }
 
   Debugger.scriptParsed(clientEvents.scriptParsed);

--- a/packages/devtools-client-adapters/src/chrome/events.js
+++ b/packages/devtools-client-adapters/src/chrome/events.js
@@ -72,7 +72,7 @@ function globalObjectCleared() {
 
 // Page Events
 function frameNavigated(frame: any) {
-  actions.navigate();
+  actions.navigated();
 }
 
 function frameStartedLoading() {


### PR DESCRIPTION
Associate issue #168

#### Testing Steps
- Select chrome as the debuggee
- Set breakpoints in the `willNavigate()` and `navigated()` actions
- Go back and forward using the using the back and forward buttons in chrome
- Watch for the breakpoints hit

![willnavigate](https://cloud.githubusercontent.com/assets/792924/22711973/02260f2c-ed7b-11e6-8031-5e87a16b2327.gif)
