### PR TITLE
Bump react-immutable-proptypes version

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -79,7 +79,7 @@
     "react": "=15.3.2",
     "react-dom": "=15.3.2",
     "react-hot-loader": "^1.3.1",
-    "react-immutable-proptypes": "^1.7.1",
+    "react-immutable-proptypes": "^2.1.0",
     "react-inlinesvg": "^0.5.3",
     "react-redux": "4.4.5",
     "redux": "3.5.2",

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -3258,9 +3258,9 @@ react-hot-loader@^1.3.1:
     react-hot-api "^0.4.5"
     source-map "^0.4.4"
 
-react-immutable-proptypes@^1.7.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-1.7.2.tgz#fb1fdca24e30501617732781f4341b704ef7c320"
+react-immutable-proptypes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
 
 react-inlinesvg@^0.5.3:
   version "0.5.5"


### PR DESCRIPTION
In the process of moving the search state to Redux I've noticed a warning in the console due to the version of react-immutable-proptypes we had as a dependency.

```
23:11:37.011 Warning: You are manually calling a React.PropTypes validation function for the `searchModifiers.caseSensitive` prop on `Editor`. This is deprecated and will not work in the next major version. You may be seeing this warning due to a third-party PropTypes library. See https://fb.me/react-warning-dont-call-proptypes for details. 1 debugger.js:2580:10
```

This updates the package which has fixes for this warning.