### PR TITLE
Add Yarn as a dev dependency

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -91,6 +91,9 @@
     "webpack-hot-middleware": "^2.12.0",
     "ws": "^1.0.1"
   },
+  "devDependencies": {
+    "yarn": "^0.20.3"
+  },
   "files": [
     "bin",
     "src",


### PR DESCRIPTION
Because we use Yarn in the prepublish step, it's important to control the
version we use. As a nice side-effect, `npm install` now works even on systems
where Yarn isn't installed globally.