### PR TITLE
Display getters and setters in Reps and in the ObjectInspector.

### DIFF
--- a/packages/devtools-reps/src/reps/accessor.js
+++ b/packages/devtools-reps/src/reps/accessor.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Dependencies
+const React = require("react");
+const {
+  wrapRender,
+} = require("./rep-utils");
+const { MODE } = require("./constants");
+// Shortcuts
+const {
+  span,
+} = React.DOM;
+/**
+ * Renders an object. An object is represented by a list of its
+ * properties enclosed in curly brackets.
+ */
+Accessor.propTypes = {
+  object: React.PropTypes.object.isRequired,
+  mode: React.PropTypes.oneOf(Object.values(MODE)),
+};
+
+function Accessor(props) {
+  const {
+    object,
+  } = props;
+
+  const accessors = [];
+  if (hasGetter(object)) {
+    accessors.push("Getter");
+  }
+  if (hasSetter(object)) {
+    accessors.push("Setter");
+  }
+  const title = accessors.join(" & ");
+
+  return (
+    span({className: "objectBox objectBox-accessor"},
+      span({
+        className: "objectTitle",
+      }, title)
+    )
+  );
+}
+
+function hasGetter(object) {
+  return object && object.get && object.get.type !== "undefined";
+}
+
+function hasSetter(object) {
+  return object && object.set && object.set.type !== "undefined";
+}
+
+function supportsObject(object, type, noGrip = false) {
+  if (noGrip !== true && (hasGetter(object) || hasSetter(object))) {
+    return true;
+  }
+
+  return false;
+}
+
+// Exports from this module
+module.exports = {
+  rep: wrapRender(Accessor),
+  supportsObject,
+};

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -16,6 +16,7 @@ const Obj = require("./object");
 const SymbolRep = require("./symbol");
 const InfinityRep = require("./infinity");
 const NaNRep = require("./nan");
+const Accessor = require("./accessor");
 
 // DOM types (grips)
 const Attribute = require("./attribute");
