### PR TITLE
update the circleci config and remove yarn-install script

### DIFF
--- a/bin/install-yarn
+++ b/bin/install-yarn
@@ -1,5 +1,0 @@
-if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
-  echo "Installing Yarn $YARN_VERSION"
-  rm -rf ~/.yarn
-  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
-fi

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,8 @@ machine:
     version: 7.0
   environment:
     DOWNLOADS_PATH: "$HOME/downloads"
-    YARN_PATH: "$HOME/.yarn"
-    YARN_VERSION: 0.18.1
-    PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+
 test:
   post:
     - yarn run lint-css
@@ -13,13 +12,10 @@ test:
     - yarn run flow
 
 dependencies:
-  pre:
-    - ./bin/install-yarn
   cache_directories:
     - ~/.cache/yarn
-    - ~/.yarn
   override:
-    - yarn install
+    - yarn
 
 general:
   artifacts:


### PR DESCRIPTION
CircleCI updated their yarn docs https://circleci.com/docs/yarn/

If we don't care as much about the yarn version as we used to, and I don't think we do, then we can use a much simpler setup that uses the latest available yarn.