### PR TITLE
Change default properties node styling

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -55,3 +55,8 @@ html[dir="rtl"] .arrow svg,
 .object-label {
   color: var(--theme-highlight-blue);
 }
+
+.lessen {
+  opacity: 0.6;
+}
+

--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -26,12 +26,13 @@ const {
   getChildren,
   getParent,
   getValue,
-  nodeIsDefault,
   nodeHasAccessors,
   nodeHasProperties,
+  nodeIsDefaultProperties,
   nodeIsMissingArguments,
   nodeIsOptimizedOut,
   nodeIsPrimitive,
+  nodeIsPrototype,
 } = require("./utils");
 
 import type {
@@ -132,11 +133,6 @@ class ObjectInspector extends Component {
   state: State;
   props: Props;
   actors: any;
-
-  isDefaultProperty(item: Node) {
-    const roots = this.props.roots;
-    return nodeIsDefault(item, roots);
-  }
 
   getChildren(item: Node)
     : Array<Node> | NodeContents | null {
@@ -241,7 +237,10 @@ class ObjectInspector extends Component {
       {
         className: classnames("node object-node", {
           focused,
-          "default-property": this.isDefaultProperty(item)
+          lessen: !expanded && (
+            nodeIsDefaultProperties(item)
+            || nodeIsPrototype(item)
+          )
         }),
         style: {
           marginLeft: indentWidth

--- a/packages/devtools-reps/src/object-inspector/tests/object-inspector.js
+++ b/packages/devtools-reps/src/object-inspector/tests/object-inspector.js
@@ -8,6 +8,10 @@ const { mount } = require("enzyme");
 const React = require("react");
 const { createFactory } = React;
 const ObjectInspector = createFactory(require("../index"));
+const {
+  createNode,
+  NODE_TYPES,
+} = require("../utils");
 const { MODE } = require("../../reps/constants");
 const { Rep } = require("../../reps/rep");
 const gripStubs = require("../../reps/stubs/grip");
@@ -251,6 +255,66 @@ describe("ObjectInspector", () => {
     const setLeaf = nodes.at(2);
     expect(setLeaf.find(".arrow").exists()).toBeTruthy();
     expect(setLeaf.text()).toBe("<set> : function set x()");
+  });
+
+  it("renders less-important nodes as expected", () => {
+    const defaultPropertiesNode = createNode(
+      null,
+      "root",
+      "rootpath",
+      [],
+      NODE_TYPES.DEFAULT_PROPERTIES
+    );
+
+    // The [default properties] node should have the "lessen" class only when collapsed.
+    let oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [defaultPropertiesNode],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+
+    let defaultPropertiesElementNode = oi.find(".node");
+    expect(defaultPropertiesElementNode.hasClass("lessen")).toBe(true);
+
+    oi = mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [defaultPropertiesNode],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+
+    defaultPropertiesElementNode = oi.find(".node");
+    expect(defaultPropertiesElementNode.hasClass("lessen")).toBe(false);
+
+    const prototypeNode = createNode(
+      null,
+      "root",
+      "rootpath",
+      [],
+      NODE_TYPES.PROTOTYPE
+    );
+
+    // The __proto__ node should have the "lessen" class only when collapsed.
+    oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [prototypeNode],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+
+    let protoElementNode = oi.find(".node");
+    expect(protoElementNode.hasClass("lessen")).toBe(true);
+
+    oi = mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [prototypeNode],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+
+    protoElementNode = oi.find(".node");
+    expect(protoElementNode.hasClass("lessen")).toBe(false);
   });
 
   it("does not load properties if getObjectProperties returns a truthy element", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const {
-  nodeIsDefault,
   makeNodesForProperties,
+  nodeIsDefaultProperties,
+  nodeIsPrototype,
   SAFE_PATH_PREFIX,
 } = require("../../utils");
 
@@ -126,6 +127,8 @@ describe("makeNodesForProperties", () => {
 
     expect(names).toEqual(["bar", "__proto__"]);
     expect(paths).toEqual(["root/bar", "root/__proto__"]);
+
+    expect(nodeIsPrototype(nodes[1])).toBe(true);
   });
 
   it("window object", () => {
@@ -148,25 +151,8 @@ describe("makeNodesForProperties", () => {
 
     expect(names).toEqual(["bar", "[default properties]"]);
     expect(paths).toEqual(["root/bar", "root/##-default"]);
-  });
 
-  it("window prop on normal object", () => {
-    const windowRoots = [
-      {
-        contents: { value: { class: "Window" } }
-      }
-    ];
-
-    const objectRoots = [
-      {
-        contents: { value: { class: "Object" } }
-      }
-    ];
-
-    const item = { name: "location" };
-
-    expect(nodeIsDefault(item, windowRoots)).toEqual(true);
-    expect(nodeIsDefault(item, objectRoots)).toEqual(false);
+    expect(nodeIsDefaultProperties(nodes[1])).toBe(true);
   });
 
   // For large arrays

--- a/packages/devtools-reps/src/object-inspector/utils.js
+++ b/packages/devtools-reps/src/object-inspector/utils.js
@@ -16,6 +16,7 @@ const NODE_TYPES = {
   PROMISE_STATE: Symbol("<state>"),
   PROMISE_VALUE: Symbol("<value>"),
   SET: Symbol("<set>"),
+  PROTOTYPE: Symbol("__proto__"),
 };
 
 import type {
@@ -99,15 +100,10 @@ function nodeIsPrimitive(item: Node) : boolean {
     && !nodeHasAccessors(item);
 }
 
-function nodeIsDefault(
-  item: Node,
-  roots: Array<Node>
+function nodeIsDefaultProperties(
+  item: Node
 ) : boolean {
-  if (roots && roots.length === 1) {
-    const value = getValue(roots[0]);
-    return value.class === "Window";
-  }
-  return WINDOW_PROPERTIES.includes(item.name);
+  return getType(item) === NODE_TYPES.DEFAULT_PROPERTIES;
 }
 
 function isDefaultWindowProperty(name:string) : boolean {
@@ -121,6 +117,12 @@ function nodeIsPromise(item: Node) : boolean {
   }
 
   return value.class == "Promise";
+}
+
+function nodeIsPrototype(
+  item: Node
+) : boolean {
+  return getType(item) === NODE_TYPES.PROTOTYPE;
 }
 
 function nodeHasAccessors(item: Node) : boolean {
@@ -389,7 +391,13 @@ function makeNodesForProperties(
   // Add the prototype if it exists and is not null
   if (prototype && prototype.type !== "null") {
     nodes.push(
-      createNode(parent, "__proto__", `${parentPath}/__proto__`, { value: prototype })
+      createNode(
+        parent,
+        "__proto__",
+        `${parentPath}/__proto__`,
+        { value: prototype },
+        NODE_TYPES.PROTOTYPE
+      )
     );
   }
 
@@ -502,12 +510,13 @@ module.exports = {
   nodeHasAccessors,
   nodeHasChildren,
   nodeHasProperties,
-  nodeIsDefault,
+  nodeIsDefaultProperties,
   nodeIsFunction,
   nodeIsMissingArguments,
   nodeIsObject,
   nodeIsOptimizedOut,
   nodeIsPrimitive,
+  nodeIsPrototype,
   nodeIsPromise,
   nodeSupportsBucketing,
   sortProperties,


### PR DESCRIPTION
First, we add the missing rule for the default-property class.
This patch changes how we style default properties node in
objects. Previously, we were looking for properties with the
same name as a window ownProperty. This could be dangerous
since you can have properties with the same name as one in
Window, but not necessarely under the window object.
Also, this can be weird to dim all the window default properties
when you expanded the node. If you did so, you are probably
interested in seeing what's inside.
Taking this into account, this patch applies the default-property class
to the default properties node and __proto__ ones, but only when they are
collapsed.