### PR TITLE
Prevent state corruption when clearing tabs

### DIFF
--- a/packages/devtools-launchpad/src/reducers/tabs.js
+++ b/packages/devtools-launchpad/src/reducers/tabs.js
@@ -15,7 +15,8 @@ const initialState = fromJS({
 function update(state = initialState, action) {
   switch (action.type) {
     case constants.CLEAR_TABS:
-      return state.setIn(["tabs"], Immutable.Map()).setIn("selectedTab", null);
+      return state.setIn(["tabs"], Immutable.Map())
+        .setIn(["selectedTab"], null);
 
     case constants.ADD_TABS:
       const tabs = action.value;


### PR DESCRIPTION
Small PR that fixes state corruption when a redux action `CLEAR_TABS` triggered.
`setIn` function expects an array as path specifier, it was a string before
