### PR TITLE
bump source-map deps

### DIFF
--- a/packages/devtools-source-map/package.json
+++ b/packages/devtools-source-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-source-map",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DevTools utilities for working with source maps",
   "license": "MPL-2.0",
   "author": "J. Ryan Stinnett <jryans@gmail.com>",
@@ -9,9 +9,9 @@
   "homepage": "https://github.com/devtools-html/devtools-core/tree/master/packages/devtools-source-map#readme",
   "main": "src/index.js",
   "dependencies": {
-    "devtools-client-adapters": "^0.0.19",
+    "devtools-client-adapters": "^0.0.21",
     "devtools-config": "^0.0.12",
-    "devtools-network-request": "^0.0.11",
+    "devtools-network-request": "^0.0.14",
     "md5": "^2.2.1",
     "source-map": "^0.5.6",
     "url": "^0.11.0"

--- a/packages/devtools-source-map/yarn.lock
+++ b/packages/devtools-source-map/yarn.lock
@@ -21,35 +21,35 @@ crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
-devtools-client-adapters@^0.0.19:
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/devtools-client-adapters/-/devtools-client-adapters-0.0.19.tgz#6985b4ad2a6643a7e78b1477b72d4d8f1abd6903"
+devtools-client-adapters@^0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/devtools-client-adapters/-/devtools-client-adapters-0.0.21.tgz#2bb6a08c9dac24a55cf00492394d43a55e2eef5d"
   dependencies:
     chrome-remote-interface "0.17.0"
-    devtools-config "^0.x.x"
-    devtools-modules "^0.x.x"
-    devtools-network-request "^0.x.x"
-    devtools-sham-modules "^0.x.x"
+    devtools-config "^0.0.12"
+    devtools-modules "^0.0.17"
+    devtools-network-request "^0.0.14"
+    devtools-sham-modules "^0.0.16"
 
-devtools-config@^0.0.12, devtools-config@^0.x.x:
+devtools-config@^0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/devtools-config/-/devtools-config-0.0.12.tgz#4094e62efec23cdc31bd0e6d89e15f7c51d6a7e6"
 
-devtools-modules@^0.x.x:
+devtools-modules@^0.0.17:
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.17.tgz#baaccd878ec70928d863878005fd814e2d86e048"
+
+devtools-network-request@^0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/devtools-network-request/-/devtools-network-request-0.0.14.tgz#427f13a20728ab7367ca885708e57f065742db57"
+
+devtools-sham-modules@^0.0.16:
   version "0.0.16"
-  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.16.tgz#49452f23875fdcc183434876eb8035b19d4a9435"
-
-devtools-network-request@^0.0.11, devtools-network-request@^0.x.x:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/devtools-network-request/-/devtools-network-request-0.0.11.tgz#e3a2b9927eb4ee657f2a93909dc7eb83e13bd994"
-
-devtools-sham-modules@^0.x.x:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/devtools-sham-modules/-/devtools-sham-modules-0.0.15.tgz#350c147af3686d840fa47c5df6a769a61ea70a89"
+  resolved "https://registry.yarnpkg.com/devtools-sham-modules/-/devtools-sham-modules-0.0.16.tgz#82c74831918877b075cabba4cd39933ae80c0d81"
 
 is-buffer@~1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
 md5@^2.2.1:
   version "2.2.1"
@@ -87,8 +87,8 @@ url@^0.11.0:
     querystring "0.2.0"
 
 ws@1.1.x:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
The debugger is currently including different versions of the shared dependencies.

[yarn.lock](https://gist.github.com/aef4f8b764d50d2fededeeea88a54f20)

