### PR TITLE
Add source to type Location

### DIFF
--- a/packages/devtools-client-adapters/src/types.js
+++ b/packages/devtools-client-adapters/src/types.js
@@ -43,7 +43,8 @@ export type ActorId = string;
 export type Location = {
   sourceId: SourceId,
   line: number,
-  column?: number
+  column?: number,
+  source?: any
 };
 
 /**


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/pull/2034

### Summary of Changes
- Location is missing `source`. Without `source`, flow check in `Breakpoints.js` would produce errors.