### PR TITLE
Add a MapEntry Rep.

### DIFF
--- a/packages/devtools-reps/src/reps/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/grip-map-entry.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Dependencies
+const React = require("react");
+// Shortcuts
+const { span } = React.DOM;
+const {
+  wrapRender,
+} = require("./rep-utils");
+const PropRep = require("./prop-rep");
+const { MODE } = require("./constants");
+/**
+ * Renders an map entry. A map entry is represented by its key, a column and its value.
+ */
+GripMapEntry.propTypes = {
+  object: React.PropTypes.object,
+  // @TODO Change this to Object.values once it's supported in Node's version of V8
+  mode: React.PropTypes.oneOf(Object.keys(MODE).map(key => MODE[key])),
+  onDOMNodeMouseOver: React.PropTypes.func,
+  onDOMNodeMouseOut: React.PropTypes.func,
+  onInspectIconClick: React.PropTypes.func,
+};
+
+function GripMapEntry(props) {
+  const {
+    object,
+  } = props;
+
+  const {
+    key,
+    value,
+  } = object.preview;
+
+  return span({
+    className: "objectBox objectBox-map-entry"
+  }, ...PropRep(Object.assign({}, props, {
+    name: key,
+    object: value,
+    equal: " \u2192 ",
+    title: null,
+    suppressQuotes: false,
+  })));
+}
+
+function supportsObject(grip, type, noGrip = false) {
+  if (noGrip === true) {
+    return false;
+  }
+  return (grip && grip.type === "mapEntry" && grip.preview);
+}
+
+function createGripMapEntry(key, value) {
+  return {
+    type: "mapEntry",
+    preview: {
+      key,
+      value,
+    }
+  };
+}
+
+// Exports from this module
+module.exports = {
+  rep: wrapRender(GripMapEntry),
+  createGripMapEntry,
+  supportsObject,
+};

