### PR TITLE
[WIP] Added color variables for conditional breakpoint text color

### DIFF
--- a/packages/devtools-launchpad/src/lib/themes/variables.css
+++ b/packages/devtools-launchpad/src/lib/themes/variables.css
@@ -29,6 +29,7 @@
   --theme-splitter-color: #dde1e4;
   --theme-comment: #696969;
   --theme-comment-alt: #ccd1d5;
+  --theme-conditional-breakpoint-text-color: #ccd1d5;
 
   --theme-body-color: #393f4c;
   --theme-body-color-alt: #585959;
@@ -96,6 +97,7 @@
   --theme-splitter-color: #454d5d;
   --theme-comment: #757873;
   --theme-comment-alt: #5a6375;
+  --theme-conditional-breakpoint-text-color: #9fa4a9;
 
   --theme-body-color: #8fa1b2;
   --theme-body-color-alt: #b6babf;
@@ -161,6 +163,7 @@
   --theme-splitter-color: #aabccf;
   --theme-comment: green;
   --theme-comment-alt: #ccd1d5;
+  --theme-conditional-breakpoint-text-color: #ccd1d5;
 
   --theme-body-color: #18191a;
   --theme-body-color-alt: #585959;


### PR DESCRIPTION
Trying to polish conditional breakpoint panel, as per the the issue https://github.com/devtools-html/debugger.html/issues/2918 and thought that it would be better to introduce a new variable. In light and firebug themes the color is unchanged, but dark theme color was changed to something more contrast and pleasant to the eye. Should look like this in the end:

|Current colors|Colors to be|
|----------|------|
|![current](https://cloud.githubusercontent.com/assets/69977/26761410/29dce5a8-497a-11e7-837c-7b8c8b26c009.png)|![to be](https://cloud.githubusercontent.com/assets/69977/26761397/e8fe25a6-4979-11e7-9779-4abffe3e105d.png)|