### PR TITLE
Handle non-existing sourceRoot correctly

### DIFF
--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -66,7 +66,7 @@ function _setSourceMapRoot(sourceMap, absSourceMapURL, source) {
     }
 
     parsedSourceMapURL.pathname = path.dirname(parsedSourceMapURL.pathname);
-    sourceMap.sourceRoot = new URL(sourceMap.sourceRoot,
+    sourceMap.sourceRoot = new URL(sourceMap.sourceRoot || "",
                                    parsedSourceMapURL).toString();
   }
   return sourceMap.sourceRoot;

--- a/packages/devtools-source-map/src/tests/fixtures/noroot.js
+++ b/packages/devtools-source-map/src/tests/fixtures/noroot.js
@@ -1,0 +1,2 @@
+/* Doesn't really matter what is in here.  */
+// # sourceMappingURL=noroot.js.map

--- a/packages/devtools-source-map/src/tests/fixtures/noroot.js.map
+++ b/packages/devtools-source-map/src/tests/fixtures/noroot.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "sources": [
+    "heart.js"
+  ],
+  "names": [],
+  "mappings": ";AAAA;AACA;;AAEA;AACA;;AAEA;AACA;AACA;;AAEA;AACA;AACA,uBAAe;AACf;AACA;AACA;;AAEA;AACA;;AAEA;AACA;;AAEA;AACA;AACA;;;AAGA;AACA;;AAEA;AACA;;AAEA;AACA;;AAEA;AACA;;;;;;;ACtCA;AACA,QAAO,SAAS;AAChB;;AAEA;AACA;;AAEA;AACA;AACA;;AAEA;AACA;AACA;AACA;AACA;;;;;;;ACfA;AACA;AACA;;;;;;;ACFA;AACA;AACA;;AAEA,mBAAkB;;;;;;;ACJlB;AACA;AACA",
+  "file": "noroot.js"
+}

--- a/packages/devtools-source-map/src/tests/source-map.js
+++ b/packages/devtools-source-map/src/tests/source-map.js
@@ -66,4 +66,22 @@ describe("source maps", () => {
       "http://example.com/whatever/heart.js"
     ]);
   });
+
+  test("Non-existing sourceRoot resolution", async () => {
+    const source = {
+      id: "noroot.js",
+      url: "http://example.com/whatever/noroot.js",
+      sourceMapURL: "noroot.js.map"
+    };
+
+    require("devtools-utils/src/network-request").mockImplementationOnce(() => {
+      const content = getMap("fixtures/noroot.js.map");
+      return { content };
+    });
+
+    const urls = await getOriginalURLs(source);
+    expect(urls).toEqual([
+      "http://example.com/whatever/heart.js"
+    ]);
+  });
 });


### PR DESCRIPTION
The previous patch was again wrong, this time not properly handling the
case where sourceRoot is not defined.  This patch fixes it in the
obvious way.