### PR TITLE
Use autoprefixer postcss plugin

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "amd-loader": "0.0.5",
+    "autoprefixer": "^6.7.6",
     "babel-cli": "^6.7.5",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.1.0",

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -133,7 +133,10 @@ module.exports = (webpackConfig, envConfig) => {
     webpackConfig.plugins.push(new ExtractTextPlugin("[name].css"));
   }
 
-  webpackConfig.postcss = () => [require("postcss-bidirection")];
+  webpackConfig.postcss = () => [
+    require("postcss-bidirection"),
+    require("autoprefixer")
+  ];
 
   if (isFirefoxPanel()) {
     webpackConfig = require("./webpack.config.devtools")(webpackConfig, envConfig);

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -187,7 +187,7 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-autoprefixer@^6.3.1:
+autoprefixer@^6.3.1, autoprefixer@^6.7.6:
   version "6.7.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.6.tgz#00f05656c7ef73de9d2fd9b4668f6ef6905a855a"
   dependencies:


### PR DESCRIPTION
Add `autoprefixer` plugin and use it while bundling with webpack.

Associated Issue devtools-html/debugger.html#1838

For #128 We'll need a `browserslist` config (in `package.json` or a separate file?). This should probably be in `debugger.html`.