### PR TITLE
Do not override getPrototypeAndProperties response.

### DIFF
--- a/packages/devtools-reps/src/launchpad/index.js
+++ b/packages/devtools-reps/src/launchpad/index.js
@@ -33,13 +33,7 @@ function onConnect(connection) {
     },
     getProperties: async function (grip) {
       const objClient = connection.tabConnection.threadClient.pauseGrip(grip);
-
       const resp = await objClient.getPrototypeAndProperties();
-      const { ownProperties, safeGetterValues } = resp;
-      for (const name in safeGetterValues) {
-        const { enumerable, writable, getterValue } = safeGetterValues[name];
-        ownProperties[name] = { enumerable, writable, value: getterValue };
-      }
       return resp;
     }
   };


### PR DESCRIPTION
We use to add the content of safeGetterValues into the ownProperties property we get
from client.getPrototypeAndProperties.
This could lead to differences between the launchpad and the toolbox,
so we remove that piece of code to avoid any confusion.