### PR TITLE
Do not allow the GPL

### DIFF
--- a/packages/devtools-license-check/bin/devtools-license-check
+++ b/packages/devtools-license-check/bin/devtools-license-check
@@ -30,10 +30,6 @@ const VALID_LICENSES = [
 
   'AFLv2.1',
 
-  'LGPL',
-  'GPLv2',
-  'GPLv3',
-
   'MPL-2.0',
   'MPL 2.0',
 
@@ -46,8 +42,6 @@ const VALID_LICENSES = [
   'BSD-2-Clause',
   'BSD-3-Clause',
   'BSD*',
-
-  'Artistic-2.0',
 
   'WTFPL',
   'Unlicense',

--- a/packages/devtools-license-check/package.json
+++ b/packages/devtools-license-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-license-check",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Verify licenses for inclusion in Mozilla DevTools",
   "repository": "github:devtools-html/devtools-core",
   "author": "",


### PR DESCRIPTION
Julien pointed out that the inclusion of the GPL in the whitelist was an
error; which it was, I didn't notice this when I switched from my unix
scriptish approach to checking to using Jordan's code.

This removes the GPL, LGPL, and Artistic license; none of which we seem
to need.