### PR TITLE
Correctly resolve original locations relative to absolute source roots

### DIFF
--- a/packages/devtools-source-map/src/path.js
+++ b/packages/devtools-source-map/src/path.js
@@ -1,9 +1,5 @@
 // @flow
 
-function basename(path: string) {
-  return path.split("/").pop();
-}
-
 function dirname(path: string) {
   const idx = path.lastIndexOf("/");
   return path.slice(0, idx);
@@ -22,10 +18,6 @@ function isAbsolute(str: string) {
   return str[0] === "/";
 }
 
-function join(base: string, dir: string) {
-  return `${base}/${dir}`;
-}
-
 module.exports = {
-  basename, dirname, isURL, isAbsolute, join
+  dirname, isURL, isAbsolute
 };

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -7,7 +7,7 @@
 
 const { networkRequest } = require("devtools-utils");
 
-const { parse } = require("url");
+const { parse, resolve } = require("url");
 const path = require("./path");
 const { SourceMapConsumer, SourceMapGenerator } = require("source-map");
 const assert = require("./assert");
@@ -56,19 +56,11 @@ function _setSourceMapRoot(sourceMap, absSourceMapURL, source) {
     return;
   }
 
-  const base = path.dirname(
-    (absSourceMapURL.indexOf("data:") === 0 && source.url) ?
-      source.url :
-      absSourceMapURL
-  );
-
-  if (sourceMap.sourceRoot) {
-    sourceMap.sourceRoot = path.join(base, sourceMap.sourceRoot);
-  } else {
-    sourceMap.sourceRoot = base;
+  if (absSourceMapURL.indexOf("data:") === 0 && source.url) {
+    absSourceMapURL = source.url;
   }
-
-  return sourceMap;
+  sourceMap.sourceRoot = resolve(absSourceMapURL, sourceMap.sourceRoot);
+  return sourceMap.sourceRoot;
 }
 
 function _getSourceMap(generatedSourceId: string)

--- a/packages/devtools-source-map/src/tests/fixtures/absolute.js
+++ b/packages/devtools-source-map/src/tests/fixtures/absolute.js
@@ -1,0 +1,2 @@
+/* Doesn't really matter what is in here.  */
+// # sourceMappingURL=absolute.js.map

--- a/packages/devtools-source-map/src/tests/fixtures/absolute.js.map
+++ b/packages/devtools-source-map/src/tests/fixtures/absolute.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "sources": [
+    "heart.js"
+  ],
+  "names": [],
+  "mappings": ";AAAA;AACA;;AAEA;AACA;;AAEA;AACA;AACA;;AAEA;AACA;AACA,uBAAe;AACf;AACA;AACA;;AAEA;AACA;;AAEA;AACA;;AAEA;AACA;AACA;;;AAGA;AACA;;AAEA;AACA;;AAEA;AACA;;AAEA;AACA;;;;;;;ACtCA;AACA,QAAO,SAAS;AAChB;;AAEA;AACA;;AAEA;AACA;AACA;;AAEA;AACA;AACA;AACA;AACA;;;;;;;ACfA;AACA;AACA;;;;;;;ACFA;AACA;AACA;;AAEA,mBAAkB;;;;;;;ACJlB;AACA;AACA",
+  "file": "absolute.js",
+  "sourceRoot": "http://example.com/cheese/"
+}

--- a/packages/devtools-source-map/src/tests/source-map.js
+++ b/packages/devtools-source-map/src/tests/source-map.js
@@ -30,4 +30,21 @@ describe("source maps", () => {
       "webpack:///opts.js"
     ]);
   });
+
+  test("URL resolution", async () => {
+    const source = {
+      id: "absolute.js",
+      sourceMapURL: "bundle.js.map"
+    };
+
+    require("devtools-utils/src/network-request").mockImplementationOnce(() => {
+      const content = getMap("fixtures/absolute.js.map");
+      return { content };
+    });
+
+    const urls = await getOriginalURLs(source);
+    expect(urls).toEqual([
+      "http://example.com/cheese/heart.js"
+    ]);
+  });
 });


### PR DESCRIPTION
_setSourceMapRoot was not properly resolving a location relative to an
absolute source root.  This manifested in GWT Super Dev Mode (I really
can't type that enough) as a request for an invalid original source,
like:

http://127.0.0.1:9876/sourcemaps/webadmin/http:/127.0.0.1:9876/sourcemaps/webadmin/com/google/gwt/core/client/GWT.java

This is https://bugzilla.mozilla.org/show_bug.cgi?id=1355126