### PR TITLE
Tweak styling in order to integrate it in the console

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -277,7 +277,7 @@ const Tree = module.exports = createClass({
 
     return dom.div(
       {
-        className: "tree",
+        className: `tree ${this.props.className ? this.props.className : ""}`,
         ref: "tree",
         onKeyDown: this._onKeyDown,
         onKeyPress: this._preventArrowKeyScrolling,

--- a/packages/devtools-reps/bin/copy-assets.js
+++ b/packages/devtools-reps/bin/copy-assets.js
@@ -32,13 +32,6 @@ function start() {
 
   console.log("  output path is:", mcPath);
 
-  console.log("  copying reps.css...");
-  copyFile(
-    path.resolve(projectPath, "src/reps/reps.css"),
-    path.join(mcPath, mcModulePath, "reps.css"),
-    {cwd: projectPath}
-  );
-
   console.log("  creating reps.js bundle...");
   makeBundle({
     outputPath: path.join(mcPath, mcModulePath),

--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .tree {
-  white-space: nowrap;
   overflow: auto;
-  min-width: 100%;
+  display: inline-block;
+}
+
+.tree.nowrap {
+  white-space: nowrap;
 }
 
 .tree.noselect {
@@ -32,24 +35,23 @@
 }
 
 .arrow svg {
-  --width: 10px;
   fill: var(--theme-splitter-color);
-  /*margin-top: 3px;*/
   transition: transform 0.125s ease;
-  width: var(--width);
-  /*margin-top: calc((16px - var(--width) / 2));*/
-}
-
-html:not([dir="rtl"]) .arrow svg {
-  margin-right: 5px;
+  width: 10px;
+  margin-inline-end: 5px;
   transform: rotate(-90deg);
 }
 
-html[dir="rtl"] .arrow svg {
-  margin-left: 5px;
+html[dir="rtl"] .arrow svg,
+.arrow svg:dir(rtl),
+.arrow svg:-moz-locale-dir(rtl) {
   transform: rotate(90deg);
 }
 
 .arrow.expanded.expanded svg {
   transform: rotate(0deg);
+}
+
+.object-label {
+  color: var(--theme-highlight-blue);
 }

--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -45,6 +45,7 @@ type Props = {
   itemHeight: number,
   mode: Mode,
   roots: Array<ObjectInspectorItem>,
+  disableWrap: boolean,
   getObjectProperties: (actor:string) => any,
   loadObjectProperties: (value:Grip) => any,
   onFocus: ?(ObjectInspectorItem) => any,
@@ -333,6 +334,7 @@ class ObjectInspector extends Component {
       autoExpandAll = true,
       disabledFocus,
       itemHeight = 20,
+      disableWrap = false,
     } = this.props;
 
     const {
@@ -346,6 +348,7 @@ class ObjectInspector extends Component {
     }
 
     return Tree({
+      className: disableWrap ? "nowrap" : "",
       autoExpandAll,
       autoExpandDepth,
       disabledFocus,
@@ -374,6 +377,7 @@ ObjectInspector.propTypes = {
   autoExpandAll: PropTypes.bool,
   autoExpandDepth: PropTypes.number,
   disabledFocus: PropTypes.bool,
+  disableWrap: PropTypes.bool,
   roots: PropTypes.array,
   getObjectProperties: PropTypes.func.isRequired,
   loadObjectProperties: PropTypes.func.isRequired,

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -42,7 +42,9 @@ function DateTime(props) {
 }
 
 function getTitle(grip) {
-  return span({}, grip.class + " ");
+  return span({
+    className: "objectTitle"
+  }, grip.class + " ");
 }
 
 // Registration

--- a/packages/devtools-reps/src/reps/document.js
+++ b/packages/devtools-reps/src/reps/document.js
@@ -44,7 +44,9 @@ function getLocation(grip) {
 }
 
 function getTitle(grip) {
-  return span({}, grip.class + " ");
+  return span({
+    className: "objectTitle",
+  }, grip.class + " ");
 }
 
 // Registration

--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -52,7 +52,9 @@ function getTitle(props, grip) {
     title = "async " + title;
   }
 
-  return span({}, title);
+  return span({
+    className: "objectTitle",
+  }, title);
 }
 
 function summarizeFunction(grip) {

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -98,7 +98,9 @@ function getTitle(props, object) {
   }
 
   let title = props.title || object.class || "Array";
-  return span({}, title + " ");
+  return span({
+    className: "objectTitle",
+  }, title + " ");
 }
 
 function getPreviewItems(grip) {

--- a/packages/devtools-reps/src/reps/grip-map.js
+++ b/packages/devtools-reps/src/reps/grip-map.js
@@ -64,7 +64,9 @@ function GripMap(props) {
 
 function getTitle(props, object) {
   let title = props.title || (object && object.class ? object.class : "Map");
-  return span({}, title);
+  return span({
+    className: "objectTitle",
+  }, title);
 }
 
 function safeEntriesIterator(props, object, max) {

--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -67,7 +67,9 @@ function GripRep(props) {
 
 function getTitle(props, object) {
   let title = props.title || object.class || "Object";
-  return span({}, title);
+  return span({
+    className: "objectTitle",
+  }, title);
 }
 
 function safePropIterator(props, object, max) {

--- a/packages/devtools-reps/src/reps/object-with-url.js
+++ b/packages/devtools-reps/src/reps/object-with-url.js
@@ -36,7 +36,7 @@ function ObjectWithURL(props) {
 }
 
 function getTitle(grip) {
-  return span({className: "objectBox"}, getType(grip) + " ");
+  return span({className: "objectTitle"}, getType(grip) + " ");
 }
 
 function getType(grip) {

--- a/packages/devtools-reps/src/reps/promise.js
+++ b/packages/devtools-reps/src/reps/promise.js
@@ -69,7 +69,9 @@ function PromiseRep(props) {
 }
 
 function getTitle(object) {
-  return span({}, object.class);
+  return span({
+    className: "objectTitle",
+  }, object.class);
 }
 
 function getProps(props, promiseState) {

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+require("./reps.css");
 const { isGrip } = require("./rep-utils");
 
 // Load all existing rep templates

--- a/packages/devtools-reps/src/reps/reps.css
+++ b/packages/devtools-reps/src/reps/reps.css
@@ -30,11 +30,6 @@
 
 /******************************************************************************/
 
-.objectLink:hover {
-  cursor: pointer;
-  text-decoration: underline;
-}
-
 .inline {
   display: inline;
   white-space: normal;
@@ -49,15 +44,15 @@
 .objectBox-string,
 .objectBox-symbol,
 .objectBox-text,
-.objectLink-textNode,
+.objectBox-textNode,
 .objectBox-table {
   white-space: pre-wrap;
 }
 
 .objectBox-number,
-.objectLink-styleRule,
-.objectLink-element,
-.objectLink-textNode,
+.objectBox-styleRule,
+.objectBox-element,
+.objectBox-textNode,
 .objectBox-array > .length {
   color: var(--number-color);
 }
@@ -68,13 +63,13 @@
   color: var(--string-color);
 }
 
-.objectLink-function,
+.objectBox-function,
 .objectBox-stackTrace,
-.objectLink-profile {
+.objectBox-profile {
   color: var(--object-color);
 }
 
-.objectLink-Location {
+.objectBox-Location {
   font-style: italic;
   color: var(--location-color);
 }
@@ -87,7 +82,7 @@
   color: var(--null-color);
 }
 
-.objectLink-sourceLink {
+.objectBox-sourceLink {
   position: absolute;
   right: 4px;
   top: 2px;
@@ -107,11 +102,11 @@
 
 /******************************************************************************/
 
-.objectLink-event,
-.objectLink-eventLog,
-.objectLink-regexp,
-.objectLink-object,
-.objectLink-Date {
+.objectBox-event,
+.objectBox-eventLog,
+.objectBox-regexp,
+.objectBox-object,
+.objectBox-Date {
   font-weight: bold;
   color: var(--object-color);
   white-space: pre-wrap;
@@ -119,17 +114,15 @@
 
 /******************************************************************************/
 
-.objectLink-object .nodeName,
-.objectLink-NamedNodeMap .nodeName,
-.objectLink-NamedNodeMap .objectEqual,
-.objectLink-NamedNodeMap .arrayLeftBracket,
-.objectLink-NamedNodeMap .arrayRightBracket,
-.objectLink-Attr .attrEqual,
-.objectLink-Attr .attrTitle {
+.objectBox-object .nodeName,
+.objectBox-NamedNodeMap .nodeName,
+.objectBox-NamedNodeMap .objectEqual,
+.objectBox-Attr .attrEqual,
+.objectBox-Attr .attrTitle {
   color: var(--node-color);
 }
 
-.objectLink-object .nodeName {
+.objectBox-object .nodeName {
   font-weight: normal;
 }
 
@@ -139,21 +132,20 @@
 .objectRightBrace,
 .arrayLeftBracket,
 .arrayRightBracket {
-  cursor: pointer;
-  font-weight: bold;
+  color: var(--theme-highlight-blue);
 }
 
 /******************************************************************************/
 /* Cycle reference*/
 
-.objectLink-Reference {
+.objectBox-Reference {
   font-weight: bold;
   color: var(--reference-color);
 }
 
-.objectBox-array > .objectTitle {
-  font-weight: bold;
-  color: var(--object-color);
+[class*="objectBox-"] > .objectTitle {
+  color: var(--theme-highlight-blue);
+  font-style: italic;
 }
 
 .caption {

--- a/packages/devtools-reps/src/reps/stylesheet.js
+++ b/packages/devtools-reps/src/reps/stylesheet.js
@@ -38,7 +38,7 @@ function StyleSheet(props) {
 
 function getTitle(grip) {
   let title = "StyleSheet ";
-  return span({className: "objectBox"}, title);
+  return span({className: "objectBoxTitle"}, title);
 }
 
 function getLocation(grip) {

--- a/packages/devtools-reps/src/reps/window.js
+++ b/packages/devtools-reps/src/reps/window.js
@@ -56,7 +56,7 @@ function WindowRep(props) {
 
 function getTitle(object) {
   let title = object.displayClass || object.class || "Window";
-  return span({className: "objectBox"}, title);
+  return span({className: "objectBoxTitle"}, title);
 }
 
 function getLocation(object) {


### PR DESCRIPTION
This patch removes CSS references to `objectLink` and adds an `objectTitle` class on all the Reps that have a title.
This also allow the tree items to be wrapped, unless a `noWrap` prop is passed to the object inspector.