### PR TITLE
Put original URL in getOriginalLocation result

### DIFF
--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -142,7 +142,7 @@ async function getGeneratedLocation(location: Location, originalSource: Source)
   };
 }
 
-async function getOriginalLocation(location: Location) {
+async function getOriginalLocation(location: Location) : Promise<Location> {
   if (!isGeneratedId(location.sourceId)) {
     return location;
   }
@@ -164,6 +164,7 @@ async function getOriginalLocation(location: Location) {
 
   return {
     sourceId: generatedToOriginalId(location.sourceId, url),
+    sourceUrl: url,
     line,
     column
   };


### PR DESCRIPTION
Change getOriginalLocation to put the original URL in the result
object.  This is simpler for clients that don't want to maintain their
own mapping of original IDs to URLs.