### PR TITLE
Set the root font-size to force a consistent size between firefox/chrome/etc

### DIFF
--- a/packages/devtools-launchpad/src/components/Root.css
+++ b/packages/devtools-launchpad/src/components/Root.css
@@ -1,3 +1,7 @@
+:root {
+  font-size: 14px;
+}
+
 :root.theme-light,
 :root .theme-light {
   --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);


### PR DESCRIPTION
Firefox uses 13.33333px default on my system
Chrome uses 16px.

This forces both to use 14 (which I took from Atom/VS Code as their default size). 🤷‍♂️ 