--- a/packages/devtools-reps/src/reps/grip-map.js
+++ b/packages/devtools-reps/src/reps/grip-map.js
@@ -156,7 +156,7 @@ function getEntries(props, entries, indexes) {
 
     return PropRep({
       name: key,
-      equal: ": ",
+      equal: " \u2192 ",
       object: value,
       mode: MODE.TINY,
       onDOMNodeMouseOver,

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -36,6 +36,7 @@ const ObjectWithText = require("./object-with-text");
 const ObjectWithURL = require("./object-with-url");
 const GripArray = require("./grip-array");
 const GripMap = require("./grip-map");
+const GripMapEntry = require("./grip-map-entry");
 const Grip = require("./grip");
 
 // List of all registered template.
@@ -61,6 +62,7 @@ let reps = [
   ErrorRep,
   GripArray,
   GripMap,
+  GripMapEntry,
   Grip,
   Undefined,
   Null,
@@ -147,6 +149,7 @@ module.exports = {
     Grip,
     GripArray,
     GripMap,
+    GripMapEntry,
     InfinityRep,
     LongStringRep,
     NaNRep,

--- a/packages/devtools-reps/src/reps/stubs/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/stubs/grip-map-entry.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+let stubs = new Map();
+stubs.set("A → 0", {
+  type: "mapEntry",
+  preview: {
+    key: "A",
+    value: 0
+  }
+});
+
+module.exports = stubs;

--- a/packages/devtools-reps/src/reps/tests/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map-entry.js
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ /* global jest */
+const { shallow } = require("enzyme");
+
+const {
+  REPS,
+  getRep,
+} = require("../rep");
+
+const { GripMapEntry } = REPS;
+const { createGripMapEntry } = GripMapEntry;
+const { MODE } = require("../constants");
+
+const stubs = require("../stubs/grip-map-entry");
+const nodeStubs = require("../stubs/element-node");
+const gripArrayStubs = require("../stubs/grip-array");
+
+const renderRep = (object, mode, props) => {
+  return shallow(GripMapEntry.rep(Object.assign({
+      object,
+      mode,
+  }, props)));
+};
+
+describe("GripMapEntry - simple", () => {
+  const stub = stubs.get("A → 0");
+
+  it("Rep correctly selects GripMapEntry Rep", () => {
+    expect(getRep(stub)).toBe(GripMapEntry.rep);
+  });
+
+  it("GripMapEntry rep has expected text content", () => {
+    const renderedComponent = renderRep(stub);
+    expect(renderedComponent.text()).toEqual("A → 0");
+  });
+});
+
+describe("GripMapEntry - createGripMapEntry", () => {
+  it("return the expected object", () => {
+    const entry = createGripMapEntry("A", 0);
+    expect(entry).toEqual(stubs.get("A → 0"));
+  });
+});
+
+describe("GripMapEntry - complex", () => {
+  it.only("Handles complex objects as key and value", () => {
+    let stub = gripArrayStubs.get("testBasic");
+    let entry = createGripMapEntry("A", stub);
+    expect(renderRep(entry, MODE.TINY).text()).toEqual("A → []");
+    expect(renderRep(entry, MODE.SHORT).text()).toEqual("A → Array []");
+    expect(renderRep(entry, MODE.LONG).text()).toEqual("A → Array []");
+
+    entry = createGripMapEntry(stub, "A");
+    expect(renderRep(entry, MODE.TINY).text()).toEqual(`[] → "A"`);
+    expect(renderRep(entry, MODE.SHORT).text()).toEqual(`Array [] → "A"`);
+    expect(renderRep(entry, MODE.LONG).text()).toEqual(`Array [] → "A"`);
+
+    stub = gripArrayStubs.get("testMaxProps");
+    entry = createGripMapEntry("A", stub);
+    expect(renderRep(entry, MODE.TINY).text()).toEqual(`A → […]`);
+    expect(renderRep(entry, MODE.SHORT).text()).toEqual(`A → Array [ 1, "foo", {} ]`);
+    expect(renderRep(entry, MODE.LONG).text()).toEqual(`A → Array [ 1, "foo", {} ]`);
+
+    entry = createGripMapEntry(stub, "A");
+    expect(renderRep(entry, MODE.TINY).text()).toEqual(`[…] → "A"`);
+    expect(renderRep(entry, MODE.SHORT).text()).toEqual(`Array [ 1, "foo", {} ] → "A"`);
+    expect(renderRep(entry, MODE.LONG).text()).toEqual(`Array [ 1, "foo", {} ] → "A"`);
+
+    stub = gripArrayStubs.get("testMoreThanShortMaxProps");
+    entry = createGripMapEntry("A", stub);
+    expect(renderRep(entry, MODE.TINY).text()).toEqual(`A → […]`);
+    expect(renderRep(entry, MODE.SHORT).text())
+      .toEqual(`A → Array [ "test string", "test string", "test string", … ]`);
+    expect(renderRep(entry, MODE.LONG).text()).toEqual(
+      `A → Array [ "test string", "test string", "test string", "test string" ]`);
+
+    entry = createGripMapEntry(stub, "A");
+    expect(renderRep(entry, MODE.TINY).text()).toEqual(`[…] → "A"`);
+    expect(renderRep(entry, MODE.SHORT).text())
+      .toEqual(`Array [ "test string", "test string", "test string", … ] → "A"`);
+    expect(renderRep(entry, MODE.LONG).text()).toEqual(
+      `Array [ "test string", "test string", "test string", "test string" ] → "A"`);
+  });
+
+  it("Handles Element Nodes as key and value", () => {
+    const stub = nodeStubs.get("Node");
+
+    const onInspectIconClick = jest.fn();
+    const onDOMNodeMouseOut = jest.fn();
+    const onDOMNodeMouseOver = jest.fn();
+
+    let entry = createGripMapEntry("A", stub);
+    let renderedComponent = renderRep(entry, MODE.TINY, {
+      onInspectIconClick,
+      onDOMNodeMouseOut,
+      onDOMNodeMouseOver,
+    });
+    expect(renderRep(entry, MODE.TINY).text())
+      .toEqual("A → input#newtab-customize-button.bar.baz");
+
+    let node = renderedComponent.find(".objectBox-node");
+    let icon = node.find(".open-inspector");
+    icon.simulate("click", { type: "click" });
+    expect(icon.exists()).toBeTruthy();
+    expect(onInspectIconClick.mock.calls.length).toEqual(1);
+    expect(onInspectIconClick.mock.calls[0][0]).toEqual(stub);
+    expect(onInspectIconClick.mock.calls[0][1].type).toEqual("click");
+
+    node.simulate("mouseout");
+    expect(onDOMNodeMouseOut.mock.calls.length).toEqual(1);
+
+    node.simulate("mouseover");
+    expect(onDOMNodeMouseOver.mock.calls.length).toEqual(1);
+    expect(onDOMNodeMouseOver.mock.calls[0][0]).toEqual(stub);
+
+    entry = createGripMapEntry(stub, "A");
+    renderedComponent = renderRep(entry, MODE.TINY, {
+      onInspectIconClick,
+      onDOMNodeMouseOut,
+      onDOMNodeMouseOver,
+    });
+    expect(renderRep(entry, MODE.TINY).text())
+      .toEqual(`input#newtab-customize-button.bar.baz → "A"`);
+
+    node = renderedComponent.find(".objectBox-node");
+    icon = node.find(".open-inspector");
+    icon.simulate("click", { type: "click" });
+    expect(node.exists()).toBeTruthy();
+    expect(onInspectIconClick.mock.calls.length).toEqual(2);
+    expect(onInspectIconClick.mock.calls[1][0]).toEqual(stub);
+    expect(onInspectIconClick.mock.calls[1][1].type).toEqual("click");
+
+    node.simulate("mouseout");
+    expect(onDOMNodeMouseOut.mock.calls.length).toEqual(2);
+
+    node.simulate("mouseover");
+    expect(onDOMNodeMouseOver.mock.calls.length).toEqual(2);
+    expect(onDOMNodeMouseOver.mock.calls[1][0]).toEqual(stub);
+  });
+});

--- a/packages/devtools-reps/src/reps/tests/grip-map.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map.js
@@ -62,7 +62,7 @@ describe("GripMap - Symbol-keyed Map", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = `Map { Symbol(a): "value-a", Symbol(b): "value-b" }`;
+    const defaultOutput = `Map { Symbol(a) → "value-a", Symbol(b) → "value-b" }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("Map");
@@ -81,7 +81,7 @@ describe("GripMap - WeakMap", () => {
 
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
-    const defaultOutput = `WeakMap { {…}: "value-a" }`;
+    const defaultOutput = `WeakMap { {…} → "value-a" }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("WeakMap");
@@ -90,7 +90,7 @@ describe("GripMap - WeakMap", () => {
     expect(renderRep({
       mode: MODE.LONG,
       title: "CustomTitle"
-    }).text()).toBe(`CustomTitle { {…}: "value-a" }`);
+    }).text()).toBe(`CustomTitle { {…} → "value-a" }`);
   });
 });
 
@@ -106,7 +106,7 @@ describe("GripMap - max entries", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput =
-      `Map { "key-a": "value-a", "key-b": "value-b", "key-c": "value-c" }`;
+      `Map { "key-a" → "value-a", "key-b" → "value-b", "key-c" → "value-c" }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("Map");
@@ -127,14 +127,14 @@ describe("GripMap - more than max entries", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput =
-      `Map { "key-0": "value-0", "key-1": "value-1", "key-2": "value-2", … }`;
+      `Map { "key-0" → "value-0", "key-1" → "value-1", "key-2" → "value-2", … }`;
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("Map");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
 
     let longString = Array.from({length: maxLengthMap.get(MODE.LONG)})
-      .map((_, i) => `"key-${i}": "value-${i}"`);
+      .map((_, i) => `"key-${i}" → "value-${i}"`);
     expect(renderRep({ mode: MODE.LONG }).text())
       .toBe(`Map { ${longString.join(", ")}, … }`);
   });
@@ -152,13 +152,13 @@ describe("GripMap - uninteresting entries", () => {
   it("renders as expected", () => {
     const renderRep = (props) => shallowRenderRep(object, props);
     const defaultOutput =
-      `Map { "key-a": null, "key-c": "value-c", "key-d": 4, … }`;
+      `Map { "key-a" → null, "key-c" → "value-c", "key-d" → 4, … }`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("Map");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
 
     const longOutput =
-      `Map { "key-a": null, "key-b": undefined, "key-c": "value-c", "key-d": 4 }`;
+      `Map { "key-a" → null, "key-b" → undefined, "key-c" → "value-c", "key-d" → 4 }`;
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(longOutput);
   });
 });


### PR DESCRIPTION
When we fetch entries from the server, we get a grip with a "mapEntry" type that we weren't handling previously.
This patch adds a Rep to deal with those kind of grips and harmonize the way we render map entries (even in the map preview), to match what we had previously in the VariableView (e.g. `Map {a → 1}` instead of `Map {a: 1}`, this works better in an OI context where you can have `0: a → 1`, instead of an awkward `0: a: 1`).

~This relies on https://github.com/devtools-html/devtools-core/pull/531 (Some tests are failing without this patch).~  https://github.com/devtools-html/devtools-core/pull/531 Is now merged, CI should be happier.