### PR TITLE
Add a prop to force object to be rendered using non-remote reps

### DIFF
--- a/packages/devtools-reps/src/reps/attribute.js
+++ b/packages/devtools-reps/src/reps/attribute.js
@@ -48,8 +48,8 @@ function getTitle(grip) {
 }
 
 // Registration
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/comment-node.js
+++ b/packages/devtools-reps/src/reps/comment-node.js
@@ -42,8 +42,8 @@ function CommentNode(props) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
   return object.preview && object.preview.nodeType === nodeConstants.COMMENT_NODE;

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -45,8 +45,8 @@ function getTitle(props, grip) {
 }
 
 // Registration
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/document.js
+++ b/packages/devtools-reps/src/reps/document.js
@@ -47,8 +47,8 @@ function getTitle(props, grip) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -130,8 +130,8 @@ function getElements(grip, mode) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
   return object.preview && object.preview.nodeType === nodeConstants.ELEMENT_NODE;

--- a/packages/devtools-reps/src/reps/error.js
+++ b/packages/devtools-reps/src/reps/error.js
@@ -46,8 +46,8 @@ function ErrorRep(props) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
   return (object.preview && type === "Error");

--- a/packages/devtools-reps/src/reps/event.js
+++ b/packages/devtools-reps/src/reps/event.js
@@ -87,8 +87,8 @@ function getTitle(props) {
 }
 
 // Registration
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -75,8 +75,8 @@ function renderParams(props) {
 }
 
 // Registration
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return (type == "function");
   }
 

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -185,8 +185,8 @@ function getEmptySlotsElement(number) {
   return `<${number} empty slot${number > 1 ? "s" : ""}>`;
 }
 
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/grip-map.js
+++ b/packages/devtools-reps/src/reps/grip-map.js
@@ -192,8 +192,8 @@ function getEntriesIndexes(entries, max, filter) {
     }, []);
 }
 
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
   return (grip.preview && grip.preview.kind == "MapLike");

--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -31,6 +31,7 @@ GripRep.propTypes = {
   onDOMNodeMouseOver: React.PropTypes.func,
   onDOMNodeMouseOut: React.PropTypes.func,
   onInspectIconClick: React.PropTypes.func,
+  noGrip: React.PropTypes.bool,
 };
 
 function GripRep(props) {
@@ -242,8 +243,8 @@ function getPropValue(property) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
   return (object.preview && object.preview.ownProperties);

--- a/packages/devtools-reps/src/reps/long-string.js
+++ b/packages/devtools-reps/src/reps/long-string.js
@@ -53,8 +53,8 @@ function LongStringRep(props) {
   return span(config, formattedString);
 }
 
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
   return object.type === "longString";

--- a/packages/devtools-reps/src/reps/null.js
+++ b/packages/devtools-reps/src/reps/null.js
@@ -21,7 +21,11 @@ function Null(props) {
   );
 }
 
-function supportsObject(object, type) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true) {
+    return false;
+  }
+
   if (object && object.type && object.type == "null") {
     return true;
   }

--- a/packages/devtools-reps/src/reps/object-with-text.js
+++ b/packages/devtools-reps/src/reps/object-with-text.js
@@ -52,8 +52,8 @@ function getDescription(grip) {
 }
 
 // Registration
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/object-with-url.js
+++ b/packages/devtools-reps/src/reps/object-with-url.js
@@ -47,8 +47,8 @@ function getDescription(grip) {
 }
 
 // Registration
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/promise.js
+++ b/packages/devtools-reps/src/reps/promise.js
@@ -96,8 +96,8 @@ function getProps(props, promiseState) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
   return type === "Promise";

--- a/packages/devtools-reps/src/reps/regexp.js
+++ b/packages/devtools-reps/src/reps/regexp.js
@@ -35,8 +35,8 @@ function getSource(grip) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -80,7 +80,7 @@ const Rep = function (props) {
     object,
     defaultRep,
   } = props;
-  let rep = getRep(object, defaultRep);
+  let rep = getRep(object, defaultRep, props.noGrip);
   return rep(props);
 };
 
