### PR TITLE
Account for editor tabs

### DIFF
--- a/packages/devtools-source-editor/src/source-editor.js
+++ b/packages/devtools-source-editor/src/source-editor.js
@@ -111,8 +111,14 @@ class SourceEditor {
    */
   alignLine(line: number, align: AlignOpts = "top") {
     let cm = this.editor;
-    let from = cm.lineAtHeight(0, "page");
-    let to = cm.lineAtHeight(cm.getWrapperElement().clientHeight, "page");
+    let editorClientRect = cm.getWrapperElement().getBoundingClientRect();
+
+    let from = cm.lineAtHeight(editorClientRect.top, "page");
+    let to = cm.lineAtHeight(
+      editorClientRect.height + editorClientRect.top,
+      "page"
+    );
+
     let linesVisible = to - from;
     let halfVisible = Math.round(linesVisible / 2);
 


### PR DESCRIPTION
Fixes https://github.com/devtools-html/debugger.html/issues/3357

Accounts for the offset of the editor bc tabs take space too.