### PR TITLE
Modify how we indicate there is more to see in an object.

### DIFF
--- a/packages/devtools-reps/src/reps/array.js
+++ b/packages/devtools-reps/src/reps/array.js
@@ -7,7 +7,6 @@ const React = require("react");
 const {
   wrapRender,
 } = require("./rep-utils");
-const Caption = require("./caption");
 const { MODE } = require("./constants");
 
 const ModePropType = React.PropTypes.oneOf(
@@ -41,7 +40,14 @@ function ArrayRep(props) {
 
   if (mode === MODE.TINY) {
     let isEmpty = object.length === 0;
-    items = [DOM.span({className: "length"}, isEmpty ? "" : object.length)];
+    if (isEmpty) {
+      items = [];
+    } else {
+      items = [DOM.span({
+        className: "more-ellipsis",
+        title: "more…"
+      }, "…")];
+    }
     brackets = needSpace(false);
   } else {
     items = arrayIterator(props, object, maxLengthMap.get(mode));
@@ -92,9 +98,10 @@ function arrayIterator(props, array, max) {
   }
 
   if (array.length > max) {
-    items.push(Caption({
-      object: DOM.span({}, "more…")
-    }));
+    items.push(DOM.span({
+      className: "more-ellipsis",
+      title: "more…"
+    }, "…"));
   }
 
   return items;

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -8,7 +8,6 @@ const {
   isGrip,
   wrapRender,
 } = require("./rep-utils");
-const Caption = require("./caption");
 const { MODE } = require("./constants");
 
 // Shortcuts
@@ -43,9 +42,14 @@ function GripArray(props) {
   if (mode === MODE.TINY) {
     let objectLength = getLength(object);
     let isEmpty = objectLength === 0;
-    items = [span({
-      className: "length",
-    }, isEmpty ? "" : objectLength)];
+    if (isEmpty) {
+      items = [];
+    } else {
+      items = [span({
+        className: "more-ellipsis",
+        title: "more…"
+      }, "…")];
+    }
     brackets = needSpace(false);
   } else {
     let max = maxLengthMap.get(mode);
@@ -175,9 +179,10 @@ function arrayIterator(props, grip, max) {
 
   const itemsShown = (items.length + foldedEmptySlots);
   if (gripLength > itemsShown) {
-    items.push(Caption({
-      object: span({}, "more…")
-    }));
+    items.push(span({
+      className: "more-ellipsis",
+      title: "more…"
+    }, "…"));
   }
 
   return items;

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -112,7 +112,7 @@ function getPreviewItems(grip) {
     return null;
   }
 
-  return grip.preview.items || grip.preview.childNodes || null;
+  return grip.preview.items || grip.preview.childNodes || [];
 }
 
 function arrayIterator(props, grip, max) {
@@ -126,9 +126,9 @@ function arrayIterator(props, grip, max) {
   }
 
   const previewItems = getPreviewItems(grip);
-  if (!previewItems) {
-    return items;
-  }
+  // if (!previewItems) {
+  //   return items;
+  // }
 
   let provider = props.provider;
 

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -126,10 +126,6 @@ function arrayIterator(props, grip, max) {
   }
 
   const previewItems = getPreviewItems(grip);
-  // if (!previewItems) {
-  //   return items;
-  // }
-
   let provider = props.provider;
 
   let emptySlots = 0;

--- a/packages/devtools-reps/src/reps/grip-map.js
+++ b/packages/devtools-reps/src/reps/grip-map.js
@@ -102,8 +102,8 @@ function entriesIterator(props, object, max) {
   }
 
   let entries = getEntries(props, mapEntries, indexes);
-  if (entries.length < mapEntries.length) {
-    // There are some undisplayed entries. Then display "more…".
+  if (entries.length < object.preview.size) {
+    // There are some undisplayed entries. Then display "…".
     entries.push(span({
       key: "more",
       className: "more-ellipsis",

--- a/packages/devtools-reps/src/reps/grip-map.js
+++ b/packages/devtools-reps/src/reps/grip-map.js
@@ -8,7 +8,6 @@ const {
   isGrip,
   wrapRender,
 } = require("./rep-utils");
-const Caption = require("./caption");
 const PropRep = require("./prop-rep");
 const { MODE } = require("./constants");
 // Shortcuts
@@ -105,10 +104,11 @@ function entriesIterator(props, object, max) {
   let entries = getEntries(props, mapEntries, indexes);
   if (entries.length < mapEntries.length) {
     // There are some undisplayed entries. Then display "more…".
-    entries.push(Caption({
+    entries.push(span({
       key: "more",
-      object: span({}, "more…")
-    }));
+      className: "more-ellipsis",
+      title: "more…"
+    }, "…"));
   }
 
   return unfoldEntries(entries);

--- a/packages/devtools-reps/src/reps/object.js
+++ b/packages/devtools-reps/src/reps/object.js
@@ -7,11 +7,13 @@ const React = require("react");
 const {
   wrapRender,
 } = require("./rep-utils");
-const Caption = require("./caption");
 const PropRep = require("./prop-rep");
 const { MODE } = require("./constants");
 // Shortcuts
 const { span } = React.DOM;
+
+const DEFAULT_TITLE = "Object";
+
 /**
  * Renders an object. An object is represented by a list of its
  * properties enclosed in curly brackets.
@@ -27,17 +29,34 @@ function ObjectRep(props) {
   let object = props.object;
   let propsArray = safePropIterator(props, object);
 
-  if (props.mode === MODE.TINY || !propsArray.length) {
-    return (
-      span({className: "objectBox objectBox-object"},
-        getTitle(props, object)
-      )
-    );
+  if (props.mode === MODE.TINY) {
+    const tinyModeItems = [];
+    if (getTitle(props, object) !== DEFAULT_TITLE) {
+      tinyModeItems.push(getTitleElement(props, object));
+    } else {
+      tinyModeItems.push(
+        span({
+          className: "objectLeftBrace",
+        }, "{"),
+        propsArray.length > 0
+          ? span({
+            key: "more",
+            className: "more-ellipsis",
+            title: "more…"
+          }, "…")
+          : null,
+        span({
+          className: "objectRightBrace",
+        }, "}")
+      );
+    }
+
+    return span({className: "objectBox objectBox-object"}, ...tinyModeItems);
   }
 
   return (
     span({className: "objectBox objectBox-object"},
-      getTitle(props, object),
+      getTitleElement(props, object),
       span({
         className: "objectLeftBrace",
       }, " { "),
@@ -49,9 +68,12 @@ function ObjectRep(props) {
   );
 }
 
+function getTitleElement(props, object) {
+  return span({className: "objectTitle"}, getTitle(props, object));
+}
+
 function getTitle(props, object) {
-  let title = props.title || object.class || "Object";
-  return span({className: "objectTitle"}, title);
+  return props.title || object.class || DEFAULT_TITLE;
 }
 
 function safePropIterator(props, object, max) {
@@ -94,9 +116,10 @@ function propIterator(props, object, max) {
 
   let propsArray = getPropsArray(interestingObject);
   if (Object.keys(object).length > max) {
-    propsArray.push(Caption({
-      object: span({}, "more…")
-    }));
+    propsArray.push(span({
+      className: "more-ellipsis",
+      title: "more…"
+    }, "…"));
   }
 
   return unfoldProps(propsArray);

--- a/packages/devtools-reps/src/reps/reps.css
+++ b/packages/devtools-reps/src/reps/reps.css
@@ -191,3 +191,9 @@
 .open-inspector svg:hover {
   fill: rgb(65, 175, 230);
 }
+
+/******************************************************************************/
+/* "more…" ellipsis */
+.more-ellipsis {
+  color: var(--theme-comment);
+}

--- a/packages/devtools-reps/src/reps/stubs/grip-array.js
+++ b/packages/devtools-reps/src/reps/stubs/grip-array.js
@@ -652,4 +652,20 @@ stubs.set("[0,1,2,,,,]", {
   }
 });
 
+// We can have cases where we don't have the array items in the preview,
+// (e.g. in the packet for `Promise.resolve([1, 2, 3])`), but we have the
+// length of the array.
+stubs.set("testItemsNotInPreview", {
+  "type": "object",
+  "actor": "server2.conn0.child1/obj135",
+  "class": "Array",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false,
+  "ownPropertyLength": 4,
+  "preview": {
+    "kind": "ArrayLike",
+    "length": 3
+  }
+});
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/stubs/grip-map.js
+++ b/packages/devtools-reps/src/reps/stubs/grip-map.js
@@ -119,7 +119,7 @@ stubs.set("testMoreThanMaxEntries", {
   "preview": {
     "kind": "MapLike",
     "size": maxLengthMap.get(MODE.LONG) + 1,
-    "entries": Array.from({length: maxLengthMap.get(MODE.LONG) + 1}).map((_, i) => {
+    "entries": Array.from({length: 10}).map((_, i) => {
       return [`key-${i}`, `value-${i}`];
     })
   }

--- a/packages/devtools-reps/src/reps/tests/array.js
+++ b/packages/devtools-reps/src/reps/tests/array.js
@@ -34,9 +34,9 @@ describe("Array", () => {
     const object = [1, "foo", {}];
     const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
 
-    const defaultOutput = `[ 1, "foo", Object ]`;
+    const defaultOutput = `[ 1, "foo", {} ]`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[3]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -46,10 +46,10 @@ describe("Array", () => {
     const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
 
     const defaultShortOutput =
-      `[ ${Array(maxLengthMap.get(MODE.SHORT)).fill("\"foo\"").join(", ")}, more… ]`;
+      `[ ${Array(maxLengthMap.get(MODE.SHORT)).fill("\"foo\"").join(", ")}, … ]`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultShortOutput);
     expect(renderRep({ mode: MODE.TINY }).text())
-      .toBe(`[${maxLengthMap.get(MODE.SHORT) + 1}]`);
+      .toBe(`[…]`);
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultShortOutput);
     expect(renderRep({ mode: MODE.LONG }).text())
       .toBe(`[ ${Array(maxLengthMap.get(MODE.SHORT) + 1).fill("\"foo\"").join(", ")} ]`);
@@ -60,13 +60,12 @@ describe("Array", () => {
     const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
 
     const defaultShortOutput =
-      `[ ${Array(maxLengthMap.get(MODE.SHORT)).fill("\"foo\"").join(", ")}, more… ]`;
+      `[ ${Array(maxLengthMap.get(MODE.SHORT)).fill("\"foo\"").join(", ")}, … ]`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultShortOutput);
-    expect(renderRep({ mode: MODE.TINY }).text())
-      .toBe(`[${maxLengthMap.get(MODE.LONG) + 1}]`);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultShortOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(
-      `[ ${Array(maxLengthMap.get(MODE.LONG)).fill("\"foo\"").join(", ")}, more… ]`);
+      `[ ${Array(maxLengthMap.get(MODE.LONG)).fill("\"foo\"").join(", ")}, … ]`);
   });
 
   it("renders recursive array as expected", () => {
@@ -74,9 +73,9 @@ describe("Array", () => {
     object.push(object);
     const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
 
-    const defaultOutput = "[ 1, [2] ]";
+    const defaultOutput = "[ 1, […] ]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[2]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -90,9 +89,9 @@ describe("Array", () => {
     }];
     const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
 
-    const defaultOutput = "[ Object ]";
+    const defaultOutput = "[ {…} ]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[1]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });

--- a/packages/devtools-reps/src/reps/tests/event.js
+++ b/packages/devtools-reps/src/reps/tests/event.js
@@ -27,7 +27,7 @@ describe("Event - beforeprint", () => {
   it("renders with expected text", () => {
     const renderedComponent = shallow(Event.rep({object}));
     expect(renderedComponent.text()).toEqual(
-      "beforeprint { target: Window, isTrusted: true, currentTarget: Window, more… }");
+      "beforeprint { target: Window, isTrusted: true, currentTarget: Window, … }");
     expectActorAttribute(renderedComponent, object.actor);
   });
 });
@@ -42,7 +42,7 @@ describe("Event - keyboard event", () => {
   it("renders with expected text", () => {
     const renderRep = props => shallow(Event.rep(Object.assign({object}, props)));
     expect(renderRep().text()).toEqual(
-      "keyup { target: body, key: \"Control\", charCode: 0, more… }");
+      "keyup { target: body, key: \"Control\", charCode: 0, … }");
     expect(renderRep({mode: MODE.LONG}).text()).toEqual(
       "keyup { target: body, key: \"Control\", charCode: 0, keyCode: 17 }");
   });
@@ -72,11 +72,11 @@ describe("Event - message event", () => {
   it("renders with expected text", () => {
     const renderRep = props => shallow(Event.rep(Object.assign({object}, props)));
     expect(renderRep().text()).toEqual(
-      "message { target: Window, isTrusted: false, data: \"test data\", more… }");
+      "message { target: Window, isTrusted: false, data: \"test data\", … }");
     expect(renderRep({mode: MODE.LONG}).text()).toEqual(
       `message { target: Window, isTrusted: false, data: "test data", ` +
       `origin: "null", lastEventId: "", source: Window, ports: Array, ` +
-      `currentTarget: Window, eventPhase: 2, bubbles: false, more… }`);
+      `currentTarget: Window, eventPhase: 2, bubbles: false, … }`);
   });
 });
 
@@ -93,7 +93,7 @@ describe("Event - mouse event", () => {
 
   it("renders with expected text", () => {
     expect(renderRep().text()).toEqual(
-      "click { target: div#test, clientX: 62, clientY: 18, more… }");
+      "click { target: div#test, clientX: 62, clientY: 18, … }");
     expect(renderRep({mode: MODE.LONG}).text()).toEqual(
       "click { target: div#test, buttons: 0, clientX: 62, clientY: 18, layerX: 0, " +
       "layerY: 0 }");

--- a/packages/devtools-reps/src/reps/tests/grip-array.js
+++ b/packages/devtools-reps/src/reps/tests/grip-array.js
@@ -57,9 +57,9 @@ describe("GripArray - max props", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = `Array [ 1, "foo", Object ]`;
+    const defaultOutput = `Array [ 1, "foo", {…} ]`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[3]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
 
@@ -68,7 +68,7 @@ describe("GripArray - max props", () => {
     expect(renderRep({
       mode: MODE.LONG,
       title: "CustomTitle",
-    }).text()).toBe(`CustomTitle [ 1, "foo", Object ]`);
+    }).text()).toBe(`CustomTitle [ 1, "foo", {…} ]`);
   });
 });
 
@@ -81,10 +81,10 @@ describe("GripArray - more than short mode max props", () => {
     const shortLength = maxLengthMap.get(MODE.SHORT);
     const shortContent = Array(shortLength).fill('"test string"').join(", ");
     const longContent = Array(shortLength + 1).fill('"test string"').join(", ");
-    const defaultOutput = `Array [ ${shortContent}, more… ]`;
+    const defaultOutput = `Array [ ${shortContent}, … ]`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe(`[${shortLength + 1}]`);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(`Array [ ${longContent} ]`);
   });
@@ -99,14 +99,14 @@ describe("GripArray - more than long mode max props", () => {
     const shortLength = maxLengthMap.get(MODE.SHORT);
     const longLength = maxLengthMap.get(MODE.LONG);
     const shortContent = Array(shortLength).fill('"test string"').join(", ");
-    const defaultOutput = `Array [ ${shortContent}, more… ]`;
+    const defaultOutput = `Array [ ${shortContent}, … ]`;
     const longContent = Array(longLength).fill('"test string"').join(", ");
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe(`[${longLength + 1}]`);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text())
-      .toBe(`Array [ ${longContent}, more… ]`);
+      .toBe(`Array [ ${longContent}, … ]`);
   });
 });
 
@@ -116,10 +116,10 @@ describe("GripArray - recursive array", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = `Array [ [1] ]`;
+    const defaultOutput = `Array [ […] ]`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[1]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -131,11 +131,11 @@ describe("GripArray - preview limit", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const shortOutput = "Array [ 0, 1, 2, more… ]";
-    const longOutput = "Array [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, more… ]";
+    const shortOutput = "Array [ 0, 1, 2, … ]";
+    const longOutput = "Array [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, … ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(shortOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[11]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(shortOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -149,7 +149,7 @@ describe("GripArray - empty slots", () => {
     const defaultOutput = "Array [ <5 empty slots> ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[5]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -158,11 +158,11 @@ describe("GripArray - empty slots", () => {
     const object = stubs.get("[,1,2,3]");
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = "Array [ <1 empty slot>, 1, 2, more… ]";
+    const defaultOutput = "Array [ <1 empty slot>, 1, 2, … ]";
     const longOutput = "Array [ <1 empty slot>, 1, 2, 3 ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[4]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -172,11 +172,11 @@ describe("GripArray - empty slots", () => {
       const object = stubs.get("[,,,3,4,5]");
       const renderRep = (props) => shallowRenderRep(object, props);
 
-      const defaultOutput = "Array [ <3 empty slots>, 3, 4, more… ]";
+      const defaultOutput = "Array [ <3 empty slots>, 3, 4, … ]";
       const longOutput = "Array [ <3 empty slots>, 3, 4, 5 ]";
 
       expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-      expect(renderRep({ mode: MODE.TINY }).text()).toBe("[6]");
+      expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
       expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
       expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
     }
@@ -186,11 +186,11 @@ describe("GripArray - empty slots", () => {
     const object = stubs.get("[0,1,,3,4,5]");
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = "Array [ 0, 1, <1 empty slot>, more… ]";
+    const defaultOutput = "Array [ 0, 1, <1 empty slot>, … ]";
     const longOutput = "Array [ 0, 1, <1 empty slot>, 3, 4, 5 ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[6]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -199,11 +199,11 @@ describe("GripArray - empty slots", () => {
     const object = stubs.get("[0,1,,,,5]");
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = "Array [ 0, 1, <3 empty slots>, more… ]";
+    const defaultOutput = "Array [ 0, 1, <3 empty slots>, … ]";
     const longOutput = "Array [ 0, 1, <3 empty slots>, 5 ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[6]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -212,11 +212,11 @@ describe("GripArray - empty slots", () => {
     const object = stubs.get("[0,,2,,4,5]");
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = "Array [ 0, <1 empty slot>, 2, more… ]";
+    const defaultOutput = "Array [ 0, <1 empty slot>, 2, … ]";
     const longOutput = "Array [ 0, <1 empty slot>, 2, <1 empty slot>, 4, 5 ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[6]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -225,11 +225,11 @@ describe("GripArray - empty slots", () => {
     const object = stubs.get("[0,,,3,,,,7,8]");
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = "Array [ 0, <2 empty slots>, 3, more… ]";
+    const defaultOutput = "Array [ 0, <2 empty slots>, 3, … ]";
     const longOutput = "Array [ 0, <2 empty slots>, 3, <3 empty slots>, 7, 8 ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[9]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -238,11 +238,11 @@ describe("GripArray - empty slots", () => {
     const object = stubs.get("[0,1,2,3,4,,]");
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = "Array [ 0, 1, 2, more… ]";
+    const defaultOutput = "Array [ 0, 1, 2, … ]";
     const longOutput = "Array [ 0, 1, 2, 3, 4, <1 empty slot> ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[6]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -251,11 +251,11 @@ describe("GripArray - empty slots", () => {
     const object = stubs.get("[0,1,2,,,,]");
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = "Array [ 0, 1, 2, more… ]";
+    const defaultOutput = "Array [ 0, 1, 2, … ]";
     const longOutput = "Array [ 0, 1, 2, <3 empty slots> ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[6]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
@@ -270,7 +270,7 @@ describe("GripArray - NamedNodeMap", () => {
     const defaultOutput = 'NamedNodeMap [ class="myclass", cellpadding="7", border="3" ]';
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[3]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -286,7 +286,7 @@ describe("GripArray - NodeList", () => {
       "button#btn-2.btn.btn-err, button#btn-3.btn.btn-count ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[3]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -353,13 +353,13 @@ describe("GripArray - DocumentFragment", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
 
     const defaultOutput = "DocumentFragment [ li#li-0.list-element, " +
-      "li#li-1.list-element, li#li-2.list-element, more… ]";
+      "li#li-1.list-element, li#li-2.list-element, … ]";
     const longOutput = "DocumentFragment [ " +
       "li#li-0.list-element, li#li-1.list-element, li#li-2.list-element, " +
       "li#li-3.list-element, li#li-4.list-element ]";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[5]");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });

--- a/packages/devtools-reps/src/reps/tests/grip-array.js
+++ b/packages/devtools-reps/src/reps/tests/grip-array.js
@@ -364,3 +364,32 @@ describe("GripArray - DocumentFragment", () => {
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
 });
+
+describe("GripArray - Items not in preview", () => {
+  const object = stubs.get("testItemsNotInPreview");
+
+  it("correctly selects GripArray Rep", () => {
+    expect(getRep(object)).toBe(GripArray.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = "Array [ … ]";
+
+    let component = renderRep({ mode: undefined });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.TINY });
+    expect(component.text()).toBe("[…]");
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.SHORT });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.LONG });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+  });
+});

--- a/packages/devtools-reps/src/reps/tests/grip-map.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map.js
@@ -81,7 +81,7 @@ describe("GripMap - WeakMap", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = `WeakMap { Object: "value-a" }`;
+    const defaultOutput = `WeakMap { {…}: "value-a" }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("WeakMap");
@@ -90,7 +90,7 @@ describe("GripMap - WeakMap", () => {
     expect(renderRep({
       mode: MODE.LONG,
       title: "CustomTitle"
-    }).text()).toBe(`CustomTitle { Object: "value-a" }`);
+    }).text()).toBe(`CustomTitle { {…}: "value-a" }`);
   });
 });
 
@@ -127,7 +127,7 @@ describe("GripMap - more than max entries", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput =
-      `Map { "key-0": "value-0", "key-1": "value-1", "key-2": "value-2", more… }`;
+      `Map { "key-0": "value-0", "key-1": "value-1", "key-2": "value-2", … }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("Map");
@@ -136,7 +136,7 @@ describe("GripMap - more than max entries", () => {
     let longString = Array.from({length: maxLengthMap.get(MODE.LONG)})
       .map((_, i) => `"key-${i}": "value-${i}"`);
     expect(renderRep({ mode: MODE.LONG }).text())
-      .toBe(`Map { ${longString.join(", ")}, more… }`);
+      .toBe(`Map { ${longString.join(", ")}, … }`);
   });
 });
 
@@ -152,7 +152,7 @@ describe("GripMap - uninteresting entries", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput =
-      `Map { "key-a": null, "key-c": "value-c", "key-d": 4, more… }`;
+      `Map { "key-a": null, "key-c": "value-c", "key-d": 4, … }`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("Map");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -39,7 +39,7 @@ describe("Grip - empty object", () => {
     expectActorAttribute(component, object.actor);
 
     component = renderRep({ mode: MODE.TINY });
-    expect(component.text()).toBe("Object");
+    expect(component.text()).toBe("{}");
     expectActorAttribute(component, object.actor);
 
     component = renderRep({ mode: MODE.SHORT });
@@ -119,7 +119,7 @@ describe("Grip - Proxy", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = "Proxy { <target>: Object, <handler>: [3] }";
+    const defaultOutput = "Proxy { <target>: {…}, <handler>: […] }";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("Proxy");
@@ -177,7 +177,7 @@ describe("Grip - ApplicationCache", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput =
-      "OfflineResourceList { status: 0, onchecking: null, onerror: null, more… }";
+      "OfflineResourceList { status: 0, onchecking: null, onerror: null, … }";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("OfflineResourceList");
@@ -203,7 +203,7 @@ describe("Grip - Object with max props", () => {
     const defaultOutput = `Object { a: "a", b: "b", c: "c" }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -219,10 +219,10 @@ describe("Grip - Object with more than short mode max props", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = `Object { b: 1, more: 2, d: 3, more… }`;
+    const defaultOutput = `Object { b: 1, more: 2, d: 3, … }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
 
     const longOutput = `Object { a: undefined, b: 1, more: 2, d: 3 }`;
@@ -240,15 +240,15 @@ describe("Grip - Object with more than long mode max props", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = `Object { p0: "0", p1: "1", p2: "2", more… }`;
+    const defaultOutput = `Object { p0: "0", p1: "1", p2: "2", … }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
 
     const props = Array.from({length: maxLengthMap.get(MODE.LONG)})
       .map((item, i) => `p${i}: "${i}"`);
-    const longOutput = `Object { ${props.join(", ")}, more… }`;
+    const longOutput = `Object { ${props.join(", ")}, … }`;
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
 });
@@ -268,7 +268,7 @@ describe("Grip - Object with uninteresting properties", () => {
     const defaultOutput = `Object {c: "c", d: 1, a: undefined, more...}`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -284,10 +284,10 @@ describe("Grip - Object with non-enumerable properties", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = "Object {  }";
+    const defaultOutput = "Object { … }";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -303,10 +303,10 @@ describe("Grip - Object with nested object", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = `Object { objProp: Object, strProp: "test string" }`;
+    const defaultOutput = `Object { objProp: {…}, strProp: "test string" }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
 
@@ -315,7 +315,7 @@ describe("Grip - Object with nested object", () => {
     expect(renderRep({
       mode: MODE.LONG,
       title: "CustomTitle",
-    }).text()).toBe(`CustomTitle { objProp: Object, strProp: "test string" }`);
+    }).text()).toBe(`CustomTitle { objProp: {…}, strProp: "test string" }`);
   });
 });
 
@@ -329,10 +329,10 @@ describe("Grip - Object with nested array", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = "Object { arrProp: [3] }";
+    const defaultOutput = "Object { arrProp: […] }";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
@@ -356,7 +356,7 @@ describe("Grip - Object with connected nodes", () => {
       "Object { foo: button#btn-1.btn.btn-log, bar: button#btn-2.btn.btn-err }";
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("Object");
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });

--- a/packages/devtools-reps/src/reps/tests/object.js
+++ b/packages/devtools-reps/src/reps/tests/object.js
@@ -16,7 +16,7 @@ const renderComponent = (object, props) => {
 
 describe("Object - Basic", () => {
   const object = {};
-  const defaultOutput = "Object";
+  const defaultOutput = "Object {  }";
 
   it("selects the correct rep", () => {
     expect(getRep(object)).toBe(Obj.rep);
@@ -25,8 +25,7 @@ describe("Object - Basic", () => {
   it("renders basic object as expected", () => {
     expect(renderComponent(object, { mode: undefined }).text())
       .toEqual(defaultOutput);
-    expect(renderComponent(object, { mode: MODE.TINY }).text())
-      .toEqual(defaultOutput);
+    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{}");
     expect(renderComponent(object, { mode: MODE.SHORT }).text())
       .toEqual(defaultOutput);
     expect(renderComponent(object, { mode: MODE.LONG }).text())
@@ -41,8 +40,7 @@ describe("Object - Max props", () => {
   it("renders object with max props as expected", () => {
     expect(renderComponent(object, { mode: undefined }).text())
       .toEqual(defaultOutput);
-    expect(renderComponent(object, { mode: MODE.TINY }).text())
-      .toEqual("Object");
+    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{…}");
     expect(renderComponent(object, { mode: MODE.SHORT }).text())
       .toEqual(defaultOutput);
     expect(renderComponent(object, { mode: MODE.LONG }).text())
@@ -55,13 +53,12 @@ describe("Object - Many props", () => {
   for (let i = 0; i < 100; i++) {
     object[`p${i}`] = i;
   }
-  const defaultOutput = "Object { p0: 0, p1: 1, p2: 2, more… }";
+  const defaultOutput = "Object { p0: 0, p1: 1, p2: 2, … }";
 
   it("renders object with many props as expected", () => {
     expect(renderComponent(object, { mode: undefined }).text())
       .toEqual(defaultOutput);
-    expect(renderComponent(object, { mode: MODE.TINY }).text())
-      .toEqual("Object");
+    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{…}");
     expect(renderComponent(object, { mode: MODE.SHORT }).text())
       .toEqual(defaultOutput);
     expect(renderComponent(object, { mode: MODE.LONG }).text())
@@ -71,13 +68,12 @@ describe("Object - Many props", () => {
 
 describe("Object - Uninteresting props", () => {
   const object = {a: undefined, b: undefined, c: "c", d: 0};
-  const defaultOutput = "Object { c: \"c\", d: 0, a: undefined, more… }";
+  const defaultOutput = "Object { c: \"c\", d: 0, a: undefined, … }";
 
   it("renders object with uninteresting props as expected", () => {
     expect(renderComponent(object, { mode: undefined }).text())
       .toEqual(defaultOutput);
-    expect(renderComponent(object, { mode: MODE.TINY }).text())
-      .toEqual("Object");
+    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{…}");
     expect(renderComponent(object, { mode: MODE.SHORT }).text())
       .toEqual(defaultOutput);
     expect(renderComponent(object, { mode: MODE.LONG }).text())
@@ -92,8 +88,7 @@ describe("Object - Escaped property names", () => {
   it("renders object with escaped property names as expected", () => {
     expect(renderComponent(object, { mode: undefined }).text())
       .toEqual(defaultOutput);
-    expect(renderComponent(object, { mode: MODE.TINY }).text())
-      .toEqual("Object");
+    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{…}");
     expect(renderComponent(object, { mode: MODE.SHORT }).text())
       .toEqual(defaultOutput);
     expect(renderComponent(object, { mode: MODE.LONG }).text())
@@ -110,14 +105,13 @@ describe("Object - Nested", () => {
     strProp: "test string",
     arrProp: [1]
   };
-  const defaultOutput = "Object { strProp: \"test string\", objProp: Object," +
-    " arrProp: [1] }";
+  const defaultOutput = "Object { strProp: \"test string\", objProp: {…}," +
+    " arrProp: […] }";
 
   it("renders nested object as expected", () => {
     expect(renderComponent(object, { mode: undefined }).text())
       .toEqual(defaultOutput);
-    expect(renderComponent(object, { mode: MODE.TINY }).text())
-      .toEqual("Object");
+    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{…}");
     expect(renderComponent(object, { mode: MODE.SHORT }).text())
       .toEqual(defaultOutput);
     expect(renderComponent(object, { mode: MODE.LONG }).text())
@@ -132,13 +126,12 @@ describe("Object - More prop", () => {
     "more": 2,
     d: 3
   };
-  const defaultOutput = "Object { b: 1, more: 2, d: 3, more… }";
+  const defaultOutput = "Object { b: 1, more: 2, d: 3, … }";
 
   it("renders object with more properties as expected", () => {
     expect(renderComponent(object, { mode: undefined }).text())
       .toEqual(defaultOutput);
-    expect(renderComponent(object, { mode: MODE.TINY }).text())
-      .toEqual("Object");
+    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{…}");
     expect(renderComponent(object, { mode: MODE.SHORT }).text())
       .toEqual(defaultOutput);
     expect(renderComponent(object, { mode: MODE.LONG }).text())

--- a/packages/devtools-reps/src/reps/tests/promise.js
+++ b/packages/devtools-reps/src/reps/tests/promise.js
@@ -69,7 +69,7 @@ describe("Promise - fulfilled with string", () => {
 
 describe("Promise - fulfilled with object", () => {
   const object = stubs.get("FulfilledWithObject");
-  const defaultOutput = `Promise { <state>: "fulfilled", <value>: Object }`;
+  const defaultOutput = `Promise { <state>: "fulfilled", <value>: {…} }`;
 
   it("correctly selects PromiseRep Rep for Promise fulfilled with an object", () => {
     expect(getRep(object)).toBe(PromiseRep.rep);
@@ -89,7 +89,7 @@ describe("Promise - fulfilled with object", () => {
 
 describe("Promise - fulfilled with array", () => {
   const object = stubs.get("FulfilledWithArray");
-  const defaultOutput = `Promise { <state>: "fulfilled", <value>: [3] }`;
+  const defaultOutput = `Promise { <state>: "fulfilled", <value>: […] }`;
 
   it("correctly selects PromiseRep Rep for Promise fulfilled with an array", () => {
     expect(getRep(object)).toBe(PromiseRep.rep);


### PR DESCRIPTION
Basically, for the most case we switched from `more…` to `…` only.
We also re-use the ellipsis in TINY mode for arrays and objects.
Now empty arrays and objects in TINY mode should render respectively
as `[]` and `{}`, and non-empty arrays and objects `[…]` and `{…}`.

This should indicate more clearly and in a more consistent way that
there are hidden properties/items in what we render, and encourage the
user to expand the object/array to check what it really contains.

Doing this work was also a great opportunity to be more consistent through
all the reps, and mostly have the same output for RDP and "plain" objects
for the same test cases.