### PR TITLE
Resolves #161 [Launchpad] Show Launch button when no targets exist

### DIFF
--- a/packages/devtools-launchpad/src/components/LandingPage.css
+++ b/packages/devtools-launchpad/src/components/LandingPage.css
@@ -43,7 +43,15 @@
   transition: var(--base-transition);
 }
 
-.landing-page .panel header input[type=button] {
+.landing-page .panel .hero {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.landing-page .panel input[type=button] {
   background-color: var(--theme-tab-toolbar-background);
   color: var(--theme-comment);
   font-size: var(--ui-element-font-size);

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -104,8 +104,17 @@ const LandingPage = React.createClass({
     });
   },
 
+  renderEmptyPanel() {
+    return dom.div({ className: "hero" }, this.renderLaunchButton());
+  },
+
+  renderSettings() {
+    const { config, setValue } = this.props;
+    return Settings({ config, setValue });
+  },
+
   renderPanel() {
-    const { onTabClick, config, setValue } = this.props;
+    const { onTabClick } = this.props;
     const { selectedPane } = this.state;
 
     const {
@@ -140,7 +149,7 @@ const LandingPage = React.createClass({
           }
         }
       })
-    ) : dom.div({ className: "hero" }, this.renderLaunchButton());
+    ) : this.renderEmptyPanel();
 
     return dom.main(
       { className: "panel" },
@@ -148,8 +157,8 @@ const LandingPage = React.createClass({
         targetsContent :
         dom.header({},
           dom.h1({}, configMap.Settings.name)),
-          isSettingsPaneSelected ?
-          Settings({ config, setValue }) :
+          isSettingsPaneSelected ? this.renderSettings()
+           :
           Tabs({ targets, paramName, onTabClick }),
         firstTimeMessage(name, docsUrlPart)
     );

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -3,7 +3,7 @@ const React = require("react");
 require("./LandingPage.css");
 const { DOM: dom } = React;
 const ImPropTypes = require("react-immutable-proptypes");
-
+const configMap = require("../constants").sidePanelItems;
 const Tabs = React.createFactory(require("./Tabs"));
 const Sidebar = React.createFactory(require("./Sidebar"));
 const Settings = React.createFactory(require("./Settings"));
@@ -43,7 +43,7 @@ const LandingPage = React.createClass({
 
   getInitialState() {
     return {
-      selectedPane: "Firefox",
+      selectedPane: configMap.Firefox.name,
       firefoxConnected: false,
       chromeConnected: false
     };
@@ -67,51 +67,26 @@ const LandingPage = React.createClass({
 
   renderPanel() {
     const { onTabClick, config, setValue } = this.props;
-    const configMap = {
-      Firefox: {
-        name: "Firefox",
-        clientType: "firefox",
-        paramName: "firefox-tab",
-        docsUrlPart: "firefox"
-      },
-      Chrome: {
-        name: "Chrome",
-        clientType: "chrome",
-        paramName: "chrome-tab",
-        docsUrlPart: "chrome"
-      },
-      Node: {
-        name: "Node",
-        clientType: "node",
-        paramName: "node-tab",
-        docsUrlPart: "node"
-      },
-      Settings: {
-        name: "Settings",
-        clientType: "settings",
-        paramName: "settings-tab",
-        docsUrlPart: "settings"
-      }
-    };
+    const { selectedPane } = this.state;
 
-    let {
+    const {
       name,
       clientType,
       paramName,
       docsUrlPart
-    } = configMap[this.state.selectedPane];
+    } = configMap[selectedPane];
 
-    let {
+    const {
       tabs,
       filterString = ""
     } = this.props;
 
-    let { selectedPane } = this.state;
 
     const targets = getTabsByClientType(tabs, clientType);
-    const isSettingsPaneSelected = name === "Settings";
-    const isNodeSelected = name === configMap.Node.name;
     const currentTargetsExist = targets && targets.count() > 0;
+
+    const isSettingsPaneSelected = name === configMap.Settings.name;
+    const isNodeSelected = name === configMap.Node.name;
 
     const launchBrowser = (browser) => {
       fetch("/launch", {
@@ -122,7 +97,7 @@ const LandingPage = React.createClass({
         method: "post"
       })
       .then(resp => {
-        if (browser == "firefox") {
+        if (browser.name === configMap.Firefox.name) {
           this.setState({ firefoxConnected: true });
         } else {
           this.setState({ chromeConnected: true });
@@ -133,7 +108,7 @@ const LandingPage = React.createClass({
       });
     };
 
-    const isConnected = name == "Firefox"
+    const isConnected = name === configMap.Firefox.name
       ? this.state.firefoxConnected
       : this.state.chromeConnected;
 
@@ -142,7 +117,7 @@ const LandingPage = React.createClass({
 
     const launchButton = isConnected ? connectedStateText : dom.input({
       type: "button",
-      value: `Launch ${selectedPane}`,
+      value: `Launch ${configMap[selectedPane].name}`,
       onClick: () => launchBrowser(selectedPane)
     });
 
@@ -167,7 +142,7 @@ const LandingPage = React.createClass({
       !isSettingsPaneSelected ?
         targetsContent :
         dom.header({},
-          dom.h1({}, "Settings")),
+          dom.h1({}, configMap.Settings.name)),
           isSettingsPaneSelected ?
           Settings({ config, setValue }) :
           Tabs({ targets, paramName, onTabClick }),

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -110,6 +110,8 @@ const LandingPage = React.createClass({
 
     const targets = getTabsByClientType(tabs, clientType);
     const isSettingsPaneSelected = name === "Settings";
+    const isNodeSelected = name === configMap.Node.name;
+    const currentTargetsExist = targets && targets.count() > 0;
 
     const launchBrowser = (browser) => {
       fetch("/launch", {
@@ -134,30 +136,36 @@ const LandingPage = React.createClass({
     const isConnected = name == "Firefox"
       ? this.state.firefoxConnected
       : this.state.chromeConnected;
-    const launchButton = isConnected ? null : dom.input({
+
+    const connectedStateText = isNodeSelected ?
+      null : `Please open a tab in ${name}`;
+
+    const launchButton = isConnected ? connectedStateText : dom.input({
       type: "button",
       value: `Launch ${selectedPane}`,
       onClick: () => launchBrowser(selectedPane)
     });
+
+    const targetsContent = currentTargetsExist ? dom.header({},
+      dom.input({
+        ref: "filterInput",
+        placeholder: "Filter tabs",
+        value: filterString,
+        autoFocus: true,
+        type: "search",
+        onChange: e => this.onFilterChange(e.target.value),
+        onKeyDown: e => {
+          if (targets.size === 1 && e.keyCode === 13) {
+            this.onTabClick(targets.first(), paramName);
+          }
+        }
+      })
+    ) : dom.div({ className: "hero" }, launchButton);
+
     return dom.main(
       { className: "panel" },
       !isSettingsPaneSelected ?
-        dom.header({},
-          dom.input({
-            ref: "filterInput",
-            placeholder: "Filter tabs",
-            value: filterString,
-            autoFocus: true,
-            type: "search",
-            onChange: e => this.onFilterChange(e.target.value),
-            onKeyDown: e => {
-              if (targets.size === 1 && e.keyCode === 13) {
-                this.onTabClick(targets.first(), paramName);
-              }
-            }
-          }),
-          launchButton
-        ) :
+        targetsContent :
         dom.header({},
           dom.h1({}, "Settings")),
           isSettingsPaneSelected ?

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -11,17 +11,19 @@ const Settings = React.createFactory(require("./Settings"));
 const githubUrl = "https://github.com/devtools-html/debugger.html/blob/master";
 
 function getTabsByClientType(tabs, clientType) {
-  return tabs.valueSeq()
-    .filter(tab => tab.get("clientType") == clientType);
+  return tabs.valueSeq().filter(tab => tab.get("clientType") == clientType);
 }
 
 function firstTimeMessage(title, urlPart) {
   return dom.div(
     { className: "footer-note" },
     `First time connecting to ${title}? Checkout out the `,
-    dom.a({
-      href: `${githubUrl}/docs/getting-setup.md#starting-${urlPart}`
-    }, "docs"),
+    dom.a(
+      {
+        href: `${githubUrl}/docs/getting-setup.md#starting-${urlPart}`
+      },
+      "docs"
+    ),
     "."
   );
 }
@@ -74,14 +76,21 @@ const LandingPage = React.createClass({
       : this.state.chromeConnected;
     const isNodeSelected = name === configMap.Node.name;
 
-    const connectedStateText = isNodeSelected ?
-      null : `Please open a tab in ${name}`;
+    if (isNodeSelected) {
+      return dom.h3({}, "Run a node script in the terminal with `--inspect`");
+    }
 
-    return isConnected ? connectedStateText : dom.input({
-      type: "button",
-      value: `Launch ${configMap[selectedPane].name}`,
-      onClick: () => this.launchBrowser(configMap[selectedPane].name)
-    });
+    const connectedStateText = isNodeSelected
+      ? null
+      : `Please open a tab in ${name}`;
+
+    return isConnected
+      ? connectedStateText
+      : dom.input({
+        type: "button",
+        value: `Launch ${configMap[selectedPane].name}`,
+        onClick: () => this.launchBrowser(configMap[selectedPane].name)
+      });
   },
 
   launchBrowser(browser) {
@@ -92,16 +101,16 @@ const LandingPage = React.createClass({
       },
       method: "post"
     })
-    .then(resp => {
-      if (browser === configMap.Firefox.name) {
-        this.setState({ firefoxConnected: true });
-      } else {
-        this.setState({ chromeConnected: true });
-      }
-    })
-    .catch(err => {
-      alert(`Error launching ${browser}. ${err.message}`);
-    });
+      .then(resp => {
+        if (browser === configMap.Firefox.name) {
+          this.setState({ firefoxConnected: true });
+        } else {
+          this.setState({ chromeConnected: true });
+        }
+      })
+      .catch(err => {
+        alert(`Error launching ${browser}. ${err.message}`);
+      });
   },
 
   renderEmptyPanel() {
@@ -111,10 +120,9 @@ const LandingPage = React.createClass({
   renderSettings() {
     const { config, setValue } = this.props;
 
-    return dom.div({},
-      dom.header({},
-        dom.h1({}, configMap.Settings.name)
-      ),
+    return dom.div(
+      {},
+      dom.header({}, dom.h1({}, configMap.Settings.name)),
       Settings({ config, setValue })
     );
   },
@@ -122,19 +130,14 @@ const LandingPage = React.createClass({
   renderFilter() {
     const { selectedPane } = this.state;
 
-    const {
-      tabs,
-      filterString = ""
-    } = this.props;
+    const { tabs, filterString = "" } = this.props;
 
-    const {
-      clientType,
-      paramName,
-    } = configMap[selectedPane];
+    const { clientType, paramName } = configMap[selectedPane];
 
     const targets = getTabsByClientType(tabs, clientType);
 
-    return dom.header({},
+    return dom.header(
+      {},
       dom.input({
         ref: "filterInput",
         placeholder: "Filter tabs",
@@ -155,11 +158,7 @@ const LandingPage = React.createClass({
     const { onTabClick, tabs } = this.props;
     const { selectedPane } = this.state;
 
-    const {
-      name,
-      clientType,
-      paramName,
-    } = configMap[selectedPane];
+    const { name, clientType, paramName } = configMap[selectedPane];
 
     const clientTargets = getTabsByClientType(tabs, clientType);
     const tabsDetected = clientTargets && clientTargets.count() > 0;
@@ -175,9 +174,10 @@ const LandingPage = React.createClass({
       return this.renderEmptyPanel();
     }
 
-    return dom.div({},
-        this.renderFilter(),
-        Tabs({ targets, paramName, onTabClick })
+    return dom.div(
+      {},
+      this.renderFilter(),
+      Tabs({ targets, paramName, onTabClick })
     );
   },
 
@@ -186,18 +186,18 @@ const LandingPage = React.createClass({
     const { selectedPane } = this.state;
     const { onSideBarItemClick } = this;
 
-    const {
-      name,
-      docsUrlPart
-    } = configMap[selectedPane];
+    const { name, docsUrlPart } = configMap[selectedPane];
 
     return dom.div(
       {
         className: "landing-page"
       },
       Sidebar({
-        supportsFirefox, supportsChrome, title,
-        selectedPane, onSideBarItemClick
+        supportsFirefox,
+        supportsChrome,
+        title,
+        selectedPane,
+        onSideBarItemClick
       }),
       dom.main(
         { className: "panel" },

--- a/packages/devtools-launchpad/src/components/LandingPage.js
+++ b/packages/devtools-launchpad/src/components/LandingPage.js
@@ -110,32 +110,31 @@ const LandingPage = React.createClass({
 
   renderSettings() {
     const { config, setValue } = this.props;
-    return Settings({ config, setValue });
+
+    return dom.div({},
+      dom.header({},
+        dom.h1({}, configMap.Settings.name)
+      ),
+      Settings({ config, setValue })
+    );
   },
 
-  renderPanel() {
-    const { onTabClick } = this.props;
+  renderFilter() {
     const { selectedPane } = this.state;
-
-    const {
-      name,
-      clientType,
-      paramName,
-      docsUrlPart
-    } = configMap[selectedPane];
 
     const {
       tabs,
       filterString = ""
     } = this.props;
 
+    const {
+      clientType,
+      paramName,
+    } = configMap[selectedPane];
 
     const targets = getTabsByClientType(tabs, clientType);
-    const currentTargetsExist = targets && targets.count() > 0;
 
-    const isSettingsPaneSelected = name === configMap.Settings.name;
-
-    const targetsContent = currentTargetsExist ? dom.header({},
+    return dom.header({},
       dom.input({
         ref: "filterInput",
         placeholder: "Filter tabs",
@@ -149,18 +148,36 @@ const LandingPage = React.createClass({
           }
         }
       })
-    ) : this.renderEmptyPanel();
+    );
+  },
 
-    return dom.main(
-      { className: "panel" },
-      !isSettingsPaneSelected ?
-        targetsContent :
-        dom.header({},
-          dom.h1({}, configMap.Settings.name)),
-          isSettingsPaneSelected ? this.renderSettings()
-           :
-          Tabs({ targets, paramName, onTabClick }),
-        firstTimeMessage(name, docsUrlPart)
+  renderPanel() {
+    const { onTabClick, tabs } = this.props;
+    const { selectedPane } = this.state;
+
+    const {
+      name,
+      clientType,
+      paramName,
+    } = configMap[selectedPane];
+
+    const clientTargets = getTabsByClientType(tabs, clientType);
+    const tabsDetected = clientTargets && clientTargets.count() > 0;
+    const targets = clientTargets.filter(t => !t.get("filteredOut"));
+
+    const isSettingsPaneSelected = name === configMap.Settings.name;
+
+    if (isSettingsPaneSelected) {
+      return this.renderSettings();
+    }
+
+    if (!tabsDetected) {
+      return this.renderEmptyPanel();
+    }
+
+    return dom.div({},
+        this.renderFilter(),
+        Tabs({ targets, paramName, onTabClick })
     );
   },
 
@@ -168,6 +185,12 @@ const LandingPage = React.createClass({
     const { supportsFirefox, supportsChrome, title } = this.props;
     const { selectedPane } = this.state;
     const { onSideBarItemClick } = this;
+
+    const {
+      name,
+      docsUrlPart
+    } = configMap[selectedPane];
+
     return dom.div(
       {
         className: "landing-page"
@@ -176,7 +199,11 @@ const LandingPage = React.createClass({
         supportsFirefox, supportsChrome, title,
         selectedPane, onSideBarItemClick
       }),
-      this.renderPanel()
+      dom.main(
+        { className: "panel" },
+        this.renderPanel(),
+        firstTimeMessage(name, docsUrlPart)
+      )
     );
   }
 });

--- a/packages/devtools-launchpad/src/constants.js
+++ b/packages/devtools-launchpad/src/constants.js
@@ -3,6 +3,32 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+const sidePanelItems = {
+  Firefox: {
+    name: "Firefox",
+    clientType: "firefox",
+    paramName: "firefox-tab",
+    docsUrlPart: "firefox"
+  },
+  Chrome: {
+    name: "Chrome",
+    clientType: "chrome",
+    paramName: "chrome-tab",
+    docsUrlPart: "chrome"
+  },
+  Node: {
+    name: "Node",
+    clientType: "node",
+    paramName: "node-tab",
+    docsUrlPart: "node"
+  },
+  Settings: {
+    name: "Settings",
+    clientType: "settings",
+    paramName: "settings-tab",
+    docsUrlPart: "settings"
+  }
+};
 
 module.exports = {
   CLEAR_TABS: "CLEAR_TABS",
@@ -10,5 +36,8 @@ module.exports = {
   SELECT_TAB: "SELECT_TAB",
   FILTER_TABS: "FILTER_TABS",
   SET_VALUE: "SET_VALUE",
-  SET_CONFIG: "SET_CONFIG"
+  SET_CONFIG: "SET_CONFIG",
+  sidePanelItems
 };
+
+

--- a/packages/devtools-launchpad/src/constants.js
+++ b/packages/devtools-launchpad/src/constants.js
@@ -39,5 +39,3 @@ module.exports = {
   SET_CONFIG: "SET_CONFIG",
   sidePanelItems
 };
-
-

--- a/packages/devtools-launchpad/src/selectors.js
+++ b/packages/devtools-launchpad/src/selectors.js
@@ -8,10 +8,13 @@ function getTabs(state) {
     return tabs;
   }
 
-  return tabs.filter(tab => (
+  return tabs.map(tab => {
+    const _overallScore =
     score(tab.get("title"), filterString) +
-    score(tab.get("url"), filterString) > 0
-  ));
+    score(tab.get("url"), filterString);
+    return tab.set("filteredOut", _overallScore === 0);
+  }
+);
 }
 
 function getSelectedTab(state) {

--- a/packages/devtools-launchpad/stories/index.js
+++ b/packages/devtools-launchpad/stories/index.js
@@ -8,6 +8,8 @@ let constants = require("../src/constants");
 let getState = combineReducers(reducers);
 const selectors = require("../src/selectors");
 
+import { Map } from "immutable";
+
 // Add devtools theme styles
 require("../src/lib/themes/light-theme.css");
 document.body.classList.add("theme-light");
@@ -37,11 +39,21 @@ const getTabs = (tabs, state) => {
 const renderLandingPage = (props) => {
   return React.DOM.div({}, React.createElement(LandingPage, Object.assign({
     onFilterChange: action("onFilterChange"),
-    onTabClick: action("onTabClick")
+    onTabClick: action("onTabClick"),
+    title: "Storybook test",
+    supportsFirefox: true,
+    supportsChrome: true,
+    config: {},
+    setValue: () => {}
   }, props)));
 };
 
 storiesOf("LandingPage", module)
+  .add("No Tabs", () => {
+    return renderLandingPage({
+      tabs: Map()
+    });
+  })
   .add("six firefox tabs", () => {
     let tabs = [
       getTab(1, "Page 1", "firefox"),
@@ -53,10 +65,7 @@ storiesOf("LandingPage", module)
     ];
 
     return renderLandingPage({
-      tabs: getTabs(tabs),
-      supportsFirefox: true,
-      supportsChrome: true,
-      title: "Storybook test"
+      tabs: getTabs(tabs)
     });
   })
   .add("two of each", () => {
@@ -70,10 +79,7 @@ storiesOf("LandingPage", module)
     ];
 
     return renderLandingPage({
-      tabs: getTabs(tabs),
-      supportsFirefox: true,
-      supportsChrome: true,
-      title: "Storybook test"
+      tabs: getTabs(tabs)
     });
   })
   .add("one hundred firefox tabs with long titles and URLs", () => {
@@ -89,10 +95,7 @@ storiesOf("LandingPage", module)
       );
 
     return renderLandingPage({
-      tabs: getTabs(tabs),
-      supportsFirefox: true,
-      supportsChrome: true,
-      title: "Storybook test"
+      tabs: getTabs(tabs)
     });
   })
   .add("six firefox tabs, filtered with \"MoZ\" (two tabs match)", () => {
@@ -113,10 +116,7 @@ storiesOf("LandingPage", module)
 
     return renderLandingPage({
       tabs: getTabs(tabs, state),
-      filterString: selectors.getFilterString(state),
-      supportsFirefox: true,
-      supportsChrome: true,
-      title: "Storybook test"
+      filterString: selectors.getFilterString(state)
     });
   })
   .add("One of each", () => {
@@ -127,9 +127,6 @@ storiesOf("LandingPage", module)
     ];
 
     return renderLandingPage({
-      tabs: getTabs(tabs),
-      supportsFirefox: true,
-      supportsChrome: true,
-      title: "Storybook test"
+      tabs: getTabs(tabs)
     });
   });


### PR DESCRIPTION
- Removes "Launch `Target`" when targets detected
- Shows "Launch `Target`" when no targets detected
- Shows "Please open a new tab in `target`" in connected state
- ⚠️ Shows nothing when "Node" tab is detected, I need help / advise on what to show when node tab selected

The PR was submitted as part of #goodnessSquad open source contribution event
Thanks to @amitzur for mentoring