### PR TITLE
Show a "more…" label when needed.

### DIFF
--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -128,7 +128,7 @@ function propIterator(props, object, max) {
   // unquoted.
   const suppressQuotes = object.class === "Proxy";
   let propsArray = getProps(props, properties, indexes, suppressQuotes);
-  if (Object.keys(properties).length > max) {
+  if (Object.keys(properties).length > max || propertiesLength > max) {
     // There are some undisplayed props. Then display "more...".
     propsArray.push(Caption({
       object: span({}, "more…")

--- a/packages/devtools-reps/src/reps/stubs/grip.js
+++ b/packages/devtools-reps/src/reps/stubs/grip.js
@@ -70,7 +70,7 @@ stubs.set("testMoreThanMaxProps", {
   "ownPropertyLength": longModeMaxLength + 1,
   "preview": {
     "kind": "Object",
-    "ownProperties": Array.from({length: longModeMaxLength + 1})
+    "ownProperties": Array.from({length: longModeMaxLength})
       .reduce((res, item, index) => Object.assign(res, {
         ["p" + index]: {
           "configurable": true,


### PR DESCRIPTION
There was a bug in the Grip rep in long mode if the object had more than 10 properties.
This wasn't caught by tests because we handemade the stub, which ended up not looking
the same from what we actually get from the server.