### PR TITLE
update the formatting for the npm package links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Package|README|
 |:----:|:---:|
-| [![devtools-client-adapters-version]] [devtools-client-adapters-pkg] | [devtools-client-adapters] |
+| [![devtools-client-adapters-version]][devtools-client-adapters-pkg] | [devtools-client-adapters] |
 | [![devtools-launchpad-version]][devtools-launchpad-pkg] | [devtools-launchpad] |
 | [![devtools-network-request-version]][devtools-network-request-pkg] | [devtools-network-request] |
 | [![devtools-config-version]][devtools-config-pkg] | [devtools-config] |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 ### DevTools Core
 
-* [![Npm version](https://img.shields.io/npm/v/devtools-client-adapters.svg)](https://npmjs.org/package/devtools-client-adapters) [devtools-client-adapters](./packages/devtools-client-adapters/README.md)
-* [![Npm version](https://img.shields.io/npm/v/devtools-launchpad.svg)](https://npmjs.org/package/devtools-launchpad) [devtools-launchpad](./packages/devtools-launchpad/README.md)
-* [![Npm version](https://img.shields.io/npm/v/devtools-network-request.svg)](https://npmjs.org/package/devtools-network-request) [devtools-network-request](./packages/devtools-network-request/README.md)
-* [![Npm version](https://img.shields.io/npm/v/devtools-config.svg)](https://npmjs.org/package/devtools-config) [devtools-config](./packages/devtools-config/README.md)
-* [![Npm version](https://img.shields.io/npm/v/devtools-modules.svg)](https://npmjs.org/package/devtools-modules) [devtools-modules](./packages/devtools-modules/README.md)
-* [![Npm version](https://img.shields.io/npm/v/devtools-sham-modules.svg)](https://npmjs.org/package/devtools-sham-modules) [devtools-sham-modules](./packages/devtools-sham-modules/README.md)
-* [![Npm version](https://img.shields.io/npm/v/devtools-source-map.svg)](https://npmjs.org/package/devtools-source-map) [devtools-source-map](./packages/devtools-source-map/README.md)
+|Package|README|
+|:----:|:---:|
+| [![devtools-client-adapters-version]] [devtools-client-adapters-pkg] | [devtools-client-adapters] |
+| [![devtools-launchpad-version]][devtools-launchpad-pkg] | [devtools-launchpad] |
+| [![devtools-network-request-version]][devtools-network-request-pkg] | [devtools-network-request] |
+| [![devtools-config-version]][devtools-config-pkg] | [devtools-config] |
+| [![devtools-modules-version]][devtools-modules-pkg] | [devtools-modules] |
+| [![devtools-sham-modules-version]][devtools-sham-modules-pkg] | [devtools-sham-modules] |
+| [![devtools-source-map-version]][devtools-source-map-pkg] | [devtools-source-map] |
 
 ### Docs
 
@@ -16,3 +18,31 @@
 - [Versioning](./docs/versioning.md)
   - [Update a Package](./docs/versioning.md#update-a-package)
   - [Updating a Launchpad Dependency](./docs/versioning.md#updating-a-launchpad-dependency)
+
+[devtools-client-adapters-version]:https://img.shields.io/npm/v/devtools-client-adapters.svg
+[devtools-client-adapters-pkg]:https://npmjs.org/package/devtools-client-adapters
+[devtools-client-adapters]:./packages/devtools-client-adapters/#readme
+
+[devtools-launchpad-version]:https://img.shields.io/npm/v/devtools-launchpad.svg
+[devtools-launchpad-pkg]:https://npmjs.org/package/devtools-launchpad
+[devtools-launchpad]:./packages/devtools-launchpad/#readme
+
+[devtools-network-request-version]:https://img.shields.io/npm/v/devtools-network-request.svg
+[devtools-network-request-pkg]:https://npmjs.org/package/devtools-network-request
+[devtools-network-request]:./packages/devtools-network-request/#readme
+
+[devtools-config-version]:https://img.shields.io/npm/v/devtools-config.svg
+[devtools-config-pkg]:https://npmjs.org/package/devtools-config
+[devtools-config]:./packages/devtools-config/#readme
+
+[devtools-modules-version]:https://img.shields.io/npm/v/devtools-modules.svg
+[devtools-modules-pkg]:https://npmjs.org/package/devtools-modules
+[devtools-modules]:./packages/devtools-modules/#readme
+
+[devtools-sham-modules-version]:https://img.shields.io/npm/v/devtools-sham-modules.svg
+[devtools-sham-modules-pkg]:https://npmjs.org/package/devtools-sham-modules
+[devtools-sham-modules]:./packages/devtools-sham-modules/#readme
+
+[devtools-source-map-version]:https://img.shields.io/npm/v/devtools-source-map.svg
+[devtools-source-map-pkg]:https://npmjs.org/package/devtools-source-map
+[devtools-source-map]:./packages/devtools-source-map/#readme


### PR DESCRIPTION
Use a table instead of a list
Move all the links below
Link to the package directory readme section instead of the readme file.  For example instead of linking to [devtools-config](../tree/master/packages/devtools-config/README.md) we link to [devtools-config](../tree/master/packages/devtools-config/#readme) which takes you to the directory where the readme is but not the actual file.