### PR TITLE
Display symbols properties on objects.

### DIFF
--- a/packages/devtools-reps/src/reps/prop-rep.js
+++ b/packages/devtools-reps/src/reps/prop-rep.js
@@ -64,6 +64,7 @@ function PropRep(props) {
     key = span({"className": "nodeName"}, name);
   } else {
     key = Rep(Object.assign({}, props, {
+      className: "nodeName",
       object: name,
       mode: mode || MODE.TINY,
       defaultRep: Grip,

--- a/packages/devtools-reps/src/reps/stubs/grip.js
+++ b/packages/devtools-reps/src/reps/stubs/grip.js
@@ -745,4 +745,211 @@ stubs.set("TestObjectWithGetterAndSetter", {
   }
 });
 
+// Packet for :
+// ({
+//   [Symbol()]: "first unnamed symbol",
+//   [Symbol()]: "second unnamed symbol",
+//   [Symbol("named")] : "named symbol",
+//   [Symbol.iterator] : function* () {yield 1;yield 2;},
+//   x: 10,
+// })
+stubs.set("TestObjectWithSymbolProperties", {
+  "type": "object",
+  "actor": "server2.conn1.child1/obj30",
+  "class": "Object",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false,
+  "ownPropertyLength": 1,
+  "preview": {
+    "kind": "Object",
+    "ownProperties": {
+      "x": {
+        "configurable": true,
+        "enumerable": true,
+        "writable": true,
+        "value": 10
+      }
+    },
+    "ownSymbols": [
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "first unnamed symbol"
+        },
+        "type": "symbol"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "second unnamed symbol"
+        },
+        "type": "symbol"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "named symbol"
+        },
+        "type": "symbol",
+        "name": "named"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": {
+            "type": "object",
+            "actor": "server2.conn1.child1/obj31",
+            "class": "Function",
+            "extensible": true,
+            "frozen": false,
+            "sealed": false,
+            "location": {
+              "url": "debugger eval code",
+              "line": 1
+            }
+          }
+        },
+        "type": "symbol",
+        "name": "Symbol.iterator"
+      }
+    ],
+    "ownPropertiesLength": 1,
+    "ownSymbolsLength": 4,
+    "safeGetterValues": {}
+  }
+});
+
+// Packet for :
+// x = {};
+// for(let i = 0; i < 11; i++) {
+//   x[Symbol(`i-${i}`)] = `value-${i}`
+// }
+// x;
+stubs.set("TestObjectWithMoreThanMaxSymbolProperties", {
+  "type": "object",
+  "actor": "server2.conn1.child1/obj39",
+  "class": "Object",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false,
+  "ownPropertyLength": 0,
+  "preview": {
+    "kind": "Object",
+    "ownProperties": {},
+    "ownSymbols": [
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-0"
+        },
+        "type": "symbol",
+        "name": "i-0"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-1"
+        },
+        "type": "symbol",
+        "name": "i-1"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-2"
+        },
+        "type": "symbol",
+        "name": "i-2"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-3"
+        },
+        "type": "symbol",
+        "name": "i-3"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-4"
+        },
+        "type": "symbol",
+        "name": "i-4"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-5"
+        },
+        "type": "symbol",
+        "name": "i-5"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-6"
+        },
+        "type": "symbol",
+        "name": "i-6"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-7"
+        },
+        "type": "symbol",
+        "name": "i-7"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-8"
+        },
+        "type": "symbol",
+        "name": "i-8"
+      },
+      {
+        "descriptor": {
+          "configurable": true,
+          "enumerable": true,
+          "writable": true,
+          "value": "value-9"
+        },
+        "type": "symbol",
+        "name": "i-9"
+      }
+    ],
+    "ownPropertiesLength": 0,
+    "ownSymbolsLength": 11
+  }
+});
+
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/symbol.js
+++ b/packages/devtools-reps/src/reps/symbol.js
@@ -18,13 +18,13 @@ SymbolRep.propTypes = {
 };
 
 function SymbolRep(props) {
-  let {object} = props;
+  let {
+    className = "objectBox objectBox-symbol",
+    object,
+  } = props;
   let {name} = object;
 
-  return (
-    span({className: "objectBox objectBox-symbol"},
-      `Symbol(${name || ""})`)
-  );
+  return span({className}, `Symbol(${name || ""})`);
 }
 
 function supportsObject(object, type) {

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -474,3 +474,49 @@ describe("Grip - Object with getter and setter", () => {
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
 });
+
+describe("Grip - Object with symbol properties", () => {
+  const object = stubs.get("TestObjectWithSymbolProperties");
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = `Object { x: 10, Symbol(): "first unnamed symbol", ` +
+                          `Symbol(): "second unnamed symbol", … }`;
+
+    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
+    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text())
+      .toBe(`Object { x: 10, Symbol(): "first unnamed symbol", ` +
+            `Symbol(): "second unnamed symbol", Symbol(named): "named symbol", ` +
+            `Symbol(Symbol.iterator): function () }`);
+  });
+});
+
+describe("Grip - Object with more than max symbol properties", () => {
+  const object = stubs.get("TestObjectWithMoreThanMaxSymbolProperties");
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = `Object { Symbol(i-0): "value-0", Symbol(i-1): "value-1", ` +
+                          `Symbol(i-2): "value-2", … }`;
+
+    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
+    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text())
+      .toBe(`Object { Symbol(i-0): "value-0", Symbol(i-1): "value-1", ` +
+            `Symbol(i-2): "value-2", Symbol(i-3): "value-3", Symbol(i-4): "value-4", ` +
+            `Symbol(i-5): "value-5", Symbol(i-6): "value-6", Symbol(i-7): "value-7", ` +
+            `Symbol(i-8): "value-8", Symbol(i-9): "value-9", … }`);
+  });
+});
+


### PR DESCRIPTION
This patch adds the support for the `ownSymbols` property
introduced in [Bug 881480](https://bugzilla.mozilla.org/show_bug.cgi?id=881480),
as well as some tests (and stubs) to ensure they are rendered as expected.