### PR TITLE
Always show quotes when rendering an empty string.

### DIFF
--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -42,7 +42,7 @@ function StringRep(props) {
     config.style = style;
   }
 
-  if (useQuotes) {
+  if (useQuotes || text === "") {
     text = escapeString(text, escapeWhitespace);
   } else {
     text = sanitizeString(text);

--- a/packages/devtools-reps/src/reps/tests/string.js
+++ b/packages/devtools-reps/src/reps/tests/string.js
@@ -70,6 +70,13 @@ const testCases = [{
     escapeWhitespace: false,
   },
   result: "\"line 1\r\nline 2\n\tline 3\""
+}, {
+  name: "empty string",
+  props: {
+    object: "",
+    useQuotes: false,
+  },
+  result: `""`
 }];
 
 describe("test String", () => {


### PR DESCRIPTION
Fixes #490.