### PR TITLE
Set root font-size to 11px

### DIFF
--- a/packages/devtools-launchpad/src/lib/themes/common.css
+++ b/packages/devtools-launchpad/src/lib/themes/common.css
@@ -6,6 +6,7 @@
 
 :root {
   font: message-box;
+  font-size: 11px;
   --monospace-font-family: Menlo, monospace;
 }
 


### PR DESCRIPTION
This sets a consistent root font size between chrome and firefox

### Before

![screen shot 2017-03-05 at 11 38 52 am](https://cloud.githubusercontent.com/assets/254562/23589368/8bcaf21a-0199-11e7-9859-ea510e2d93ae.png)
![screen shot 2017-03-05 at 11 38 49 am](https://cloud.githubusercontent.com/assets/254562/23589369/8bcdda2a-0199-11e7-9561-24fae35adfe3.png)