@@ -96,12 +96,14 @@ const Rep = function (props) {
  *
  * @param defaultObject {React.Component} The default template
  * that should be used to render given object if none is found.
+ *
+ * @param noGrip {Boolean} If true, will only check reps not made for remote objects.
  */
-function getRep(object, defaultRep = Obj) {
+function getRep(object, defaultRep = Obj, noGrip = false) {
   let type = typeof object;
   if (type == "object" && object instanceof String) {
     type = "string";
-  } else if (object && type == "object" && object.type) {
+  } else if (object && type == "object" && object.type && noGrip !== true) {
     type = object.type;
   }
 
@@ -115,7 +117,7 @@ function getRep(object, defaultRep = Obj) {
       // supportsObject could return weight (not only true/false
       // but a number), which would allow to priorities templates and
       // support better extensibility.
-      if (rep.supportsObject(object, type)) {
+      if (rep.supportsObject(object, type, noGrip)) {
         return rep.rep;
       }
     } catch (err) {

--- a/packages/devtools-reps/src/reps/stylesheet.js
+++ b/packages/devtools-reps/src/reps/stylesheet.js
@@ -47,8 +47,8 @@ function getLocation(grip) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/tests/object.js
+++ b/packages/devtools-reps/src/reps/tests/object.js
@@ -191,3 +191,140 @@ describe("Object - Object link", () => {
       .toEqual(defaultOutput);
   });
 });
+
+// Test that object that might look like Grips are rendered as Object when passed
+// the `noGrip` property.
+describe("Object - noGrip prop", () => {
+  it("object with type property", () => {
+    expect(getRep({type: "string"}, undefined, true)).toBe(Obj.rep);
+  });
+
+  it("object with actor property", () => {
+    expect(getRep({actor: "fake/actorId"}, undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Attribute grip", () => {
+    const stubs = require("../stubs/attribute");
+    expect(getRep(stubs.get("Attribute"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("CommentNode grip", () => {
+    const stubs = require("../stubs/comment-node");
+    expect(getRep(stubs.get("Comment"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("DateTime grip", () => {
+    const stubs = require("../stubs/date-time");
+    expect(getRep(stubs.get("DateTime"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Document grip", () => {
+    const stubs = require("../stubs/document");
+    expect(getRep(stubs.get("Document"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("ElementNode grip", () => {
+    const stubs = require("../stubs/element-node");
+    expect(getRep(stubs.get("BodyNode"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Error grip", () => {
+    const stubs = require("../stubs/error");
+    expect(getRep(stubs.get("SimpleError"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Event grip", () => {
+    const stubs = require("../stubs/event");
+    expect(getRep(stubs.get("testEvent"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Function grip", () => {
+    const stubs = require("../stubs/function");
+    expect(getRep(stubs.get("Named"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Array grip", () => {
+    const stubs = require("../stubs/grip-array");
+    expect(getRep(stubs.get("testMaxProps"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Map grip", () => {
+    const stubs = require("../stubs/grip-map");
+    expect(getRep(stubs.get("testSymbolKeyedMap"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Object grip", () => {
+    const stubs = require("../stubs/grip");
+    expect(getRep(stubs.get("testMaxProps"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Infinity grip", () => {
+    const stubs = require("../stubs/infinity");
+    expect(getRep(stubs.get("Infinity"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("LongString grip", () => {
+    const stubs = require("../stubs/long-string");
+    expect(getRep(stubs.get("testMultiline"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("NaN grip", () => {
+    const stubs = require("../stubs/nan");
+    expect(getRep(stubs.get("NaN"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Null grip", () => {
+    const stubs = require("../stubs/null");
+    expect(getRep(stubs.get("Null"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Number grip", () => {
+    const stubs = require("../stubs/number");
+    expect(getRep(stubs.get("NegZeroGrip"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("ObjectWithText grip", () => {
+    const stubs = require("../stubs/object-with-text");
+    expect(getRep(stubs.get("ObjectWithText"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("ObjectWithURL grip", () => {
+    const stubs = require("../stubs/object-with-url");
+    expect(getRep(stubs.get("ObjectWithUrl"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Promise grip", () => {
+    const stubs = require("../stubs/promise");
+    expect(getRep(stubs.get("Pending"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("RegExp grip", () => {
+    const stubs = require("../stubs/regexp");
+    expect(getRep(stubs.get("RegExp"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Stylesheet grip", () => {
+    const stubs = require("../stubs/stylesheet");
+    expect(getRep(stubs.get("StyleSheet"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Symbol grip", () => {
+    const stubs = require("../stubs/symbol");
+    expect(getRep(stubs.get("Symbol"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("TextNode grip", () => {
+    const stubs = require("../stubs/text-node");
+    expect(getRep(stubs.get("testRendering"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Undefined grip", () => {
+    const stubs = require("../stubs/undefined");
+    expect(getRep(stubs.get("Undefined"), undefined, true)).toBe(Obj.rep);
+  });
+
+  it("Window grip", () => {
+    const stubs = require("../stubs/window");
+    expect(getRep(stubs.get("Window"), undefined, true)).toBe(Obj.rep);
+  });
+});

--- a/packages/devtools-reps/src/reps/text-node.js
+++ b/packages/devtools-reps/src/reps/text-node.js
@@ -94,8 +94,8 @@ function getTitle(props, grip) {
 }
 
 // Registration
-function supportsObject(grip, type) {
-  if (!isGrip(grip)) {
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 

--- a/packages/devtools-reps/src/reps/undefined.js
+++ b/packages/devtools-reps/src/reps/undefined.js
@@ -21,12 +21,12 @@ const Undefined = function () {
   );
 };
 
-function supportsObject(object, type) {
-  if (object && object.type && object.type == "undefined") {
-    return true;
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true) {
+    return false;
   }
 
-  return (type == "undefined");
+  return (object && object.type && object.type == "undefined") || type == "undefined";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/window.js
+++ b/packages/devtools-reps/src/reps/window.js
@@ -63,8 +63,8 @@ function getLocation(object) {
 }
 
 // Registration
-function supportsObject(object, type) {
-  if (!isGrip(object)) {
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip === true || !isGrip(object)) {
     return false;
   }
 


### PR DESCRIPTION
Fixes #480

Modify the `getRep` and `supportsObject` functions so we can pass this `noGrip`
property to it.
Add tests in the `Obj` rep which try to render stubs representing different
remote object, with the `noGrip` prop, and makes sure it uses the `Obj` rep,
and not the "remote" one.