### PR TITLE
Add source-utils from m-c into devtools-core

### DIFF
--- a/packages/devtools-reps/src/index.js
+++ b/packages/devtools-reps/src/index.js
@@ -5,6 +5,7 @@
 const { MODE } = require("./reps/constants");
 const { REPS, getRep } = require("./reps/rep");
 const ObjectInspector = require("./object-inspector/");
+const ObjectInspectorUtils = require("./object-inspector/utils");
 
 const {
   parseURLEncodedText,
@@ -22,4 +23,5 @@ module.exports = {
   parseURLParams,
   getGripPreviewItems,
   ObjectInspector,
+  ObjectInspectorUtils,
 };


### PR DESCRIPTION
This work is done in order to be able to import the Stacktrace (and thus Frame) component, which use those utils functions, in devtools-component from mozilla-central.
The end goal is to use the Stacktrace component in Error Rep so we can have full sourcemap support (instead of the error.stack string we use now).

The tests were also copied from mozilla-central and migrated to jest.