### PR TITLE
[Sources] Only expand tree when right arrow pressed

### DIFF
--- a/packages/devtools-sham-modules/client/shared/components/tree.js
+++ b/packages/devtools-sham-modules/client/shared/components/tree.js
@@ -519,8 +519,6 @@ const Tree = module.exports = createClass({
       case "ArrowRight":
         if (!this.props.isExpanded(this.props.focused)) {
           this._onExpand(this.props.focused);
-        } else {
-          this._focusNextNode();
         }
         return;
     }


### PR DESCRIPTION
Associated Issue: devtools-html/debugger.html#2256

### Summary of Changes

* Removes focusing the next node in the tree (either the child of the branch or the next leaf) when pressing the right arrow

### Test Plan

#### Expanding a Branch

- [x] Select a closed branch (e.g. a directory) in the tree
- [x] Press right arrow. Branch should expand
- [x] Press right arrow again. Focus should *not* move (e.g. to the first leaf)


#### Navigating from a leaf

- [x] Select leaf node (e.g. file) in the tree
- [x] Press right arrow. Focus should *not* move
