### PR TITLE
Add object inspector tests.

### DIFF
--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -42,6 +42,7 @@
     "fs-extra": "^2.0.0",
     "jest": "^20.0.4",
     "jest-cli": "^20.0.4",
+    "jest-flow-transform": "^1.0.1",
     "react-addons-test-utils": "=15.3.2"
   },
   "jest": {
@@ -58,6 +59,9 @@
     "transformIgnorePatterns": [
       "node_modules/(?!devtools-)"
     ],
+    "transform": {
+      "^.+\\.js(?:\\.flow)?$": "jest-flow-transform"
+    },
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/test/__mocks__/styleMock.js",
       "\\.svg$": "<rootDir>/test/__mocks__/svgMock.js"

--- a/packages/devtools-reps/src/object-inspector/tests/__snapshots__/object-inspector.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/__snapshots__/object-inspector.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`promises getPromiseProperties 1`] = `
+exports[`promises utils function getPromiseProperties 1`] = `
 Array [
   Object {
     "contents": Object {

--- a/packages/devtools-reps/src/object-inspector/tests/object-inspector.js
+++ b/packages/devtools-reps/src/object-inspector/tests/object-inspector.js
@@ -2,6 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+ /* global jest */
+
+const { mount } = require("enzyme");
+const React = require("react");
+const { createFactory } = React;
+const ObjectInspector = createFactory(require("../index"));
+const { MODE } = require("../../reps/constants");
+const { Rep } = require("../../reps/rep");
+const gripStubs = require("../../reps/stubs/grip");
+
 const {
   getPromiseProperties,
   isDefault,
@@ -218,7 +228,7 @@ describe("makeNodesForProperties", () => {
   });
 });
 
-describe("promises", () => {
+describe("promises utils function", () => {
   it("is promise", () => {
     const promise = {
       contents: {
@@ -289,5 +299,276 @@ describe("promises", () => {
 
     const properties = getPromiseProperties(promise);
     expect(properties).toMatchSnapshot();
+  });
+});
+
+describe("ObjectInspector", () => {
+  it("renders as expected", () => {
+    const stub = gripStubs.get("testMoreThanMaxProps");
+
+    const renderObjectInspector = mode => mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+      mode,
+    }));
+    const renderRep = mode => Rep({object: stub, mode});
+
+    const tinyOi = renderObjectInspector(MODE.TINY);
+    expect(tinyOi.find(".arrow").exists()).toBeTruthy();
+    expect(tinyOi.contains(renderRep(MODE.TINY))).toBeTruthy();
+
+    const shortOi = renderObjectInspector(MODE.SHORT);
+    expect(shortOi.find(".arrow").exists()).toBeTruthy();
+    expect(shortOi.contains(renderRep(MODE.SHORT))).toBeTruthy();
+
+    const longOi = renderObjectInspector(MODE.LONG);
+    expect(longOi.find(".arrow").exists()).toBeTruthy();
+    expect(longOi.contains(renderRep(MODE.LONG))).toBeTruthy();
+
+    const oi = renderObjectInspector();
+    expect(oi.find(".arrow").exists()).toBeTruthy();
+    // When no mode is provided, it defaults to TINY mode to render the Rep.
+    expect(oi.contains(renderRep(MODE.TINY))).toBeTruthy();
+  });
+
+  it("directly renders a Rep with the stub is not expandable", () => {
+    const object = 42;
+
+    const renderObjectInspector = mode => mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        contents: {
+          value: object
+        }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+      mode,
+    }));
+    const renderRep = mode => mount(Rep({object, mode}));
+
+    const tinyOi = renderObjectInspector(MODE.TINY);
+    expect(tinyOi.find(".arrow").exists()).toBeFalsy();
+    expect(tinyOi.html()).toEqual(renderRep(MODE.TINY).html());
+
+    const shortOi = renderObjectInspector(MODE.SHORT);
+    expect(shortOi.find(".arrow").exists()).toBeFalsy();
+    expect(shortOi.html()).toEqual(renderRep(MODE.SHORT).html());
+
+    const longOi = renderObjectInspector(MODE.LONG);
+    expect(longOi.find(".arrow").exists()).toBeFalsy();
+    expect(longOi.html()).toEqual(renderRep(MODE.LONG).html());
+
+    const oi = renderObjectInspector();
+    expect(oi.find(".arrow").exists()).toBeFalsy();
+    // When no mode is provided, it defaults to TINY mode to render the Rep.
+    expect(oi.html()).toEqual(renderRep(MODE.TINY).html());
+  });
+
+  it("renders as expected when provided a name", () => {
+    const object = gripStubs.get("testMoreThanMaxProps");
+    const name = "myproperty";
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        name,
+        contents: {
+          value: object
+        }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+      mode: MODE.SHORT,
+    }));
+
+    expect(oi.find(".object-label").text()).toEqual(name);
+  });
+
+  it("renders as expected when not provided a name", () => {
+    const object = gripStubs.get("testMoreThanMaxProps");
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        contents: {
+          value: object
+        }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+      mode: MODE.SHORT,
+    }));
+
+    expect(oi.find(".object-label").exists()).toBeFalsy();
+  });
+
+  it("renders leaves with a shorter mode than the root", () => {
+    const stub = gripStubs.get("testMaxProps");
+
+    const renderObjectInspector = mode => mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      getObjectProperties: actor => {
+        return {
+          ownProperties: Object.keys(stub.preview.ownProperties).reduce((res, key) => {
+            return Object.assign({
+              [key]: {
+                value: stub
+              },
+            }, res);
+          }, {}),
+        };
+      },
+      loadObjectProperties: () => {},
+      mode,
+    }));
+    const renderRep = mode => Rep({object: stub, mode});
+
+    const tinyOi = renderObjectInspector(MODE.TINY);
+    expect(tinyOi.find(".node").at(1).contains(renderRep(MODE.TINY))).toBeTruthy();
+
+    const shortOi = renderObjectInspector(MODE.SHORT);
+    expect(shortOi.find(".node").at(1).contains(renderRep(MODE.TINY))).toBeTruthy();
+
+    const longOi = renderObjectInspector(MODE.LONG);
+    expect(longOi.find(".node").at(1).contains(renderRep(MODE.SHORT))).toBeTruthy();
+
+    const oi = renderObjectInspector();
+    // When no mode is provided, it defaults to TINY mode to render the Rep.
+    expect(oi.find(".node").at(1).contains(renderRep(MODE.TINY))).toBeTruthy();
+  });
+
+  it("does not load properties if getObjectProperties returns a truthy element", () => {
+    const stub = gripStubs.get("testMaxProps");
+    const loadObjectProperties = jest.fn();
+
+    mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      getObjectProperties: actor => {
+        return {
+          ownProperties: stub.preview.ownProperties,
+        };
+      },
+      loadObjectProperties,
+    }));
+
+    expect(loadObjectProperties.mock.calls.length).toBe(0);
+  });
+
+  it("calls loadObjectProperties when expandable leaf is clicked", () => {
+    const stub = gripStubs.get("testMaxProps");
+    const loadObjectProperties = jest.fn();
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties,
+    }));
+
+    const node = oi.find(".node");
+    node.simulate("click");
+
+    expect(loadObjectProperties.mock.calls.length).toBe(1);
+  });
+
+  it("calls the onFocus prop function when provided one and given focus", () => {
+    const stub = gripStubs.get("testMaxProps");
+    const onFocus = jest.fn();
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+      onFocus,
+    }));
+
+    const node = oi.find(".node").first();
+    node.simulate("focus");
+
+    expect(onFocus.mock.calls.length).toBe(1);
+  });
+
+  it("calls the onDoubleClick prop function when provided one and double clicked", () => {
+    const stub = gripStubs.get("testMaxProps");
+    const onDoubleClick = jest.fn();
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+      onDoubleClick,
+    }));
+
+    const node = oi.find(".node").first();
+    node.simulate("doubleclick");
+
+    expect(onDoubleClick.mock.calls.length).toBe(1);
+  });
+
+  it("calls the onLabel prop function when provided one and label clicked", () => {
+    const stub = gripStubs.get("testMaxProps");
+    const onLabelClick = jest.fn();
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      getObjectProperties: actor => {
+        return {
+          ownProperties: stub.preview.ownProperties,
+        };
+      },
+      loadObjectProperties: () => {},
+      onLabelClick,
+    }));
+
+    const label = oi.find(".object-label").first();
+    label.simulate("click");
+
+    expect(onLabelClick.mock.calls.length).toBe(1);
   });
 });

