### PR TITLE
Fix Services not found error

### DIFF
--- a/packages/devtools-modules/client/shared/prefs.js
+++ b/packages/devtools-modules/client/shared/prefs.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { Services } = require("./shim/services");
+const Services = require("./shim/services");
 const EventEmitter = require("../../shared/event-emitter");
 
 /**


### PR DESCRIPTION
Fix error which caused by #301. Services module should be exported directly.