### PR TITLE
[launchpad] Clear firefox tabs after getting new tabs

### DIFF
--- a/packages/devtools-launchpad/src/index.js
+++ b/packages/devtools-launchpad/src/index.js
@@ -144,8 +144,8 @@ async function connectClients(actions) {
 }
 
 async function getTabs(actions) {
-  actions.clearTabs();
   const firefoxTabs = await firefox.getTabs();
+  actions.clearTabs();
   actions.newTabs(firefoxTabs);
 }
 


### PR DESCRIPTION
Clearing firefox tabs before getting new tabs was causing flicker.

### Summary of changes
* Clear firefox tabs after getting new tabs. So that there is no noticeable delay between clearing tabs and displaying new tabs.

Fixes #229