### PR TITLE
Drop SingleModulePlugin

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -79,7 +79,6 @@
     "react-redux": "4.4.5",
     "redux": "3.5.2",
     "selenium-webdriver": "^3.0.1",
-    "single-module-webpack-plugin": "^0.0.2",
     "style-loader": "^0.13.1",
     "svg-inline-loader": "^0.7.1",
     "webpack": "1.14.0",

--- a/packages/devtools-launchpad/src/index.js
+++ b/packages/devtools-launchpad/src/index.js
@@ -104,8 +104,10 @@ function renderRoot(_React, _ReactDOM, component, _store) {
     root.appendChild(component);
   }
 
-  updateConfig();
-  updateTheme();
+  if (isDevelopment()) {
+    updateConfig();
+    updateTheme();
+  }
 }
 
 function unmountRoot(_ReactDOM) {

--- a/packages/devtools-launchpad/webpack.config.devtools.js
+++ b/packages/devtools-launchpad/webpack.config.devtools.js
@@ -4,20 +4,12 @@ const webpack = require("webpack");
 
 const { DefinePlugin } = webpack;
 
-const ignoreRegexes = [
-  /(chrome-remote-debugging-protocol)/
-];
-
 const nativeMapping = {
   "../utils/source-editor": "devtools/client/sourceeditor/editor",
   "./test-flag": "devtools/shared/flags",
   "./client/shared/shim/Services": "Services",
-
-  // React can be required a few different ways, make sure they are
-  // all mapped.
   "react": "devtools/client/shared/vendor/react",
-  "devtools/client/shared/vendor/react": "devtools/client/shared/vendor/react",
-  "react/lib/ReactDOM": "devtools/client/shared/vendor/react-dom"
+  "react-dom": "devtools/client/shared/vendor/react-dom",
 };
 
 let packagesPath = path.join(__dirname, "../");
@@ -37,10 +29,7 @@ module.exports = (webpackConfig, envConfig) => {
     let mod = request;
 
     // Any matching paths here won't be included in the bundle.
-    if (ignoreRegexes.some(r => r.test(request))) {
-      callback(null, "var {}");
-      return;
-    } else if (nativeMapping[mod]) {
+    if (nativeMapping[mod]) {
       const mapping = nativeMapping[mod];
 
       if (webpackConfig.externalsRequire) {

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -1,9 +1,7 @@
-
 require("babel-register");
 
 const path = require("path");
 const webpack = require("webpack");
-const SingleModulePlugin = require("single-module-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const { isDevelopment, isFirefoxPanel, getValue } = require("devtools-config");
 const NODE_ENV = process.env.NODE_ENV || "development";
@@ -67,18 +65,7 @@ module.exports = (webpackConfig, envConfig) => {
   webpackConfig.resolveLoader.root = webpackConfig.resolveLoader.root || [];
   webpackConfig.resolveLoader.root.push(path.resolve("./node_modules"));
 
-  const ignoreRegexes = [/^fs$/];
-  webpackConfig.externals = webpackConfig.externals || [];
-
-  function externalsTest(context, request, callback) {
-    // Any matching paths here won't be included in the bundle.
-    if (ignoreRegexes.some(r => r.test(request))) {
-      return callback(null, "var {}");
-    }
-
-    callback();
-  }
-  webpackConfig.externals.push(externalsTest);
+  webpackConfig.node = { fs: "empty" };
 
   webpackConfig.plugins = webpackConfig.plugins || [];
   webpackConfig.plugins.push(
@@ -90,8 +77,6 @@ module.exports = (webpackConfig, envConfig) => {
       "DebuggerConfig": JSON.stringify(envConfig)
     })
   );
-
-  webpackConfig.plugins.push(new SingleModulePlugin());
 
   if (isDevelopment()) {
     webpackConfig.module.loaders.push({

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -1664,32 +1664,31 @@ detective@^4.3.1:
     acorn "^3.1.0"
     defined "^1.0.0"
 
-devtools-client-adapters@^0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/devtools-client-adapters/-/devtools-client-adapters-0.0.12.tgz#3d8bff4d077c125d918c815ae9937504edf47763"
+devtools-client-adapters@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/devtools-client-adapters/-/devtools-client-adapters-0.0.15.tgz#20a82ec9b6bdaf3b661d443eab7ae64ec271a499"
   dependencies:
     chrome-remote-interface "0.17.0"
-    devtools-config "^0.0.11"
-    devtools-modules "^0.0.14"
-    devtools-network-request "^0.0.10"
-    devtools-sham-modules "^0.0.12"
-    tcomb "^3.1.0"
+    devtools-config "^0.0.12"
+    devtools-modules "^0.0.16"
+    devtools-network-request "^0.0.11"
+    devtools-sham-modules "^0.0.13"
 
-devtools-config@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/devtools-config/-/devtools-config-0.0.11.tgz#f82a052e1e205fdb4c2eea5085560da0e580a84b"
-
-devtools-modules@^0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.14.tgz#03edc685a8d03d39cff065d7e3acb12e9d381492"
-
-devtools-network-request@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/devtools-network-request/-/devtools-network-request-0.0.10.tgz#cc72b1fb80a858b6ac569efb9f3876097a64e325"
-
-devtools-sham-modules@^0.0.12:
+devtools-config@^0.0.12:
   version "0.0.12"
-  resolved "https://registry.yarnpkg.com/devtools-sham-modules/-/devtools-sham-modules-0.0.12.tgz#0fe0cb529e283e54207ef73bc2fed616cc501e8a"
+  resolved "https://registry.yarnpkg.com/devtools-config/-/devtools-config-0.0.12.tgz#4094e62efec23cdc31bd0e6d89e15f7c51d6a7e6"
+
+devtools-modules@^0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.16.tgz#49452f23875fdcc183434876eb8035b19d4a9435"
+
+devtools-network-request@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/devtools-network-request/-/devtools-network-request-0.0.11.tgz#e3a2b9927eb4ee657f2a93909dc7eb83e13bd994"
+
+devtools-sham-modules@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/devtools-sham-modules/-/devtools-sham-modules-0.0.13.tgz#adf77140789b5454375d1c2f642e6f69be36d811"
 
 doctrine@^1.2.2:
   version "1.5.0"
@@ -3126,6 +3125,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+no-op@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/no-op/-/no-op-1.0.3.tgz#c1bd81323890658fe3aef6e495c3c103f5eec54d"
+
 node-dir@^0.1.10:
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.16.tgz#d2ef583aa50b90d93db8cdd26fcea58353957fe4"
@@ -4522,10 +4525,6 @@ tar@^2.1.1, tar@~2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
-
-tcomb@^3.1.0:
-  version "3.2.16"
-  resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.16.tgz#345782f2f060839a2df30480209b1afc8b16e1fa"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This removes the need for SMP, which was keeping us from using `babel-traverse`.

SMP was needed before because it helps deal with duplicate versions of `devtools-config` or `react`. If we take on the responsibility of making sure that we don't do this, we are okay.

I tested this version in the debugger and hot reloading worked.