### PR TITLE
Suppress chunk logs of webpack

### DIFF
--- a/packages/devtools-launchpad/bin/development-server.js
+++ b/packages/devtools-launchpad/bin/development-server.js
@@ -215,7 +215,10 @@ function startDevServer(devConfig, webpackConfig, rootDir) {
   app.use(webpackDevMiddleware(compiler, {
     publicPath: webpackConfig.output.publicPath,
     noInfo: true,
-    stats: { colors: true }
+    stats: {
+      colors: true,
+      chunks: false
+    }
   }));
 
   if (getValue("hotReloading")) {


### PR DESCRIPTION
Disable chunk logs from webpack.

### Screenshot
![webpack](https://cloud.githubusercontent.com/assets/1755089/23173230/7e35c7e8-f87e-11e6-9b06-99c699c28f97.png)
