### PR TITLE
Recognize data: in isURL

### DIFF
--- a/packages/devtools-source-map/src/path.js
+++ b/packages/devtools-source-map/src/path.js
@@ -10,7 +10,12 @@ function dirname(path: string) {
 }
 
 function isURL(str: string) {
-  return str.indexOf("://") !== -1;
+  try {
+    new URL(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 function isAbsolute(str: string) {

--- a/packages/devtools-source-map/src/tests/isURL.js
+++ b/packages/devtools-source-map/src/tests/isURL.js
@@ -1,0 +1,7 @@
+const { isURL } = require("../path");
+
+test("isURL", () => {
+  expect(isURL("http://www.example.com/")).toEqual(true);
+  expect(isURL("www.example.com/")).toEqual(false);
+  expect(isURL("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D")).toEqual(true);
+});


### PR DESCRIPTION
Currently, isURL does not recognize data: URLs.  This is the cause of
https://bugzilla.mozilla.org/show_bug.cgi?id=1360357
This patch fixes it in the obvious way.