### PR TITLE
adds streaming worker

### DIFF
--- a/packages/devtools-utils/src/tests/worker-utils.js
+++ b/packages/devtools-utils/src/tests/worker-utils.js
@@ -77,9 +77,6 @@ describe("worker utils", () => {
 it("streams a task", async () => {
   jest.useRealTimers();
 
-  const dispatcher = new WorkerDispatcher();
-  global.Worker = jest.fn();
-
   const postMessageMock = jest.fn();
 
   const worker = {

--- a/packages/devtools-utils/src/tests/worker-utils.js
+++ b/packages/devtools-utils/src/tests/worker-utils.js
@@ -112,12 +112,12 @@ it("streams a task", async () => {
   expect(postMessageMock.mock.calls[1][0]).toEqual({
     id,
     status: "pending",
-    data: [2]
+    data: [1]
   });
   expect(postMessageMock.mock.calls[2][0]).toEqual({
     id,
     status: "pending",
-    data: [1]
+    data: [2]
   });
   expect(postMessageMock.mock.calls[3][0]).toEqual({
     id,

--- a/packages/devtools-utils/src/tests/worker-utils.js
+++ b/packages/devtools-utils/src/tests/worker-utils.js
@@ -2,15 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { WorkerDispatcher, workerHandler } = require("../worker-utils")
+const { WorkerDispatcher, workerHandler, streamingWorkerHandler } = require("../worker-utils")
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 describe("worker utils", () => {
   it("starts a worker", () => {
     const dispatcher = new WorkerDispatcher();
-    global.Worker = jest.fn()
+    global.Worker = jest.fn();
     dispatcher.start("foo");
-    expect(dispatcher.worker).toEqual(global.Worker.mock.instances[0])
-  })
+    expect(dispatcher.worker).toEqual(global.Worker.mock.instances[0]);
+  });
 
   it("stops a worker", () => {
     const dispatcher = new WorkerDispatcher();
@@ -19,14 +20,14 @@ describe("worker utils", () => {
     global.Worker = jest.fn(() => {
       return {
         terminate: terminateMock
-      }
+      };
     });
 
     dispatcher.start();
     dispatcher.stop();
 
-    expect(dispatcher.worker).toEqual(null)
-    expect(terminateMock.mock.calls.length).toEqual(1)
+    expect(dispatcher.worker).toEqual(null);
+    expect(terminateMock.mock.calls.length).toEqual(1);
   });
 
   it("dispatches a task", () => {
@@ -38,21 +39,19 @@ describe("worker utils", () => {
       return {
         postMessage: postMessageMock,
         addEventListener: addEventListenerMock
-      }
+      };
     });
 
     dispatcher.start();
-    const task = dispatcher.task("foo")
-    task("bar")
+    const task = dispatcher.task("foo");
+    task("bar");
 
     const postMessageMockCall = postMessageMock.mock.calls[0][0];
 
     expect(postMessageMockCall).toEqual({
-        "args": [
-          "bar",
-        ],
-        "id": 1,
-        "method": "foo",
+      args: ["bar"],
+      id: 1,
+      method: "foo"
     });
 
     expect(addEventListenerMock.mock.calls.length).toEqual(1);
@@ -74,4 +73,38 @@ describe("worker utils", () => {
       error: new Error("failed"),
     });
   });
-})
+});
+
+it("streams a task", async () => {
+  const postMessageMock = jest.fn((...args) => console.log(args));
+
+  const worker = {
+    postMessage: postMessageMock
+  };
+
+  function Promisify(result) {
+    return new Promise(resolve => resolve(result));
+  }
+  const promise = Promisify(1);
+
+  function makeTasks() {
+    return [
+      {
+        callback: () => promise.then(v => v * 20)
+      },
+      {
+        callback: () => promise.then(v => v * -10)
+      }
+    ];
+  }
+
+  const workerHandler = streamingWorkerHandler(
+    { makeTasks },
+    { timeout: 1000 },
+    worker
+  );
+  const task = workerHandler({ data: { id: 1, method: "makeTasks", args: [] }});
+  await task;
+
+  expect(postMessageMock.mock.calls.length).toBe(3);
+});

--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -92,7 +92,7 @@ function streamingWorkerHandler(
 
     const results = [];
     while (tasks.length !== 0 && isWorking) {
-      const { callback, context, args } = tasks.pop();
+      const { callback, context, args } = tasks.shift();
       const result = await callback.call(context, args);
       results.push(result);
     }

--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -78,10 +78,11 @@ function workerHandler(publicInterface: Object) {
   };
 }
 
-function streamingWorkerHandler(publicInterface: Object, { timeout = 100 } = {}, worker) {
-  if (!worker) {
-    worker = self;
-  }
+function streamingWorkerHandler(
+  publicInterface: Object,
+  { timeout = 100 }: Object = {},
+  worker: Object = self
+) {
   async function streamingWorker(id, tasks) {
     let isWorking = true;
 
@@ -95,7 +96,7 @@ function streamingWorkerHandler(publicInterface: Object, { timeout = 100 } = {},
       const result = await callback.call(context, args);
       results.push(result);
     }
-    worker.postMessage({ id, results });
+    worker.postMessage({ id, status: "pending", data: results });
     clearInterval(intervalId);
 
     if (tasks.length !== 0) {


### PR DESCRIPTION
This initial PR adds the streaming worker.

I'm still working on some kinks here. But this is relatively how it should look.

Issue: On the browser, it works better but in the jest test environment using something like
````js
function delay(milliseconds) {
  return function(result) {
    return new Promise(function(resolve, reject) {
      setTimeout(function() {
        resolve(result);
      }, milliseconds);
    });
  };
}
````
would never resolve for `await` ing callers. Which prevents the tests from passing. Returning promises which resolve without setTimeout still work in the tests.
@codehag @jasonLaster @bomsy 

I want to tidy this up a bit. But suggestions welcome here. 😉 