--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -36,7 +36,7 @@ function FunctionRep(props) {
       summarizeFunction(grip),
       "(",
       ...renderParams(props),
-      ")",
+      ")"
     )
   );
 }

--- a/packages/devtools-reps/src/reps/tests/error.js
+++ b/packages/devtools-reps/src/reps/tests/error.js
@@ -28,7 +28,7 @@ describe("Error - Simple error", () => {
     expect(renderedComponent.text()).toEqual(
       "Error: Error message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:1:13\n",
+      "@debugger eval code:1:13\n"
     );
   });
 
@@ -94,7 +94,7 @@ describe("Error - Multi line stack error", () => {
       "Stack trace:\n" +
       "errorBar@debugger eval code:6:15\n" +
       "errorFoo@debugger eval code:3:3\n" +
-      "@debugger eval code:8:1\n",
+      "@debugger eval code:8:1\n"
     );
   });
 

--- a/packages/devtools-reps/yarn.lock
+++ b/packages/devtools-reps/yarn.lock
@@ -650,7 +650,7 @@ babel-types@^6.14.0, babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.13.0, babylon@^6.17.0, babylon@^6.17.2:
+babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0, babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -1976,6 +1976,13 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+flow-remove-types@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-1.2.1.tgz#58e261bf8b842bd234c86cafb982a1213aff0edb"
+  dependencies:
+    babylon "^6.15.0"
+    vlq "^0.2.1"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2308,11 +2315,11 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-iconv-lite@0.4.13, iconv-lite@~0.4.13:
+iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@0.4.15:
+iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -2830,6 +2837,12 @@ jest-environment-node@^20.0.3:
 jest-file-exists@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-file-exists/-/jest-file-exists-19.0.0.tgz#cca2e587a11ec92e24cfeab3f8a94d657f3fceb8"
+
+jest-flow-transform@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jest-flow-transform/-/jest-flow-transform-1.0.1.tgz#2e0d73a8856924afc5710b6ab662898ae70651ec"
+  dependencies:
+    flow-remove-types "^1.2.1"
 
 jest-haste-map@^19.0.0:
   version "19.0.2"
@@ -5244,6 +5257,10 @@ verror@1.3.6:
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+vlq@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
 
 vm-browserify@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Fixes #472.
There were only tests for utils functions.
This adds some basic test for the ObjectInspector itself.