### PR TITLE
[launchpad] fix cursor for tab

### DIFF
--- a/packages/devtools-launchpad/src/components/Tabs.css
+++ b/packages/devtools-launchpad/src/components/Tabs.css
@@ -13,6 +13,7 @@
   border-bottom: 1px solid var(--theme-splitter-color);
   padding: calc(var(--base-spacing) / 2) var(--base-spacing);
   font-family: sans-serif;
+  cursor: pointer;
 }
 
 .landing-page .tab-sides {
@@ -43,7 +44,6 @@
 .landing-page .tab.active {
   background: var(--theme-selection-background);
   color: var(--theme-selection-color);
-  cursor: pointer;
   transition: var(--base-transition);
 }
 


### PR DESCRIPTION
Mouse cursor when hovering over tabs in Launchpad is `default` when
there are more than one tabs.

|  |  |
|---------|------|
|Before|![before](https://cloud.githubusercontent.com/assets/1755089/24511110/b3391860-1588-11e7-8351-15356db14020.gif)|
|After|![after](https://cloud.githubusercontent.com/assets/1755089/24511126/bc4e4376-1588-11e7-8382-058aabbb9135.gif)|

