### PR TITLE
move debugger-only variables to Root.css

### DIFF
--- a/packages/devtools-launchpad/src/components/Root.css
+++ b/packages/devtools-launchpad/src/components/Root.css
@@ -4,7 +4,12 @@
 
 :root.theme-light,
 :root .theme-light {
-  --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
+  --codemirror-gutter-background: #f4f4f4;
+}
+
+:root.theme-dark,
+:root .theme-dark {
+  --codemirror-gutter-background: #262b37;
 }
 
 * {

--- a/packages/devtools-launchpad/src/lib/themes/common.css
+++ b/packages/devtools-launchpad/src/lib/themes/common.css
@@ -236,5 +236,5 @@ checkbox:-moz-focusring {
 
 .cm-s-mozilla .CodeMirror-gutters { /* vertical line next to line numbers */
   border-width: 0;
-  background-color: var(--theme-codemirror-gutter-background);
+  background-color: var(--codemirror-gutter-background);
 }

--- a/packages/devtools-launchpad/src/lib/themes/variables.css
+++ b/packages/devtools-launchpad/src/lib/themes/variables.css
@@ -74,8 +74,6 @@
   /* Command line */
   /* --theme-command-line-image: url(chrome://devtools/skin/images/commandline-icon.svg#light-theme); */
   /* --theme-command-line-image-focus: url(chrome://devtools/skin/images/commandline-icon.svg#light-theme-focus); */
-
-  --theme-codemirror-gutter-background: #f4f4f4;
 }
 
 :root.theme-dark {
@@ -88,7 +86,6 @@
   --theme-toolbar-background-alt: #2F343E;
   --theme-selection-background: #5675B9;
   --theme-selection-background-semitransparent: rgba(86, 117, 185, 0.5);
-  --theme-search-overlays-semitransparent: rgba(42, 46, 56, 0.66);
   --theme-selection-color: #f5f7fa;
   --theme-splitter-color: #454d5d;
   --theme-comment: #757873;
@@ -139,8 +136,6 @@
   /* Command line */
   /* --theme-command-line-image: url(chrome://devtools/skin/images/commandline-icon.svg#dark-theme); */
   /* --theme-command-line-image-focus: url(chrome://devtools/skin/images/commandline-icon.svg#dark-theme-focus); */
-
-  --theme-codemirror-gutter-background: #262b37;
 }
 
 :root.theme-firebug {
@@ -201,8 +196,6 @@
   /* Command line */
   /* --theme-command-line-image: url(chrome://devtools/skin/images/firebug/commandline-icon.svg); */
   /* --theme-command-line-image-focus: url(chrome://devtools/skin/images/firebug/commandline-icon.svg#focus); */
-
-  --theme-codemirror-gutter-background: #ebeced;
 }
 
 :root {


### PR DESCRIPTION
This is a partial fix for #220 

I added two variables from devtools-core's variables.css file to the mozilla central version (cf https://bugzilla.mozilla.org/show_bug.cgi?id=1343478).

For the two others, they feel very debugger specific and I don't think we should keep them in variables.css, so I'm moving them to Root.css for now. We probably should rename them and completely move them to the debugger.html repo.