### PR TITLE
rm -r node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "yarn run lint-css -s; yarn run lint-js -s",
     "lint-css": "stylelint packages/devtools-launchpad/**/*.css",
     "lint-js": "eslint packages/devtools-launchpad/src packages/devtools-client-adapters/src",
-    "reset": "rm -rf node_modules/ packages/*/node_modules/ && yarn install",
+    "nom": "rm -rf node_modules/ packages/*/node_modules/ && yarn install",
     "prepush": "yarn run lint",
     "postinstall": "lerna bootstrap"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "yarn run lint-css -s; yarn run lint-js -s",
     "lint-css": "stylelint packages/devtools-launchpad/**/*.css",
     "lint-js": "eslint packages/devtools-launchpad/src packages/devtools-client-adapters/src",
+    "reset": "rm -rf node_modules/ packages/*/node_modules/ && yarn install",
     "prepush": "yarn run lint",
     "postinstall": "lerna bootstrap"
   },


### PR DESCRIPTION
Addresses #182

Destroys the `node_modules` directories to reset in case of errors
Works on Mac and Windows (with GitHub Git Shell)