### PR TITLE
Bug 1356569 - Remove optional trailing parameters (from mozilla-central)

### DIFF
--- a/packages/devtools-modules/client/shared/prefs.js
+++ b/packages/devtools-modules/client/shared/prefs.js
@@ -156,7 +156,7 @@ function makeObserver(self, cache, prefsRoot, prefsBlueprint) {
   return {
     register: function() {
       this._branch = Services.prefs.getBranch(prefsRoot + ".");
-      this._branch.addObserver("", this, false);
+      this._branch.addObserver("", this);
     },
     unregister: function() {
       this._branch.removeObserver("", this);


### PR DESCRIPTION
Port back a fix made on mozilla-central (https://bugzilla.mozilla.org/show_bug.cgi?id=1356569)