@@ -68,6 +69,7 @@ let reps = [
   SymbolRep,
   InfinityRep,
   NaNRep,
+  Accessor,
 ];
 
 /**
@@ -132,6 +134,7 @@ function getRep(object, defaultRep = Obj, noGrip = false) {
 module.exports = {
   Rep,
   REPS: {
+    Accessor,
     ArrayRep,
     Attribute,
     CommentNode,

--- a/packages/devtools-reps/src/reps/stubs/accessor.js
+++ b/packages/devtools-reps/src/reps/stubs/accessor.js
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+let stubs = new Map();
+
+stubs.set("getter", {
+  "configurable": true,
+  "enumerable": true,
+  "get": {
+    "type": "object",
+    "actor": "server2.conn1.child1/obj106",
+    "class": "Function",
+    "extensible": true,
+    "frozen": false,
+    "sealed": false,
+    "name": "get x",
+    "displayName": "get x",
+    "location": {
+      "url": "debugger eval code",
+      "line": 1
+    }
+  },
+  "set": {
+    "type": "undefined"
+  }
+});
+
+stubs.set("setter", {
+    "configurable": true,
+    "enumerable": true,
+    "get": {
+        "type": "undefined"
+    },
+    "set": {
+        "type": "object",
+        "actor": "server2.conn1.child1/obj116",
+        "class": "Function",
+        "extensible": true,
+        "frozen": false,
+        "sealed": false,
+        "name": "set x",
+        "displayName": "set x",
+        "location": {
+            "url": "debugger eval code",
+            "line": 1
+        }
+    }
+});
+
+stubs.set("getter setter", {
+    "configurable": true,
+    "enumerable": true,
+    "get": {
+        "type": "object",
+        "actor": "server2.conn1.child1/obj127",
+        "class": "Function",
+        "extensible": true,
+        "frozen": false,
+        "sealed": false,
+        "name": "get x",
+        "displayName": "get x",
+        "location": {
+        "url": "debugger eval code",
+        "line": 1
+        }
+    },
+    "set": {
+        "type": "object",
+        "actor": "server2.conn1.child1/obj128",
+        "class": "Function",
+        "extensible": true,
+        "frozen": false,
+        "sealed": false,
+        "name": "set x",
+        "displayName": "set x",
+        "location": {
+          "url": "debugger eval code",
+          "line": 1
+        }
+    }
+});
+module.exports = stubs;

--- a/packages/devtools-reps/src/reps/stubs/grip.js
+++ b/packages/devtools-reps/src/reps/stubs/grip.js
@@ -617,4 +617,132 @@ stubs.set("testObjectWithDisconnectedNodes", {
   }
 });
 
+// Packet for `({get x(){}})`
+stubs.set("TestObjectWithGetter", {
+  "type": "object",
+  "actor": "server2.conn1.child1/obj105",
+  "class": "Object",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false,
+  "ownPropertyLength": 1,
+  "preview": {
+    "kind": "Object",
+    "ownProperties": {
+      "x": {
+        "configurable": true,
+        "enumerable": true,
+        "get": {
+          "type": "object",
+          "actor": "server2.conn1.child1/obj106",
+          "class": "Function",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "name": "get x",
+          "displayName": "get x",
+          "location": {
+            "url": "debugger eval code",
+            "line": 1
+          }
+        },
+        "set": {
+          "type": "undefined"
+        }
+      }
+    },
+    "ownPropertiesLength": 1,
+    "safeGetterValues": {}
+  }
+});
+
+// Packet for `({set x(s){}})`
+stubs.set("TestObjectWithSetter", {
+  "type": "object",
+  "actor": "server2.conn1.child1/obj115",
+  "class": "Object",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false,
+  "ownPropertyLength": 1,
+  "preview": {
+    "kind": "Object",
+    "ownProperties": {
+      "x": {
+        "configurable": true,
+        "enumerable": true,
+        "get": {
+          "type": "undefined"
+        },
+        "set": {
+          "type": "object",
+          "actor": "server2.conn1.child1/obj116",
+          "class": "Function",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "name": "set x",
+          "displayName": "set x",
+          "location": {
+            "url": "debugger eval code",
+            "line": 1
+          }
+        }
+      }
+    },
+    "ownPropertiesLength": 1,
+    "safeGetterValues": {}
+  }
+});
+
+// Packet for `({get x(){}, set x(s){}})`
+stubs.set("TestObjectWithGetterAndSetter", {
+  "type": "object",
+  "actor": "server2.conn1.child1/obj126",
+  "class": "Object",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false,
+  "ownPropertyLength": 1,
+  "preview": {
+    "kind": "Object",
+    "ownProperties": {
+      "x": {
+        "configurable": true,
+        "enumerable": true,
+        "get": {
+          "type": "object",
+          "actor": "server2.conn1.child1/obj127",
+          "class": "Function",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "name": "get x",
+          "displayName": "get x",
+          "location": {
+            "url": "debugger eval code",
+            "line": 1
+          }
+        },
+        "set": {
+          "type": "object",
+          "actor": "server2.conn1.child1/obj128",
+          "class": "Function",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "name": "set x",
+          "displayName": "set x",
+          "location": {
+            "url": "debugger eval code",
+            "line": 1
+          }
+        }
+      }
+    },
+    "ownPropertiesLength": 1,
+    "safeGetterValues": {}
+  }
+});
+
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/tests/accessor.js
+++ b/packages/devtools-reps/src/reps/tests/accessor.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { shallow } = require("enzyme");
+
+const {
+  REPS,
+  getRep,
+} = require("../rep");
+
+let { Accessor, Rep } = REPS;
+
+const stubs = require("../stubs/accessor");
+
+describe("Accessor - getter", () => {
+  const object = stubs.get("getter");
+
+  it("Rep correctly selects Accessor Rep", () => {
+    expect(getRep(object)).toBe(Accessor.rep);
+  });
+
+  it("Accessor rep has expected text content", () => {
+    const renderedComponent = shallow(Rep({object}));
+    expect(renderedComponent.text()).toEqual("Getter");
+  });
+});
+
+describe("Accessor - setter", () => {
+  const object = stubs.get("setter");
+
+  it("Rep correctly selects Accessor Rep", () => {
+    expect(getRep(object)).toBe(Accessor.rep);
+  });
+
+  it("Accessor rep has expected text content", () => {
+    const renderedComponent = shallow(Rep({object}));
+    expect(renderedComponent.text()).toEqual("Setter");
+  });
+});
+
+describe("Accessor - getter & setter", () => {
+  const object = stubs.get("getter setter");
+
+  it("Rep correctly selects Accessor Rep", () => {
+    expect(getRep(object)).toBe(Accessor.rep);
+  });
+
+  it("Accessor rep has expected text content", () => {
+    const renderedComponent = shallow(Rep({object}));
+    expect(renderedComponent.text()).toEqual("Getter & Setter");
+  });
+});

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -420,3 +420,57 @@ describe("Grip - Object with disconnected nodes", () => {
     expect(node.exists()).toBe(false);
   });
 });
+
+describe("Grip - Object with getter", () => {
+  const object = stubs.get("TestObjectWithGetter");
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = "Object { x: Getter }";
+
+    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
+    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+  });
+});
+
+describe("Grip - Object with setter", () => {
+  const object = stubs.get("TestObjectWithSetter");
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = "Object { x: Setter }";
+
+    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
+    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+  });
+});
+
+describe("Grip - Object with getter and setter", () => {
+  const object = stubs.get("TestObjectWithGetterAndSetter");
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = "Object { x: Getter & Setter }";
+
+    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
+    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+  });
+});


### PR DESCRIPTION
This PR adds an `Accessor` rep which handle object with getter and/or setter.
I choose a dedicated Rep because the plan is to make it evolve in the future,
for example to be able to evaluate a property with a getter.
This also adds pseudo `<get>` and `<set>` properties on the ObjectInspector so they can also be inspected, like we could in the VariableView.