### PR TITLE
[WIP]Resolve path correctly

### DIFF
--- a/packages/devtools-network-request/stubNetworkRequest.js
+++ b/packages/devtools-network-request/stubNetworkRequest.js
@@ -6,7 +6,7 @@ module.exports = function(url) {
     // example.com is used at a dummy URL that points to our local
     // `/src` folder.
     url = url.replace(/http:\/\/localhost:8000/, "");
-    const requestUrl = _path.join(__dirname, "/../../src/test/mochitest/", url);
+    const requestUrl = _path.join(__dirname, "../src/test/mochitest/", url);
     const content = fs.readFileSync(requestUrl, "utf8");
 
     resolve({ content });


### PR DESCRIPTION
Associated Issue:  devtools-html/debugger.html#614

### Summary of Changes

1. Before webpack [resolve](https://github.com/devtools-html/debugger.html/blob/master/src/test/node-unit-tests.js#L48) the `__dirname` to `${root}/assets/build`. 
2. Did not use `path.resolve` because it cant handle `\` and `/` correctly

### Test plan
1. cd to debugger.html root dir.
2. run `yarn test`.
3. all tests pass
