### PR TITLE
Fix cyclic dependency in WebConsoleClient and LongStringClient

### DIFF
--- a/packages/devtools-sham-modules/shared/client/main.js
+++ b/packages/devtools-sham-modules/shared/client/main.js
@@ -550,7 +550,7 @@ DebuggerClient.prototype = {
         if (this._clients.has(aConsoleActor)) {
           consoleClient = this._clients.get(aConsoleActor);
         } else {
-          consoleClient = new WebConsoleClient(this, aResponse);
+          consoleClient = new WebConsoleClient(this, aResponse, LongStringClient);
           this.registerClient(consoleClient);
         }
       }

--- a/packages/devtools-sham-modules/shared/webconsole/client.js
+++ b/packages/devtools-sham-modules/shared/webconsole/client.js
@@ -6,11 +6,10 @@
 
 "use strict";
 
-const {Cc, Ci, Cu} = require("../../sham/chrome");
+const { Cc, Ci, Cu } = require("../../sham/chrome");
 const DevToolsUtils = require("../DevToolsUtils");
 const EventEmitter = require("../event-emitter");
 const promise = require("../../sham/promise");
-const {LongStringClient} = require("../client/main");
 
 /**
  * A WebConsoleClient is used as a front end for the WebConsoleActor that is
@@ -21,11 +20,14 @@ const {LongStringClient} = require("../client/main");
  * @param object aResponse
  *        The response packet received from the "startListeners" request sent to
  *        the WebConsoleActor.
+ * @param object LongStringClient
+ *        LongStringClient constructor to get full string from server
  */
-function WebConsoleClient(aDebuggerClient, aResponse)
+function WebConsoleClient(aDebuggerClient, aResponse, LongStringClient)
 {
   this._actor = aResponse.from;
   this._client = aDebuggerClient;
+  this.LongStringClient = LongStringClient;
   this._longStrings = {};
   this.traits = aResponse.traits || {};
   this.events = [];
@@ -595,6 +597,7 @@ WebConsoleClient.prototype = {
       return this._longStrings[aGrip.actor];
     }
 
+    let LongStringClient = this.LongStringClient.bind(this);
     let client = new LongStringClient(this._client, aGrip);
     this._longStrings[aGrip.actor] = client;
     return client;


### PR DESCRIPTION
FF devtools loader allows you to require cyclic dependency but it is broken in node.

A workaround fix for solving cyclic dependency in WebConsoleClient and LongStringClient, which causes { LongStringClient } = require() always return empty object within node module system.