### PR TITLE
[Tree] Navigate to next node on right arrow key

### DIFF
--- a/packages/devtools-modules/client/shared/components/tree.js
+++ b/packages/devtools-modules/client/shared/components/tree.js
@@ -519,6 +519,8 @@ const Tree = module.exports = createClass({
       case "ArrowRight":
         if (!this.props.isExpanded(this.props.focused)) {
           this._onExpand(this.props.focused);
+        } else if (this.props.getChildren(this.props.focused).length) {
+          this._focusNextNode();
         }
         return;
     }


### PR DESCRIPTION
Navigate to next node when right arrow key is pressed and focused node is a directory. (This is consistent with how chrome devtools and VS code handle right arrow key in source tree)

### Summary of changes
* Focus next node when right arrow key is pressed and focused node is directory.