### PR TITLE
Fix bugs for grips without preview property.

### DIFF
--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -315,7 +315,12 @@ function supportsObject(object, type, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
-  return (object.preview && object.preview.ownProperties);
+
+  return (
+    object.preview
+    ? typeof object.preview.ownProperties !== "undefined"
+    : typeof object.ownPropertyLength !== "undefined"
+  );
 }
 
 const maxLengthMap = new Map();

--- a/packages/devtools-reps/src/reps/tests/grip-array.js
+++ b/packages/devtools-reps/src/reps/tests/grip-array.js
@@ -57,7 +57,7 @@ describe("GripArray - max props", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
 
-    const defaultOutput = `Array [ 1, "foo", {…} ]`;
+    const defaultOutput = `Array [ 1, "foo", {} ]`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("[…]");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
@@ -68,7 +68,7 @@ describe("GripArray - max props", () => {
     expect(renderRep({
       mode: MODE.LONG,
       title: "CustomTitle",
-    }).text()).toBe(`CustomTitle [ 1, "foo", {…} ]`);
+    }).text()).toBe(`CustomTitle [ 1, "foo", {} ]`);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -10,6 +10,8 @@ const {
 const Grip = require("../grip");
 const { MODE } = require("../constants");
 const stubs = require("../stubs/grip");
+const gripArrayStubs = require("../stubs/grip-array");
+
 const {
   expectActorAttribute,
   getSelectableInInspectorGrips,
@@ -517,6 +519,36 @@ describe("Grip - Object with more than max symbol properties", () => {
             `Symbol(i-2): "value-2", Symbol(i-3): "value-3", Symbol(i-4): "value-4", ` +
             `Symbol(i-5): "value-5", Symbol(i-6): "value-6", Symbol(i-7): "value-7", ` +
             `Symbol(i-8): "value-8", Symbol(i-9): "value-9", … }`);
+  });
+});
+
+describe("Grip - Without preview", () => {
+  // Test object: `[1, "foo", {}]`
+  const object = gripArrayStubs.get("testMaxProps").preview.items[2];
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = "Object {  }";
+
+    let component = renderRep({ mode: undefined });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.TINY });
+    expect(component.text()).toBe("{}");
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.SHORT });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
+
+    component = renderRep({ mode: MODE.LONG });
+    expect(component.text()).toBe(defaultOutput);
+    expectActorAttribute(component, object.actor);
   });
 });
 


### PR DESCRIPTION
In some cases, we can have a grip without a preview property (e.g. for the following object `[{}]`). Because the grip was only supporting object with preview property, the grip was rendered with the default rep (i.e. Object), and thus could be incorrect.
This patch fixes this and adds some tests to make sure we handle this case as expected.