### PR TITLE
Add an actor id data attribute on tree-node

### DIFF
--- a/packages/devtools-reps/src/reps/attribute.js
+++ b/packages/devtools-reps/src/reps/attribute.js
@@ -31,7 +31,10 @@ function Attribute(props) {
   let value = object.preview.value;
 
   return (
-    safeObjectLink(props, {className: "objectLink-Attr"},
+    safeObjectLink(props, {
+      className: "objectLink-Attr",
+      "data-link-actor-id": object.actor,
+    },
       span({className: "attrTitle"},
         getTitle(object)
       ),

--- a/packages/devtools-reps/src/reps/comment-node.js
+++ b/packages/devtools-reps/src/reps/comment-node.js
@@ -38,7 +38,10 @@ function CommentNode(props) {
     textContent = cropString(textContent, 50);
   }
 
-  return span({className: "objectBox theme-comment"}, `<!-- ${textContent} -->`);
+  return span({
+    className: "objectBox theme-comment",
+    "data-link-actor-id": object.actor,
+  }, `<!-- ${textContent} -->`);
 }
 
 // Registration

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -27,7 +27,10 @@ function DateTime(props) {
   let grip = props.object;
   let date;
   try {
-    date = span({className: "objectBox"},
+    date = span({
+      "data-link-actor-id": grip.actor,
+      className: "objectBox",
+    },
       getTitle(props, grip),
       span({className: "Date"},
         new Date(grip.preview.timestamp).toISOString()

--- a/packages/devtools-reps/src/reps/document.js
+++ b/packages/devtools-reps/src/reps/document.js
@@ -28,7 +28,10 @@ function Document(props) {
   let grip = props.object;
 
   return (
-    span({className: "objectBox objectBox-object"},
+    span({
+      "data-link-actor-id": grip.actor,
+      className: "objectBox objectBox-object"
+    },
       getTitle(props, grip),
       span({className: "objectPropValue"},
         getLocation(grip)

--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -43,7 +43,10 @@ function ElementNode(props) {
 
   let isInTree = object.preview && object.preview.isConnected === true;
 
-  let baseConfig = {className: "objectBox objectBox-node"};
+  let baseConfig = {
+    "data-link-actor-id": object.actor,
+    className: "objectBox objectBox-node"
+  };
   let inspectIcon;
   if (isInTree) {
     if (onDOMNodeMouseOver) {

--- a/packages/devtools-reps/src/reps/error.js
+++ b/packages/devtools-reps/src/reps/error.js
@@ -42,7 +42,10 @@ function ErrorRep(props) {
     content = `${content}\nStack trace:\n${preview.stack}`;
   }
 
-  return safeObjectLink(props, {className: "objectBox-stackTrace"}, content);
+  return safeObjectLink(props, {
+    "data-link-actor-id": object.actor,
+    className: "objectBox-stackTrace",
+  }, content);
 }
 
 // Registration

--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -29,9 +29,13 @@ function FunctionRep(props) {
   let grip = props.object;
 
   return (
-    // Set dir="ltr" to prevent function parentheses from
-    // appearing in the wrong direction
-    span({dir: "ltr", className: "objectBox objectBox-function"},
+    span({
+      "data-link-actor-id": grip.actor,
+      className: "objectBox objectBox-function",
+      // Set dir="ltr" to prevent function parentheses from
+      // appearing in the wrong direction
+      dir: "ltr",
+    },
       getTitle(props, grip),
       summarizeFunction(grip),
       "(",

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -45,7 +45,9 @@ function GripArray(props) {
   if (mode === MODE.TINY) {
     let objectLength = getLength(object);
     let isEmpty = objectLength === 0;
-    items = [span({className: "length"}, isEmpty ? "" : objectLength)];
+    items = [span({
+      className: "length",
+    }, isEmpty ? "" : objectLength)];
     brackets = needSpace(false);
   } else {
     let max = maxLengthMap.get(mode);
@@ -57,6 +59,7 @@ function GripArray(props) {
 
   return (
     span({
+      "data-link-actor-id": object.actor,
       className: "objectBox objectBox-array"},
       title,
       safeObjectLink(props, {

--- a/packages/devtools-reps/src/reps/grip-map.js
+++ b/packages/devtools-reps/src/reps/grip-map.js
@@ -37,18 +37,21 @@ function GripMap(props) {
     object,
   } = props;
 
+  const config = {
+    "data-link-actor-id": object.actor,
+    className: "objectBox objectBox-object",
+  };
+
   if (mode === MODE.TINY) {
     return (
-      span({className: "objectBox objectBox-object"},
-        getTitle(props, object)
-      )
+      span(config, getTitle(props, object))
     );
   }
 
   let propsArray = safeEntriesIterator(props, object, maxLengthMap.get(mode));
 
   return (
-    span({className: "objectBox objectBox-object"},
+    span(config,
       getTitle(props, object),
       safeObjectLink(props, {
         className: "objectLeftBrace",

--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -39,18 +39,21 @@ function GripRep(props) {
     object,
   } = props;
 
+  const config = {
+    "data-link-actor-id": object.actor,
+    className: "objectBox objectBox-object"
+  };
+
   if (mode === MODE.TINY) {
     return (
-      span({className: "objectBox objectBox-object"},
-        getTitle(props, object)
-      )
+      span(config, getTitle(props, object))
     );
   }
 
   let propsArray = safePropIterator(props, object, maxLengthMap.get(mode));
 
   return (
-    span({className: "objectBox objectBox-object"},
+    span(config,
       getTitle(props, object),
       safeObjectLink(props, {
         className: "objectLeftBrace",

--- a/packages/devtools-reps/src/reps/infinity.js
+++ b/packages/devtools-reps/src/reps/infinity.js
@@ -18,9 +18,13 @@ InfinityRep.propTypes = {
 };
 
 function InfinityRep(props) {
+  const {
+    object,
+  } = props;
+
   return (
     span({className: "objectBox objectBox-number"},
-      props.object.type
+      object.type
     )
   );
 }

--- a/packages/devtools-reps/src/reps/long-string.js
+++ b/packages/devtools-reps/src/reps/long-string.js
@@ -36,7 +36,11 @@ function LongStringRep(props) {
   } = props;
   let {fullText, initial, length} = object;
 
-  let config = {className: "objectBox objectBox-string"};
+  let config = {
+    "data-link-actor-id": object.actor,
+    className: "objectBox objectBox-string"
+  };
+
   if (style) {
     config.style = style;
   }

--- a/packages/devtools-reps/src/reps/object-with-text.js
+++ b/packages/devtools-reps/src/reps/object-with-text.js
@@ -25,7 +25,10 @@ ObjectWithText.propTypes = {
 function ObjectWithText(props) {
   let grip = props.object;
   return (
-    span({className: "objectBox objectBox-" + getType(grip)},
+    span({
+      "data-link-actor-id": grip.actor,
+      className: "objectBox objectBox-" + getType(grip)
+    },
       getTitle(props, grip),
       span({className: "objectPropValue"}, getDescription(grip))
     )

--- a/packages/devtools-reps/src/reps/object-with-url.js
+++ b/packages/devtools-reps/src/reps/object-with-url.js
@@ -27,7 +27,10 @@ ObjectWithURL.propTypes = {
 function ObjectWithURL(props) {
   let grip = props.object;
   return (
-    span({className: "objectBox objectBox-" + getType(grip)},
+    span({
+      "data-link-actor-id": grip.actor,
+      className: "objectBox objectBox-" + getType(grip)
+    },
       getTitle(props, grip),
       span({className: "objectPropValue"}, getDescription(grip))
     )

--- a/packages/devtools-reps/src/reps/promise.js
+++ b/packages/devtools-reps/src/reps/promise.js
@@ -33,11 +33,16 @@ function PromiseRep(props) {
   const object = props.object;
   const {promiseState} = object;
 
+  const config = {
+    "data-link-actor-id": object.actor,
+    className: "objectBox objectBox-object",
+  };
+
   if (props.mode === MODE.TINY) {
     let { Rep } = require("./rep");
 
     return (
-      span({className: "objectBox objectBox-object"},
+      span(config,
         getTitle(props, object),
         safeObjectLink(props, {
           className: "objectLeftBrace",
@@ -52,7 +57,7 @@ function PromiseRep(props) {
 
   const propsArray = getProps(props, promiseState);
   return (
-    span({className: "objectBox objectBox-object"},
+    span(config,
       getTitle(props, object),
       safeObjectLink(props, {
         className: "objectLeftBrace",

--- a/packages/devtools-reps/src/reps/regexp.js
+++ b/packages/devtools-reps/src/reps/regexp.js
@@ -25,6 +25,7 @@ function RegExp(props) {
 
   return (
     safeObjectLink(props, {
+      "data-link-actor-id": object.actor,
       className: "objectBox objectBox-regexp regexpSource"
     }, getSource(object))
   );

--- a/packages/devtools-reps/src/reps/stylesheet.js
+++ b/packages/devtools-reps/src/reps/stylesheet.js
@@ -28,7 +28,10 @@ function StyleSheet(props) {
   let grip = props.object;
 
   return (
-    span({className: "objectBox objectBox-object"},
+    span({
+      "data-link-actor-id": grip.actor,
+      className: "objectBox objectBox-object",
+    },
       getTitle(props, grip),
       span({className: "objectPropValue"}, getLocation(grip))
     )

--- a/packages/devtools-reps/src/reps/symbol.js
+++ b/packages/devtools-reps/src/reps/symbol.js
@@ -23,8 +23,7 @@ function SymbolRep(props) {
 
   return (
     span({className: "objectBox objectBox-symbol"},
-      `Symbol(${name || ""})`
-    )
+      `Symbol(${name || ""})`)
   );
 }
 

--- a/packages/devtools-reps/src/reps/tests/attribute.js
+++ b/packages/devtools-reps/src/reps/tests/attribute.js
@@ -10,6 +10,10 @@ const {
   getRep,
 } = require("../rep");
 
+const {
+  expectActorAttribute
+} = require("./test-helpers");
+
 let { Attribute, Rep } = REPS;
 
 const stubs = require("../stubs/attribute");
@@ -26,6 +30,7 @@ describe("Attribute", () => {
       object: stub
     }));
     expect(renderedComponent.text()).toEqual("class=\"autocomplete-suggestions\"");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("Attribute rep has expected text when an objectLink is passed as a prop", () => {

--- a/packages/devtools-reps/src/reps/tests/comment-node.js
+++ b/packages/devtools-reps/src/reps/tests/comment-node.js
@@ -9,6 +9,10 @@ const {
   getRep,
 } = require("../rep");
 
+const {
+  expectActorAttribute
+} = require("./test-helpers");
+
 const { MODE } = require("../constants");
 const { Rep, CommentNode } = REPS;
 const stubs = require("../stubs/comment-node");
@@ -32,11 +36,19 @@ describe("CommentNode", () => {
     const object = stubs.get("Comment");
     const renderRep = props => shallow(CommentNode.rep(Object.assign({object}, props)));
 
-    expect(renderRep({mode: undefined}).text())
+    let component = renderRep({mode: undefined});
+    expect(component.text())
       .toEqual(`<!-- test\nand test\nand test\nan…d test\nand test\nand test -->`);
-    expect(renderRep({mode: MODE.TINY}).text())
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({mode: MODE.TINY});
+    expect(component.text())
       .toEqual(`<!-- test\\nand test\\na… test\\nand test -->`);
-    expect(renderRep({mode: MODE.LONG}).text())
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({mode: MODE.LONG});
+    expect(component.text())
       .toEqual(`<!-- ${stub.preview.textContent} -->`);
+    expectActorAttribute(component, object.actor);
   });
 });

--- a/packages/devtools-reps/src/reps/tests/date-time.js
+++ b/packages/devtools-reps/src/reps/tests/date-time.js
@@ -11,6 +11,10 @@ const {
 } = require("../rep");
 
 const {
+  expectActorAttribute
+} = require("./test-helpers");
+
+const {
   DateTime,
   Rep
 } = REPS;
@@ -30,6 +34,7 @@ describe("test DateTime", () => {
     }));
 
     expect(renderedComponent.text()).toEqual("Date 2016-03-30T21:17:24.859Z");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/document.js
+++ b/packages/devtools-reps/src/reps/tests/document.js
@@ -8,6 +8,11 @@ const {
   REPS,
   getRep,
 } = require("../rep");
+
+const {
+  expectActorAttribute
+} = require("./test-helpers");
+
 const { Document } = REPS;
 const stubs = require("../stubs/document");
 const stub = stubs.get("Document");
@@ -24,6 +29,7 @@ describe("Document", () => {
 
     expect(renderedComponent.text())
       .toEqual("HTMLDocument https://www.mozilla.org/en-US/firefox/new/");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders with expected text content when passed an objectLink prop", () => {

--- a/packages/devtools-reps/src/reps/tests/element-node.js
+++ b/packages/devtools-reps/src/reps/tests/element-node.js
@@ -11,7 +11,10 @@ const {
 } = require("../rep");
 const { MODE } = require("../constants");
 const { ElementNode } = REPS;
-const { getSelectableInInspectorGrips } = require("./test-helpers");
+const {
+  expectActorAttribute,
+  getSelectableInInspectorGrips,
+} = require("./test-helpers");
 const stubs = require("../stubs/element-node");
 
 describe("ElementNode - BodyNode", () => {
@@ -28,6 +31,7 @@ describe("ElementNode - BodyNode", () => {
 
     expect(renderedComponent.text())
       .toEqual('<body id="body-id" class="body-class">');
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders with expected text content on tiny mode", () => {
@@ -38,6 +42,7 @@ describe("ElementNode - BodyNode", () => {
 
     expect(renderedComponent.text())
       .toEqual("body#body-id.body-class");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/error.js
+++ b/packages/devtools-reps/src/reps/tests/error.js
@@ -8,6 +8,11 @@ const {
   REPS,
   getRep
 } = require("../rep");
+
+const {
+  expectActorAttribute
+} = require("./test-helpers");
+
 const { ErrorRep } = REPS;
 const { MODE } = require("../constants");
 const stubs = require("../stubs/error");
@@ -30,6 +35,7 @@ describe("Error - Simple error", () => {
       "Stack trace:\n" +
       "@debugger eval code:1:13\n",
     );
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders with expected text for simple error in tiny mode", () => {

--- a/packages/devtools-reps/src/reps/tests/event.js
+++ b/packages/devtools-reps/src/reps/tests/event.js
@@ -10,7 +10,10 @@ const {
   getRep
 } = require("../rep");
 const { Event } = REPS;
-const { getSelectableInInspectorGrips } = require("./test-helpers");
+const {
+  expectActorAttribute,
+  getSelectableInInspectorGrips,
+} = require("./test-helpers");
 
 const { MODE } = require("../constants");
 const stubs = require("../stubs/event");
@@ -26,6 +29,7 @@ describe("Event - beforeprint", () => {
     const renderedComponent = shallow(Event.rep({object}));
     expect(renderedComponent.text()).toEqual(
       "beforeprint { target: Window, isTrusted: true, currentTarget: Window, more… }");
+    expectActorAttribute(renderedComponent, object.actor);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/function.js
+++ b/packages/devtools-reps/src/reps/tests/function.js
@@ -8,7 +8,9 @@ const { REPS } = require("../rep");
 const { MODE } = require("../constants");
 const { Func } = REPS;
 const stubs = require("../stubs/function");
-
+const {
+  expectActorAttribute
+} = require("./test-helpers");
 const renderRep = (object, props) => {
   return shallow(Func.rep(Object.assign({object}, props)));
 };
@@ -26,6 +28,8 @@ describe("Function - Named", () => {
       .toBe("function testName(a)");
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("function testName(a, b, c)");
+
+    expectActorAttribute(renderRep(object), object.actor);
   });
 
   it("renders as expected with object link", () => {

--- a/packages/devtools-reps/src/reps/tests/grip-array.js
+++ b/packages/devtools-reps/src/reps/tests/grip-array.js
@@ -12,7 +12,8 @@ const GripArray = require("../grip-array");
 const { MODE } = require("../constants");
 const stubs = require("../stubs/grip-array");
 const {
-  getSelectableInInspectorGrips
+  expectActorAttribute,
+  getSelectableInInspectorGrips,
 } = require("./test-helpers");
 const {maxLengthMap} = GripArray;
 
@@ -33,10 +34,21 @@ describe("GripArray - basic", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput = "Array []";
 
-    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[]");
-    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+    let component = renderRep({ mode: undefined });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.TINY });
+    expect(component.text()).toBe("[]");
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.SHORT });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.LONG });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/grip-map.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map.js
@@ -12,7 +12,8 @@ const GripMap = require("../grip-map");
 const { MODE } = require("../constants");
 const stubs = require("../stubs/grip-map");
 const {
-  getSelectableInInspectorGrips
+  expectActorAttribute,
+  getSelectableInInspectorGrips,
 } = require("./test-helpers");
 const {maxLengthMap} = GripMap;
 
@@ -33,10 +34,21 @@ describe("GripMap - empty map", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput = "Map {  }";
 
-    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Map");
-    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+    let component = renderRep({ mode: undefined });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.TINY });
+    expect(component.text()).toBe("Map");
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.SHORT });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.LONG });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -12,7 +12,8 @@ const Grip = require("../grip");
 const { MODE } = require("../constants");
 const stubs = require("../stubs/grip");
 const {
-  getSelectableInInspectorGrips
+  expectActorAttribute,
+  getSelectableInInspectorGrips,
 } = require("./test-helpers");
 const {maxLengthMap} = Grip;
 
@@ -34,10 +35,21 @@ describe("Grip - empty object", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput = "Object {  }";
 
-    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
-    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+    let component = renderRep({ mode: undefined });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.TINY });
+    expect(component.text()).toBe("Object");
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.SHORT });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.LONG });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/long-string.js
+++ b/packages/devtools-reps/src/reps/tests/long-string.js
@@ -7,6 +7,11 @@ const {
   REPS,
   getRep,
 } = require("../rep");
+
+const {
+  expectActorAttribute,
+} = require("./test-helpers");
+
 let { LongStringRep } = REPS;
 const stubs = require("../stubs/long-string");
 
@@ -28,6 +33,7 @@ describe("LongStringRep", () => {
     }));
 
     expect(renderedComponent.text()).toEqual(quoteNewlines(`"${stub.initial}…"`));
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders with expected text content for multiline string with " +
@@ -85,6 +91,7 @@ describe("LongStringRep", () => {
     }));
 
     expect(renderedComponent.html())
-      .toEqual('<span class="objectBox objectBox-string">a\naaaaaaaaaaaaaaaaaa…</span>');
+    .toEqual('<span data-link-actor-id="server1.conn1.child1/longString58" ' +
+             'class="objectBox objectBox-string">a\naaaaaaaaaaaaaaaaaa…</span>');
   });
 });

--- a/packages/devtools-reps/src/reps/tests/object-with-text.js
+++ b/packages/devtools-reps/src/reps/tests/object-with-text.js
@@ -9,6 +9,9 @@ const {
 
 const { shallow } = require("enzyme");
 const React = require("react");
+const {
+  expectActorAttribute,
+} = require("./test-helpers");
 
 const stubs = require("../stubs/object-with-text");
 const { ObjectWithText, Rep } = REPS;
@@ -28,6 +31,7 @@ describe("Object with text", () => {
     }));
 
     expect(renderedComponent.text()).toEqual("\".Shadow\"");
+    expectActorAttribute(renderedComponent, gripStub.actor);
   });
 
   // Test rendering with objectLink

--- a/packages/devtools-reps/src/reps/tests/object-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/object-with-url.js
@@ -10,6 +10,9 @@ const {
 } = require("../rep");
 const { ObjectWithURL } = REPS;
 const stubs = require("../stubs/object-with-url");
+const {
+  expectActorAttribute,
+} = require("./test-helpers");
 
 describe("ObjectWithURL", () => {
   const stub = stubs.get("ObjectWithUrl");
@@ -26,6 +29,7 @@ describe("ObjectWithURL", () => {
 
     expect(renderedComponent.hasClass("objectBox-Location")).toBe(true);
     expect(innerNode.text()).toBe("https://www.mozilla.org/en-US/");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders correctly with an ObjectLink", () => {

--- a/packages/devtools-reps/src/reps/tests/promise.js
+++ b/packages/devtools-reps/src/reps/tests/promise.js
@@ -13,6 +13,7 @@ const { PromiseRep } = REPS;
 const { MODE } = require("../constants");
 const stubs = require("../stubs/promise");
 const {
+  expectActorAttribute,
   getSelectableInInspectorGrips
 } = require("./test-helpers");
 
@@ -29,14 +30,21 @@ describe("Promise - Pending", () => {
   });
 
   it("renders as expected", () => {
-    expect(renderRep(object, {mode: undefined}).text())
-      .toBe(defaultOutput);
-    expect(renderRep(object, {mode: MODE.TINY}).text())
-      .toBe('Promise { "pending" }');
-    expect(renderRep(object, {mode: MODE.SHORT}).text())
-      .toBe(defaultOutput);
-    expect(renderRep(object, {mode: MODE.LONG}).text())
-      .toBe(defaultOutput);
+    let component = renderRep(object, {mode: undefined});
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep(object, {mode: MODE.TINY});
+    expect(component.text()).toBe('Promise { "pending" }');
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep(object, {mode: MODE.SHORT});
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep(object, {mode: MODE.LONG});
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/regexp.js
+++ b/packages/devtools-reps/src/reps/tests/regexp.js
@@ -10,6 +10,9 @@ const {
 } = require("../rep");
 const { Rep, RegExp } = REPS;
 const stubs = require("../stubs/regexp");
+const {
+  expectActorAttribute,
+} = require("./test-helpers");
 
 describe("test RegExp", () => {
   const stub = stubs.get("RegExp");
@@ -24,6 +27,7 @@ describe("test RegExp", () => {
     }));
 
     expect(renderedComponent.text()).toEqual("/ab+c/i");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders the expected text content when an objectLink is passed as a prop", () => {

--- a/packages/devtools-reps/src/reps/tests/stylesheet.js
+++ b/packages/devtools-reps/src/reps/tests/stylesheet.js
@@ -10,6 +10,9 @@ const {
 } = require("../rep");
 const { StyleSheet, Rep } = REPS;
 const stubs = require("../stubs/stylesheet");
+const {
+  expectActorAttribute,
+} = require("./test-helpers");
 
 describe("Test StyleSheet", () => {
   const stub = stubs.get("StyleSheet");
@@ -24,6 +27,7 @@ describe("Test StyleSheet", () => {
     }));
 
     expect(renderedComponent.text()).toEqual("StyleSheet https://example.com/styles.css");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders the expected text content when an objectLink is passed as a prop", () => {

--- a/packages/devtools-reps/src/reps/tests/test-helpers.js
+++ b/packages/devtools-reps/src/reps/tests/test-helpers.js
@@ -51,4 +51,14 @@ function getFlattenedGrips(grips) {
   }, []);
 }
 
-module.exports = { getSelectableInInspectorGrips };
+function expectActorAttribute(wrapper, expectedValue) {
+  const actorIdAttribute = "data-link-actor-id";
+  const attrElement = wrapper.find(`[${actorIdAttribute}]`);
+  expect(attrElement.exists()).toBeTruthy();
+  expect(attrElement.first().prop("data-link-actor-id")).toBe(expectedValue);
+}
+
+module.exports = {
+  expectActorAttribute,
+  getSelectableInInspectorGrips,
+};

--- a/packages/devtools-reps/src/reps/tests/text-node.js
+++ b/packages/devtools-reps/src/reps/tests/text-node.js
@@ -18,6 +18,9 @@ let {
 } = REPS;
 
 const stubs = require("../stubs/text-node");
+const {
+  expectActorAttribute,
+} = require("./test-helpers");
 
 describe("TextNode", () => {
   it("selects TextNode Rep as expected", () => {
@@ -29,10 +32,22 @@ describe("TextNode", () => {
     const renderRep = props => shallow(TextNode.rep(Object.assign({object}, props)));
 
     const defaultOutput = `#text "hello world"`;
-    expect(renderRep({mode: undefined}).text()).toBe(defaultOutput);
-    expect(renderRep({mode: MODE.TINY}).text()).toBe("#text");
-    expect(renderRep({mode: MODE.SHORT}).text()).toBe(defaultOutput);
-    expect(renderRep({mode: MODE.LONG}).text()).toBe(defaultOutput);
+
+    let component = renderRep({mode: undefined});
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({mode: MODE.TINY});
+    expect(component.text()).toBe("#text");
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({mode: MODE.SHORT});
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({mode: MODE.LONG});
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
   });
 
   it("renders as expected with EOL", () => {

--- a/packages/devtools-reps/src/reps/tests/window.js
+++ b/packages/devtools-reps/src/reps/tests/window.js
@@ -13,6 +13,9 @@ const {
 const { MODE } = require("../constants");
 const { Rep, Window } = REPS;
 const stubs = require("../stubs/window");
+const {
+  expectActorAttribute,
+} = require("./test-helpers");
 
 describe("test Window", () => {
   const stub = stubs.get("Window");
@@ -27,6 +30,7 @@ describe("test Window", () => {
     }));
 
     expect(renderedComponent.hasClass("objectBox-Window")).toBe(true);
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 
   it("renders with correct content", () => {

--- a/packages/devtools-reps/src/reps/text-node.js
+++ b/packages/devtools-reps/src/reps/text-node.js
@@ -40,7 +40,10 @@ function TextNode(props) {
     onInspectIconClick,
   } = props;
 
-  let baseConfig = {className: "objectBox objectBox-textNode"};
+  let baseConfig = {
+    "data-link-actor-id": grip.actor,
+    className: "objectBox objectBox-textNode",
+  };
   let inspectIcon;
   let isInTree = grip.preview && grip.preview.isConnected === true;
 

--- a/packages/devtools-reps/src/reps/window.js
+++ b/packages/devtools-reps/src/reps/window.js
@@ -34,16 +34,19 @@ function WindowRep(props) {
     object,
   } = props;
 
+  const config = {
+    "data-link-actor-id": object.actor,
+    className: "objectBox objectBox-Window",
+  };
+
   if (mode === MODE.TINY) {
     return (
-      span({className: "objectBox objectBox-Window"},
-        getTitle(props, object)
-      )
+      span(config, getTitle(props, object))
     );
   }
 
   return (
-    span({className: "objectBox objectBox-Window"},
+    span(config,
       getTitle(props, object),
       " ",
       span({className: "objectPropValue"},


### PR DESCRIPTION
This then can be used to retrieve the actor the node is representing.
For example, in the console we can use it in the context menu entry
to store an object as a global variable.