### PR TITLE
Do not put a rejected promise into sourceMapRequests cache

### DIFF
--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -116,7 +116,9 @@ function _fetchSourceMap(generatedSource: Source) {
 
   // Fire off the request, set it in the cache, and return it.
   const req = _resolveAndFetch(generatedSource);
-  sourceMapRequests.set(generatedSource.id, req);
+  // Make sure the cached promise does not reject, because we only
+  // want to report the error once.
+  sourceMapRequests.set(generatedSource.id, req.catch(() => null));
   return req;
 }
 

--- a/packages/devtools-source-map/src/tests/fixtures/missingmap.js
+++ b/packages/devtools-source-map/src/tests/fixtures/missingmap.js
@@ -1,0 +1,2 @@
+// Source where the map is missing.
+// # sourceMappingURL=missingmap.js.map

--- a/packages/devtools-source-map/src/tests/source-map.js
+++ b/packages/devtools-source-map/src/tests/source-map.js
@@ -111,8 +111,8 @@ describe("source maps", () => {
         sourceId: "bundle.js",
         line: 49
       };
-      const isMappaed = await hasMappedSource(location);
-      expect(isMappaed).toBe(true);
+      const isMapped = await hasMappedSource(location);
+      expect(isMapped).toBe(true);
     })
 
     test("does not have original location", async () => {
@@ -120,8 +120,8 @@ describe("source maps", () => {
         sourceId: "bundle.js",
         line: 94
       };
-      const isMappaed = await hasMappedSource(location);
-      expect(isMappaed).toBe(false);
+      const isMapped = await hasMappedSource(location);
+      expect(isMapped).toBe(false);
     })
   });
 });


### PR DESCRIPTION
My previous patch in this area was mistaken - it correctly allowed
errors from _fetchSourceMap to be propagated to the caller, but it
also cached the rejected promise in sourceMapRequests, resulting in
the same error being reported via other APIs.  This patch fixes the
oversight by caching a non-rejecting promise; this results in the
other APIs keeping their previous behavior.