### PR TITLE
Set source map worker URL in Firefox

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,3 +5,6 @@
 .*node_modules/stylelint.*
 .*node_modules/config-chain.*
 .*flow-coverage-report/.*
+
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$FlowIgnore

--- a/packages/devtools-source-map/README.md
+++ b/packages/devtools-source-map/README.md
@@ -14,4 +14,4 @@ This is used in multiple contexts:
 # Application Requirements
 
 This package assumes that an application using this code will make the
-`worker.js` file available at application specified URL `sourceMapWorkerURL`.
+`worker.js` file available at application specified URL `workers.sourceMapURL`.

--- a/packages/devtools-source-map/bin/getConfig.js
+++ b/packages/devtools-source-map/bin/getConfig.js
@@ -4,10 +4,15 @@ const path = require("path");
 
 function getConfig() {
   const developmentConfig = require("../configs/development.json");
+  const firefoxConfig = require("../configs/firefox-panel.json");
 
   let localConfig = {};
   if (fs.existsSync(path.resolve(__dirname, "../configs/local.json"))) {
     localConfig = require("../configs/local.json");
+  }
+
+  if (process.env.TARGET === "firefox-panel") {
+    return firefoxConfig;
   }
 
   return merge({}, developmentConfig, localConfig);

--- a/packages/devtools-source-map/configs/firefox-panel.json
+++ b/packages/devtools-source-map/configs/firefox-panel.json
@@ -1,0 +1,5 @@
+{
+  "workers": {
+    "sourceMapURL": "resource://devtools/client/shared/source-map/worker.js"
+  }
+}

--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -1,4 +1,5 @@
 // @flow
+/* global DebuggerConfig */
 
 const {
   originalToGeneratedId,
@@ -8,9 +9,13 @@ const {
 } = require("./util");
 
 const { workerUtils: { workerTask }} = require("devtools-modules");
-const { getValue } = require("devtools-config");
+const { setConfig, getValue } = require("devtools-config");
 
 import type { Location } from "devtools-client-adapters/src/types";
+
+// TODO: Rename this to something not specific to debugger (#265)
+// $FlowIgnore: global DebuggerConfig
+setConfig(DebuggerConfig);
 
 let sourceMapWorker;
 function restartWorker() {


### PR DESCRIPTION
This adds a Firefox panel config for `devtools-source-map`, which is used when this is landed as a bundle in m-c.

Since we're landing a standalone bundle in m-c, we can't rely on config values from apps like the debugger anymore, so we need to set config data (currently just the worker URL) in this package.