### PR TITLE
Fix to send correct args to Windows FF

### DIFF
--- a/packages/devtools-launchpad/bin/firefox-driver.js
+++ b/packages/devtools-launchpad/bin/firefox-driver.js
@@ -34,11 +34,10 @@ function addGeckoDriverToPath() {
 }
 
 function binaryArgs() {
-  return [
-    (!isWindows ? "-" : "") +
-    "-start-debugger-server=" +
-    (useWebSocket ? "ws:6080" : "6080")
-  ];
+	if (isWindows)
+		return [ "-start-debugger-server", useWebSocket ? "ws:6080" : "6080" ]  // e.g. -start-debugger-server 6080
+	else 
+		return ["--start-debugger-server=" + (useWebSocket ? "ws:6080" : "6080")] // e.g. --start-debugger-server=6080
 }
 
 function firefoxBinary() {

--- a/packages/devtools-launchpad/bin/firefox-driver.js
+++ b/packages/devtools-launchpad/bin/firefox-driver.js
@@ -34,10 +34,12 @@ function addGeckoDriverToPath() {
 }
 
 function binaryArgs() {
-	if (isWindows)
+	if (isWindows) {
 		return [ "-start-debugger-server", useWebSocket ? "ws:6080" : "6080" ]  // e.g. -start-debugger-server 6080
-	else 
+  }
+	else {
 		return ["--start-debugger-server=" + (useWebSocket ? "ws:6080" : "6080")] // e.g. --start-debugger-server=6080
+  }
 }
 
 function firefoxBinary() {


### PR DESCRIPTION
Fix bug where "yarn firefox" would not open port 6080 for remote debug on Windows platform 