### PR TITLE
Fully configurable source map worker URL

### DIFF
--- a/packages/devtools-source-map/README.md
+++ b/packages/devtools-source-map/README.md
@@ -12,4 +12,4 @@ This is used in multiple contexts:
 # Application Requirements
 
 This package assumes that an application using this code will make the
-`worker.js` file available at `${baseWorkerURL}devtools-source-map/worker.js`.
+`worker.js` file available at application specified URL `sourceMapWorkerURL`.

--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -9,8 +9,6 @@ const {
   workerTask,
 } = require("./util");
 
-const WORKER_PATH = "devtools-source-map/worker.js";
-
 import type { Location } from "devtools-client-adapters/src/types";
 
 let sourceMapWorker;
@@ -18,7 +16,7 @@ function restartWorker() {
   if (sourceMapWorker) {
     sourceMapWorker.terminate();
   }
-  sourceMapWorker = new Worker(`${getValue("baseWorkerURL")}${WORKER_PATH}`);
+  sourceMapWorker = new Worker(getValue("sourceMapWorkerURL"));
   sourceMapWorker.onerror = () => {
     console.error("Error in source map worker");
   };


### PR DESCRIPTION
When this is landed in m-c, I think we'll want full control over the URL used, so that the worker and package can easily be placed wherever makes the most sense in the tree.