### PR TITLE
Splitter - require css directly

### DIFF
--- a/packages/devtools-modules/client/shared/components/splitter/SplitBox.js
+++ b/packages/devtools-modules/client/shared/components/splitter/SplitBox.js
@@ -3,6 +3,8 @@ const ReactDOM = require("react-dom");
 const Draggable = React.createFactory(require("./Draggable"));
 const { DOM: dom, PropTypes } = React;
 
+require("./SplitBox.css");
+
 /**
  * This component represents a Splitter. The splitter supports vertical
  * as well as horizontal mode.

--- a/packages/devtools-modules/index.js
+++ b/packages/devtools-modules/index.js
@@ -1,13 +1,11 @@
 const Services = require("./client/shared/shim/Services");
 const SplitBox = require("./client/shared/components/splitter/SplitBox");
-// const SplitBoxCSS = require("./client/shared/components/splitter/SplitBox.css")
 const sprintf = require("./shared/sprintf").sprintf;
 const workerUtils = require("./shared/worker-utils");
 
 module.exports = {
   Services,
   SplitBox,
-  // SplitBoxCSS,
   sprintf,
   workerUtils,
 };


### PR DESCRIPTION
This updates the splitbox so that the component requires the CSS directly.

This will let us remove the splitbox CSS code from the debugger, which was previously being duplicated
