### PR TITLE
add clojure content type to worker

### DIFF
--- a/packages/devtools-source-map/src/util.js
+++ b/packages/devtools-source-map/src/util.js
@@ -71,6 +71,10 @@ function getContentType(url: string) {
     return "text/elm";
   }
 
+  if (url.match(/cljs$/)) {
+    return "text/x-clojure";
+  }
+
   return "text/plain";
 }
 


### PR DESCRIPTION
Comes from devtools-html/debugger.html#2307.

Since the source-map-worker is moving to devtools-core, this need needs to be merged so that clojure support can be maintained.