### PR TITLE
Add LGPL-2.1+ license

### DIFF
--- a/packages/devtools-license-check/bin/devtools-license-check
+++ b/packages/devtools-license-check/bin/devtools-license-check
@@ -53,6 +53,8 @@ const VALID_LICENSES = [
   'BSD-3-Clause',
   'BSD*',
 
+  'LGPL-2.1+',
+
   'WTFPL',
   'Unlicense',
   'Public Domain',


### PR DESCRIPTION
This adds another whitelisted license

https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html

Another option is to whitelist https://github.com/aadsm/jschardet

It would be nice to move some of the launchpad deps to dev deps in theory, but then we would need to add many of those deps to the debugger because they're not auto-installed.

here's the initial offender: https://github.com/devtools-html/debugger.html/pull/3287