### PR TITLE
Handle exceptions in network request and worker utilities

### DIFF
--- a/packages/devtools-utils/src/privileged-network-request.js
+++ b/packages/devtools-utils/src/privileged-network-request.js
@@ -4,29 +4,34 @@
 
 function networkRequest(url, opts) {
   return new Promise((resolve, reject) => {
-    const req = new XMLHttpRequest();
+    try {
+      const req = new XMLHttpRequest();
 
-    req.addEventListener("readystatechange", () => {
-      if (req.readyState === XMLHttpRequest.DONE) {
-        if (req.status === 200) {
-          resolve({ content: req.responseText });
-        } else {
-          reject(req.statusText);
+      req.addEventListener("readystatechange", () => {
+        if (req.readyState === XMLHttpRequest.DONE) {
+          if (req.status === 200) {
+            resolve({ content: req.responseText });
+          } else {
+            let text = req.statusText || "invalid URL";
+            reject(text);
+          }
         }
-      }
-    });
+      });
 
-    // Not working yet.
-    // if (!opts.loadFromCache) {
-    //   req.channel.loadFlags = (
-    //     Components.interfaces.nsIRequest.LOAD_BYPASS_CACHE |
-    //       Components.interfaces.nsIRequest.INHIBIT_CACHING |
-    //       Components.interfaces.nsIRequest.LOAD_ANONYMOUS
-    //   );
-    // }
+      // Not working yet.
+      // if (!opts.loadFromCache) {
+      //   req.channel.loadFlags = (
+      //     Components.interfaces.nsIRequest.LOAD_BYPASS_CACHE |
+      //       Components.interfaces.nsIRequest.INHIBIT_CACHING |
+      //       Components.interfaces.nsIRequest.LOAD_ANONYMOUS
+      //   );
+      // }
 
-    req.open("GET", url);
-    req.send();
+      req.open("GET", url);
+      req.send();
+    } catch (e) {
+      reject(e.toString());
+    }
   });
 }
 

--- a/packages/devtools-utils/src/tests/worker-utils.js
+++ b/packages/devtools-utils/src/tests/worker-utils.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { WorkerDispatcher } = require("../worker-utils")
+const { WorkerDispatcher, workerHandler } = require("../worker-utils")
 
 describe("worker utils", () => {
   it("starts a worker", () => {
@@ -56,6 +56,22 @@ describe("worker utils", () => {
     });
 
     expect(addEventListenerMock.mock.calls.length).toEqual(1);
-  })
+  });
 
+  it("test workerHandler error case", () => {
+    const postMessageMock = jest.fn();
+    self.postMessage = postMessageMock;
+
+    let callee = {
+      doSomething: () => { throw new Error("failed"); }
+    };
+
+    let handler = workerHandler(callee);
+    handler({data: {id: 53, method: "doSomething", args: []}});
+
+    expect(postMessageMock.mock.calls[0][0]).toEqual({
+      id: 53,
+      error: new Error("failed"),
+    });
+  });
 })

--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -57,17 +57,21 @@ WorkerDispatcher.prototype = {
       });
     };
   }
-}
+};
 
 function workerHandler(publicInterface: Object) {
-  return function workerHandler(msg: Message) {
+  return function (msg: Message) {
     const { id, method, args } = msg.data;
-    const response = publicInterface[method].apply(undefined, args);
-    if (response instanceof Promise) {
-      response.then(val => self.postMessage({ id, response: val }),
-                    err => self.postMessage({ id, error: err }));
-    } else {
-      self.postMessage({ id, response });
+    try {
+      const response = publicInterface[method].apply(undefined, args);
+      if (response instanceof Promise) {
+        response.then(val => self.postMessage({ id, response: val }),
+                      err => self.postMessage({ id, error: err }));
+      } else {
+        self.postMessage({ id, response });
+      }
+    } catch (error) {
+      self.postMessage({ id, error });
     }
   };
 }


### PR DESCRIPTION
This changes the network request code and the worker handler code to
catch exceptions and report them to the caller via their promise
results.  It also changes the network request code to provide an error
message when the XHR's statusText is empty; this can happen when an
invalid URL is used.