### PR TITLE
Fix wrong path to development-server.js in package.json

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -19,7 +19,7 @@
   },
   "main": "src/index.js",
   "bin": {
-    "start-dev-server": "./bin/development-server.js",
+    "start-dev-server": "./src/development-server.js",
     "start-firefox": "./bin/firefox-driver.js",
     "start-chrome": "./bin/chrome-driver.js"
   },


### PR DESCRIPTION
This prevented npm install from working in debugger.html.