### PR TITLE
Bump version of flow-bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "devtools-license-check": "^0.3.0",
-    "flow-bin": "^0.37.4",
+    "flow-bin": "^0.47",
     "lerna": "2.0.0-beta.30"
   }
 }

--- a/packages/devtools-launchpad/src/client/firefox-types.js
+++ b/packages/devtools-launchpad/src/client/firefox-types.js
@@ -249,7 +249,7 @@ export type TabTarget = {
   activeTab: {
     navigateTo: (string) => Promise<*>,
     reload: () => Promise<*>,
-    attachThread: () => Promise<*>
+    attachThread: (thread: any) => Promise<*>
   },
   destroy: () => void,
 };

--- a/packages/devtools-launchpad/src/client/firefox.js
+++ b/packages/devtools-launchpad/src/client/firefox.js
@@ -93,7 +93,7 @@ async function getTabs() {
   return createTabs(response.tabs);
 }
 
-function initPage() {}
+function initPage(options: Object) {}
 
 module.exports = {
   connectClient,

--- a/packages/devtools-launchpad/src/utils/L10N.js
+++ b/packages/devtools-launchpad/src/utils/L10N.js
@@ -43,6 +43,9 @@ function numberWithDecimals(number: number, decimals: number = 0) {
     return localized;
   }
 
+  // Ignore error until bug is fixed in flow
+  // https://github.com/facebook/flow/issues/4036
+  // $FlowIgnore
   return number.toLocaleString(undefined, {
     maximumFractionDigits: decimals,
     minimumFractionDigits: decimals

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,9 +1105,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.37.4:
-  version "0.37.4"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.37.4.tgz#3d8da2ef746e80e730d166e09040f4198969b76b"
+flow-bin@^0.47:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.47.0.tgz#a2a08ab3e0d1f1cb57d17e27b30b118b62fda367"
 
 for-in@^0.1.5:
   version "0.1.6"


### PR DESCRIPTION
This is to fix all the flow errors in debugger after bumping a flow-bin version. I just changed the version to 0.47 and patched all the errors by inserting `any` and some variable name to where seemed appropriate to make flow run without errors after update.