### PR TITLE
Revert 14px font sizes

### DIFF
--- a/packages/devtools-launchpad/src/components/Root.css
+++ b/packages/devtools-launchpad/src/components/Root.css
@@ -1,7 +1,3 @@
-:root {
-  font-size: 14px;
-}
-
 :root.theme-light,
 :root .theme-light {
   --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);


### PR DESCRIPTION
This caused some components to have 14px font sizes.

### before
![screen shot 2017-03-03 at 1 23 47 pm](https://cloud.githubusercontent.com/assets/254562/23563430/a92446b2-0014-11e7-9f65-8288b5b5665e.png)

### after
![screen shot 2017-03-03 at 1 22 57 pm](https://cloud.githubusercontent.com/assets/254562/23563429/a91fe540-0014-11e7-9029-945b079fe2b9.png)
