### PR TITLE
persist the filter state when clearing tabs

### DIFF
--- a/packages/devtools-launchpad/src/reducers/tabs.js
+++ b/packages/devtools-launchpad/src/reducers/tabs.js
@@ -15,7 +15,7 @@ const initialState = fromJS({
 function update(state = initialState, action) {
   switch (action.type) {
     case constants.CLEAR_TABS:
-      return initialState;
+      return state.setIn(["tabs"], Immutable.Map()).setIn("selectedTab", null);
 
     case constants.ADD_TABS:
       const tabs = action.value;


### PR DESCRIPTION
Currently your filter is cleared when their is a tab refresh because
the `getTabs` function runs a `clearTabs` to reset the tabs before
adding new tabs.  This makes the `CLEAR_TABS` action more clear by not
creating the side effect of destroying other state by returning the
`initialState`.