### PR TITLE
Support setting multiple L10n bundle

### DIFF
--- a/packages/devtools-launchpad/src/utils/L10N.js
+++ b/packages/devtools-launchpad/src/utils/L10N.js
@@ -4,7 +4,7 @@ const { sprintf } = require("devtools-modules");
 let strings = {};
 
 function setBundle(bundle: { [key: string]: string }) {
-  strings = bundle;
+  strings = Object.assign(strings, bundle);
 }
 
 function getStr(key: string) {


### PR DESCRIPTION
Calling setBundle() multiple times can merge new L10N strings. It's useful to support multiple L10N files. 