### PR TITLE
Don't call console.error from source-map.js

### DIFF
--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -115,7 +115,7 @@ function _fetchSourceMap(generatedSource: Source) {
   }
 
   // Fire off the request, set it in the cache, and return it.
-  const req = _resolveAndFetch(generatedSource).catch(e => console.error(e));
+  const req = _resolveAndFetch(generatedSource);
   sourceMapRequests.set(generatedSource.id, req);
   return req;
 }


### PR DESCRIPTION
Source mapping errors are going to be shown in the web console in
https://bugzilla.mozilla.org/show_bug.cgi?id=1345533.  There's no need
to report them here, and anyway these reports only show up in the
browser console.