### PR TITLE
Tools fixes

### DIFF
--- a/packages/devtools-launchpad/src/tools/mc/make-bundle.js
+++ b/packages/devtools-launchpad/src/tools/mc/make-bundle.js
@@ -13,7 +13,7 @@ function makeBundle({ outputPath, projectPath, watch = false }) {
 
     const postRun = (error, stats) => {
       if (stats.hasErrors()) {
-        reject();
+        reject(stats.toJson("errors-only"));
       }
 
       resolve();

--- a/packages/devtools-launchpad/src/tools/mc/symlink-tests.js
+++ b/packages/devtools-launchpad/src/tools/mc/symlink-tests.js
@@ -12,17 +12,34 @@ function rm(file, { cwd }) {
   });
 }
 
-function symlinkTests({ projectPath, mcModulePath }) {
-  const projectMochitestPath =
-    `${projectPath}/src/test/mochitest`;
-  const mcMochitestPath =
-    `${projectPath}/firefox/${mcModulePath}/test/mochitest`;
+/**
+ * Symlink tests between a project using devtools-launchpad and a working
+ * mozilla-central clone.
+ *
+ * @param {String} projectPath
+ *        Path to the current project working dir.
+ * @param {String} projectTestPath
+ *        Path to the source test folder (should be located in project).
+ * @param {String} mcTestPath
+ *        Path to the target test folder (should be located in mozilla-central
+ *        clone).
+ * @param {String} (deprecated) mcModulePath
+ */
+function symlinkTests({ projectPath, projectTestPath, mcTestPath,
+  mcModulePath }) {
+  // Backwards compatibility.
+  if (mcModulePath && !projectTestPath && !mcTestPath) {
+    console.error("mcModulePath is deprecated, please define projectTestPath" +
+      " and mcTestPath");
+    projectTestPath = `${projectPath}/src/test/mochitest`;
+    mcTestPath = `${projectPath}/firefox/${mcModulePath}/test/mochitest`;
+  }
 
-  rm(mcMochitestPath, { cwd: projectPath });
+  rm(mcTestPath, { cwd: projectPath });
 
   symlink(
-    projectMochitestPath,
-    mcMochitestPath,
+    projectTestPath,
+    mcTestPath,
     { cwd: projectPath }
   );
 }


### PR DESCRIPTION
Two changes for tools in devtools-core:
- forward error messages when make-bundle rejects
- support custom paths in symlink test

Can split the PR in two, I guess the second proposed change can be a bit divisive.