### PR TITLE
Added compatibility with Chrome on Windows for devtools-launchpad package

### DIFF
--- a/packages/devtools-launchpad/bin/chrome-driver.js
+++ b/packages/devtools-launchpad/bin/chrome-driver.js
@@ -2,8 +2,14 @@
 
 const spawn = require('child_process').spawn;
 const minimist = require("minimist");
+const os = require("os");
 
-const chromeBinary = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
+const isWindows = /^win/.test(process.platform);
+
+const chromeBinary = isWindows ?
+  "c:\\program files (x86)\\google\\chrome\\application\\chrome.exe" :
+  "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome";
+
 const args = minimist(process.argv.slice(2), {
   string: ["location"]
 });
@@ -11,7 +17,7 @@ const args = minimist(process.argv.slice(2), {
 let chromeArgs = [
   "--remote-debugging-port=9222",
   "--no-first-run",
-  "--user-data-dir=/tmp/chrome-dev-profile"
+  `--user-data-dir=${os.tmpdir()}/chrome-dev-profile`
 ];
 
 chromeArgs.push(args.location ? args.location : "about:blank");
@@ -23,10 +29,11 @@ chrome.stderr.on('data', data => console.log(`stderr: ${data}`));
 chrome.on('close', code => console.log(`chrome exited with code ${code}`));
 chrome.on('error', error => {
   if (error.code == "ENOENT") {
-    console.log(`Hmm, could not find the path ${chromeBinary}.`)
-    console.log(`Try looking for chrome with ls /Applications`)
+    console.log(`Hmm, could not find the path ${chromeBinary}.`);
+    console.log("Try looking for chrome with ls /Applications");
+
     return;
   }
 
-  console.log(error)
+  console.log(error);
 });

--- a/packages/devtools-launchpad/bin/chrome-driver.js
+++ b/packages/devtools-launchpad/bin/chrome-driver.js
@@ -2,7 +2,7 @@
 
 const spawn = require('child_process').spawn;
 const minimist = require("minimist");
-<<<<<<< HEAD
+
 const os = require("os");
 
 const isWindows = /^win/.test(process.platform);
@@ -11,13 +11,6 @@ const chromeBinary = isWindows ?
   "c:\\program files (x86)\\google\\chrome\\application\\chrome.exe" :
   "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome";
 
-=======
-const os = require('os');
-
-const chromeBinary = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
-const chromeBinaryWindows = 
-      "c:\\program files (x86)\\google\\chrome\\application\\chrome.exe"
->>>>>>> 665e4092ed16e57ab687a46ae9b2f8d7b71fdf0c
 const args = minimist(process.argv.slice(2), {
   string: ["location"]
 });
@@ -28,17 +21,9 @@ let chromeArgs = [
   `--user-data-dir=${os.tmpdir()}/chrome-dev-profile`
 ];
 
-let chromeArgsWindows = [
-  "--remote-debugging-port=9222",
-  "--no-first-run",
-  "--user-data-dir=" + os.tmpdir() + "\\chrome-dev-profile"
-];
-
-const isWindows = /^win/.test(process.platform);
-
 chromeArgs.push(args.location ? args.location : "about:blank");
 
-const chrome = isWindows ? spawn(chromeBinaryWindows, chromeArgsWindows) : spawn(chromeBinary, chromeArgs);
+const chrome = spawn(chromeBinary, chromeArgs);
 
 chrome.stdout.on('data', data => console.log(`stdout: ${data}`));
 chrome.stderr.on('data', data => console.log(`stderr: ${data}`));

--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "license": "MPL-2.0",
   "description": "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
   "repository": {


### PR DESCRIPTION
Hi,

I started to use debugger.html on Windows with Chrome. I noticed that the function start-chrome is not working on Windows, so I decided to fix that.

This is a very naive first implementation but it is working. I think that later this needs to be changed to selenium-webdriver, as it was done with firefox. 

This is my first PR to any open source project, so your feedback would be appreciated. Also, I would really love to see it merged as I need this function. 

Thanks in advance,
Sergey Lymar