### PR TITLE
Allow to pass parameter names to Function Rep

### DIFF
--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -22,6 +22,7 @@ const { span } = React.DOM;
 FunctionRep.propTypes = {
   object: React.PropTypes.object.isRequired,
   objectLink: React.PropTypes.func,
+  parameterNames: React.PropTypes.array,
 };
 
 function FunctionRep(props) {
@@ -32,7 +33,10 @@ function FunctionRep(props) {
     // appearing in the wrong direction
     span({dir: "ltr", className: "objectBox objectBox-function"},
       getTitle(props, grip),
-      summarizeFunction(grip)
+      summarizeFunction(grip),
+      "(",
+      ...renderParams(props),
+      ")",
     )
   );
 }
@@ -51,7 +55,23 @@ function getTitle(props, grip) {
 
 function summarizeFunction(grip) {
   let name = grip.userDisplayName || grip.displayName || grip.name || "";
-  return cropString(name + "()", 100);
+  return cropString(name, 100);
+}
+
+function renderParams(props) {
+  const {
+    parameterNames = []
+  } = props;
+
+  return parameterNames
+    .filter(param => param)
+    .reduce((res, param, index, arr) => {
+      res.push(span({ className: "param" }, param));
+      if (index < arr.length - 1) {
+        res.push(span({ className: "delimiter" }, ", "));
+      }
+      return res;
+    }, []);
 }
 
 // Registration

--- a/packages/devtools-reps/src/test/mochitest/test_reps_function.html
+++ b/packages/devtools-reps/src/test/mochitest/test_reps_function.html
@@ -60,6 +60,28 @@ window.onload = Task.async(function* () {
     ];
 
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+    is(rendered.textContent, "function testName()",
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "function testName(a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "function testName(a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testUserNamed() {
@@ -76,6 +98,29 @@ window.onload = Task.async(function* () {
     ];
 
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "function testUserName(a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "function testUserName(a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testVarNamed() {
@@ -92,6 +137,27 @@ window.onload = Task.async(function* () {
     ];
 
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "function testVarName(a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "function testVarName(a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testAnon() {
@@ -108,13 +174,37 @@ window.onload = Task.async(function* () {
     ];
 
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "function (a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "function (a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testLongName() {
     // Test declaration: `let f = function loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong() { }`
     const testName = "testLongName";
 
-    const defaultOutput = "function looooooooooooooooooooooooooooooooooooooooooooooooo\u2026ooooooooooooooooooooooooooooooooooooooooooooong()";
+    const functionName = "looooooooooooooooooooooooooooooooooooooooooooooooo\u2026ooooooooooooooooooooooooooooooooooooooooooooooong";
+    const defaultOutput = `function ${functionName}()`;
 
     const modeTests = [
       {
@@ -124,6 +214,29 @@ window.onload = Task.async(function* () {
     ];
 
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, `function ${functionName}(a)`,
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, `function ${functionName}(a, b, c)`,
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testAsyncFunction() {
@@ -150,6 +263,29 @@ window.onload = Task.async(function* () {
       }
     ];
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "async function waitUntil2017(a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "async function waitUntil2017(a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testAnonAsyncFunction() {
@@ -176,6 +312,29 @@ window.onload = Task.async(function* () {
       }
     ];
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "async function (a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "async function (a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testGeneratorFunction() {
@@ -202,6 +361,29 @@ window.onload = Task.async(function* () {
       }
     ];
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "function* fib(a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "function* fib(a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testAnonGeneratorFunction() {
@@ -228,6 +410,29 @@ window.onload = Task.async(function* () {
       }
     ];
     testRepRenderModes(modeTests, testName, componentUnderTest, getGripStub(testName));
+
+    // Testing parameters
+    let rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: []
+    });
+
+    is(rendered.textContent, defaultOutput,
+      "Function Rep is render has expected if parameterNames is empty");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a"]
+    });
+    is(rendered.textContent, "function* (a)",
+      "Function Rep is render has expected if parameterNames has one element");
+
+    rendered = renderComponent(Func.rep, {
+      object: getGripStub(testName),
+      parameterNames: ["a", "b", "c"]
+    });
+    is(rendered.textContent, "function* (a, b, c)",
+      "Function Rep is render has expected if parameterNames has multiple elements");
   }
 
   function testObjectLink() {


### PR DESCRIPTION
Fixes #413 

Added a props `parameterNames` for now since we don't have the data directly in the grip.
This way, the debugger will be able to use the Reps (since there we can retrieve parameter names from the AST)

@jbhoosreddy if you have some time I'd like you to review this PR since I think you're the one that created `previewFunction` , thanks !

---

Mochitest are passing locally