### PR TITLE
Add SourceEditor to devtools-modules

### DIFF
--- a/packages/devtools-modules/client/shared/components/source-editor/source-editor.css
+++ b/packages/devtools-modules/client/shared/components/source-editor/source-editor.css
@@ -1,0 +1,307 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+:root {
+  /*--breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#light");*/
+  /*--breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#light-hover");*/
+  --breakpoint-active-color: rgba(44,187,15,.2);
+  --breakpoint-active-color-hover: rgba(44,187,15,.5);
+  /*--breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#light-conditional");*/
+}
+
+.theme-dark:root {
+  /*--breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#dark");*/
+  /*--breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-hover");*/
+  --breakpoint-active-color: rgba(45,210,158,0.5);
+  --breakpoint-active-color-hover: rgba(0,255,175,.7);
+  /*--breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-conditional");*/
+}
+
+.CodeMirror .errors {
+  width: 16px;
+}
+
+.CodeMirror .error {
+  display: inline-block;
+  margin-left: 5px;
+  width: 12px;
+  height: 12px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  /*background-image: url("chrome://devtools/skin/images/editor-error.png");*/
+  opacity: 0.75;
+}
+
+.CodeMirror .hit-counts {
+  width: 6px;
+}
+
+.CodeMirror .hit-count {
+  display: inline-block;
+  height: 12px;
+  border: solid rgba(0,0,0,0.2);
+  border-width: 1px 1px 1px 0;
+  border-radius: 0 3px 3px 0;
+  padding: 0 3px;
+  font-size: 10px;
+  pointer-events: none;
+}
+
+.CodeMirror-linenumber:before {
+  content: " ";
+  display: block;
+  width: calc(100% - 3px);
+  position: absolute;
+  top: 1px;
+  left: 0;
+  height: 12px;
+  z-index: -1;
+  background-size: calc(100% - 2px) 12px;
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-inline-end: 9px;
+}
+
+.breakpoint .CodeMirror-linenumber {
+  color: var(--theme-body-background);
+}
+
+.breakpoint .CodeMirror-linenumber:before {
+  background-image: var(--breakpoint-background) !important;
+}
+
+.conditional .CodeMirror-linenumber:before {
+  background-image: var(--breakpoint-conditional-background) !important;
+}
+
+.debug-line .CodeMirror-linenumber {
+  background-color: var(--breakpoint-active-color);
+}
+
+.theme-dark .debug-line .CodeMirror-linenumber {
+  color: #c0c0c0;
+}
+
+.debug-line .CodeMirror-line {
+  background-color: var(--breakpoint-active-color) !important;
+}
+
+/* Don't display the highlight color since the debug line
+   is already highlighted */
+.debug-line .CodeMirror-activeline-background {
+  display: none;
+}
+
+.CodeMirror {
+  cursor: text;
+  height: 100%;
+}
+
+.CodeMirror-gutters {
+  cursor: default;
+}
+
+/* This is to avoid the fake horizontal scrollbar div of codemirror to go 0
+height when floating scrollbars are active. Make sure that this value is equal
+to the maximum of `min-height` specific to the `scrollbar[orient="horizontal"]`
+selector in floating-scrollbar-light.css across all platforms. */
+.CodeMirror-hscrollbar {
+  min-height: 10px;
+}
+
+/* This is to avoid the fake vertical scrollbar div of codemirror to go 0
+width when floating scrollbars are active. Make sure that this value is equal
+to the maximum of `min-width` specific to the `scrollbar[orient="vertical"]`
+selector in floating-scrollbar-light.css across all platforms. */
+.CodeMirror-vscrollbar {
+  min-width: 10px;
+}
+
+.cm-trailingspace {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QUXCToH00Y1UgAAACFJREFUCNdjPMDBUc/AwNDAAAFMTAwMDA0OP34wQgX/AQBYgwYEx4f9lQAAAABJRU5ErkJggg==");
+  opacity: 0.75;
+  background-position: left bottom;
+  background-repeat: repeat-x;
+}
+
+.cm-highlight {
+  position: relative;
+}
+
+.cm-highlight:before {
+  position: absolute;
+  border-top-style: solid;
+  border-bottom-style: solid;
+  border-top-color: var(--theme-comment-alt);
+  border-bottom-color: var(--theme-comment-alt);
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  top: -1px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  content: "";
+  margin-bottom: -1px;
+}
+
+.cm-highlight-full:before {
+  border: 1px solid var(--theme-comment-alt);
+}
+
+.cm-highlight-start:before {
+  border-left-width: 1px;
+  border-left-style: solid;
+  border-left-color: var(--theme-comment-alt);
+  margin: 0 0 -1px -1px;
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+
+.cm-highlight-end:before {
+  border-right-width: 1px;
+  border-right-style: solid;
+  border-right-color: var(--theme-comment-alt);
+  margin: 0 -1px -1px 0;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
+/* CodeMirror dialogs styling */
+
+.CodeMirror-dialog {
+  padding: 4px 3px;
+}
+
+.CodeMirror-dialog,
+.CodeMirror-dialog input {
+  font: message-box;
+}
+
+/* Fold addon */
+
+.CodeMirror-foldmarker {
+  color: blue;
+  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
+  font-family: sans-serif;
+  line-height: .3;
+  cursor: pointer;
+}
+
+.CodeMirror-foldgutter {
+  width: 16px; /* Same as breakpoints gutter above */
+}
+
+.CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded {
+  color: #555;
+  cursor: pointer;
+}
+
+.CodeMirror-foldgutter-open:after {
+  font-size: 120%;
+  content: "\25BE";
+}
+
+.CodeMirror-foldgutter-folded:after {
+  font-size: 120%;
+  content: "\25B8";
+}
+
+.CodeMirror-hints {
+  position: absolute;
+  z-index: 10;
+  overflow: hidden;
+  list-style: none;
+  margin: 0;
+  padding: 2px;
+  border-radius: 3px;
+  font-size: 90%;
+  max-height: 20em;
+  overflow-y: auto;
+}
+
+.CodeMirror-hint {
+  margin: 0;
+  padding: 0 4px;
+  border-radius: 2px;
+  max-width: 19em;
+  overflow: hidden;
+  white-space: pre;
+  cursor: pointer;
+}
+
+.CodeMirror-Tern-completion {
+  padding-inline-start: 22px;
+  position: relative;
+  line-height: 18px;
+}
+
+.CodeMirror-Tern-completion:before {
+  position: absolute;
+  left: 2px;
+  bottom: 2px;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: bold;
+  height: 15px;
+  width: 15px;
+  line-height: 16px;
+  text-align: center;
+  color: #ffffff;
+  box-sizing: border-box;
+}
+
+.CodeMirror-Tern-completion-unknown:before {
+  content: "?";
+}
+
+.CodeMirror-Tern-completion-object:before {
+  content: "O";
+}
+
+.CodeMirror-Tern-completion-fn:before {
+  content: "F";
+}
+
+.CodeMirror-Tern-completion-array:before {
+  content: "A";
+}
+
+.CodeMirror-Tern-completion-number:before {
+  content: "N";
+}
+
+.CodeMirror-Tern-completion-string:before {
+  content: "S";
+}
+
+.CodeMirror-Tern-completion-bool:before {
+  content: "B";
+}
+
+.CodeMirror-Tern-completion-guess {
+  color: #999;
+}
+
+.CodeMirror-Tern-tooltip {
+  border-radius: 3px;
+  padding: 2px 5px;
+  white-space: pre-wrap;
+  max-width: 40em;
+  position: absolute;
+  z-index: 10;
+}
+
+.CodeMirror-Tern-hint-doc {
+  max-width: 25em;
+}
+
+.CodeMirror-Tern-farg-current {
+  text-decoration: underline;
+}
+
+.CodeMirror-Tern-fhint-guess {
+  opacity: .7;
+}

--- a/packages/devtools-modules/client/shared/components/source-editor/source-editor.js
+++ b/packages/devtools-modules/client/shared/components/source-editor/source-editor.js
@@ -1,0 +1,91 @@
+const CodeMirror = require("codemirror");
+const {
+  createClass,
+  DOM,
+  PropTypes,
+} = require("react");
+
+require("codemirror/lib/codemirror.css");
+require("codemirror/mode/javascript/javascript");
+require("codemirror/mode/htmlmixed/htmlmixed");
+require("codemirror/mode/coffeescript/coffeescript");
+require("codemirror/mode/jsx/jsx");
+require("codemirror/mode/elm/elm");
+require("codemirror/mode/clojure/clojure");
+require("./source-editor.css");
+
+const { div } = DOM;
+
+const SYNTAX_HIGHLIGHT_MAX_SIZE = 102400;
+
+/**
+ * SourceEditor as a React component
+ */
+const SourceEditor = createClass({
+  propTypes: {
+    // Source editor syntax hightligh mode
+    mode: PropTypes.string,
+    // Source editor is displayed if set to true
+    open: PropTypes.bool,
+    // Source editor content
+    text: PropTypes.string,
+  },
+
+  displayName: "SourceEditor",
+
+  getDefaultProps() {
+    return {
+      mode: null,
+      open: true,
+      text: "",
+    };
+  },
+
+  componentDidMount() {
+    const { mode, text } = this.props;
+
+    this.editor = new CodeMirror(this.refs.editorElement, {
+      lineNumbers: true,
+      mode: text.length < SYNTAX_HIGHLIGHT_MAX_SIZE ? mode : null,
+      readOnly: true,
+      value: text,
+    });
+  },
+
+  componentDidUpdate(prevProps) {
+    const { mode, open, text } = this.props;
+
+    if (!open) {
+      return;
+    }
+
+    if (prevProps.mode !== mode && text.length < SYNTAX_HIGHLIGHT_MAX_SIZE) {
+      this.editor.setMode(mode);
+    }
+
+    if (prevProps.text !== text) {
+      this.editor.setText(text);
+    }
+  },
+
+  componentWillUnmount() {
+    // Unlink the current document.
+    if (this.editor.doc) {
+      this.editor.doc.cm = null;
+    }
+  },
+
+  render() {
+    return (
+      div({
+        ref: "editorElement",
+        className: "editor-mount devtools-monospace",
+        // Using visibility instead of display property to avoid breaking
+        // CodeMirror indentation
+        style: { visibility: this.props.open ? "visible" : "hidden" },
+      })
+    );
+  }
+});
+
+module.exports = SourceEditor;

--- a/packages/devtools-modules/index.js
+++ b/packages/devtools-modules/index.js
@@ -9,8 +9,8 @@ const MenuItem = require("./client/framework/menu-item");
 const networkRequest = require("./client/shared/shim/networkRequest");
 const PrefsHelper = require("./client/shared/prefs").PrefsHelper;
 const SearchBox = require("./client/shared/components/search-box");
-const StackTrace = require("./client/shared/components/stack-trace");
 const Services = require("./client/shared/shim/Services");
+const SourceEditor = require("./client/shared/components/source-editor/source-editor");
 const sourceUtils = require("./client/shared/source-utils");
 const sprintf = require("./shared/sprintf").sprintf;
 // const Tabbar = require("./client/shared/components/tabs/tabbar");
@@ -54,8 +54,8 @@ module.exports = {
   PluralForm,
   PrefsHelper,
   SearchBox,
-  StackTrace,
   Services,
+  SourceEditor,
   setNamedTimeout,
   sourceUtils,
   // LocalizationHelper,

--- a/packages/devtools-modules/package.json
+++ b/packages/devtools-modules/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "codemirror": "^5.25.0",
     "properties-parser": "^0.3.1"
   }
 }

--- a/packages/devtools-modules/yarn.lock
+++ b/packages/devtools-modules/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+codemirror@^5.25.0:
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.25.0.tgz#78e06939c7bb41f65707b8aa9c5328111948b756"
+
 properties-parser@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/properties-parser/-/properties-parser-0.3.1.tgz#1316e9539ffbfd93845e369b211022abd478771a"


### PR DESCRIPTION
This module is basically a react component wrapper which handles source editor (code mirror). This is designed to be a shared component which is able to be shared with debugger and netmonitor...anyone else who needs to embed source editor feature.

Btw, I'm not sure this should be treated as a separate module like devtools-splitter. 