### PR TITLE
Add a prop to dim top level window node.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -39,6 +39,7 @@ const {
   nodeIsOptimizedOut,
   nodeIsPrimitive,
   nodeIsPrototype,
+  nodeIsWindow,
 } = require("./utils");
 
 import type {
@@ -59,6 +60,7 @@ type Props = {
   mode: Mode,
   roots: Array<Node>,
   disableWrap: boolean,
+  dimTopLevelWindow: boolean,
   getObjectEntries: (actor:string) => ?LoadedEntries,
   getObjectProperties: (actor:string) => ?LoadedProperties,
   loadObjectEntries: (value:RdpGrip) => void,
@@ -270,6 +272,7 @@ class ObjectInspector extends Component {
     const {
       onDoubleClick,
       onLabelClick,
+      dimTopLevelWindow,
     } = this.props;
 
     return dom.div(
@@ -279,6 +282,11 @@ class ObjectInspector extends Component {
           lessen: !expanded && (
             nodeIsDefaultProperties(item)
             || nodeIsPrototype(item)
+            || (
+                dimTopLevelWindow === true
+                && nodeIsWindow(item)
+                && depth === 0
+              )
           )
         }),
         style: {

--- a/packages/devtools-reps/src/object-inspector/tests/object-inspector.js
+++ b/packages/devtools-reps/src/object-inspector/tests/object-inspector.js
@@ -14,8 +14,10 @@ const {
 } = require("../utils");
 const { MODE } = require("../../reps/constants");
 const { Rep } = require("../../reps/rep");
+
 const gripRepStubs = require("../../reps/stubs/grip");
 const gripMapRepStubs = require("../../reps/stubs/grip-map");
+const gripWindowStubs = require("../../reps/stubs/window");
 const mapStubs = require("../stubs/map");
 const accessorStubs = require("../../reps/stubs/accessor");
 
@@ -402,6 +404,93 @@ describe("ObjectInspector", () => {
 
     protoElementNode = oi.find(".node");
     expect(protoElementNode.hasClass("lessen")).toBe(false);
+  });
+
+  it("renders collapsed top-level window when dimTopLevelWindow is true", () => {
+    const windowNode = createNode(
+      null,
+      "window",
+      "windowpath",
+      {value: gripWindowStubs.get("Window")}
+    );
+
+    // The window node should have the "lessen" class when collapsed.
+    let oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [windowNode],
+      dimTopLevelWindow: true,
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+    expect(oi.find(".node.lessen").exists()).toBeTruthy();
+  });
+
+  it("renders expanded top-level window when dimTopLevelWindow is true", () => {
+    const windowNode = createNode(
+      null,
+      "window",
+      "windowpath",
+      {value: gripWindowStubs.get("Window")}
+    );
+
+    // The window node should not have the "lessen" class when expanded.
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [windowNode],
+      dimTopLevelWindow: true,
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+    expect(oi.find(".node.lessen").exists()).toBeFalsy();
+  });
+
+  it("renders collapsed top-level window when dimTopLevelWindow is false", () => {
+    const windowNode = createNode(
+      null,
+      "window",
+      "windowpath",
+      {value: gripWindowStubs.get("Window")}
+    );
+
+    // The window node should not have the "lessen" class when dimTopLevelWindow is falsy.
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [windowNode],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+    expect(oi.find(".node.lessen").exists()).toBeFalsy();
+  });
+
+  it("renders collapsed top-level window when dimTopLevelWindow is false", () => {
+    const windowNode = createNode(
+      null,
+      "window",
+      "windowpath",
+      {value: gripWindowStubs.get("Window")}
+    );
+
+    // The window node should not have the "lessen" class when it is not at top level.
+    const root = createNode(
+      null,
+      "root",
+      "rootpath",
+      [windowNode]
+    );
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [root],
+      dimTopLevelWindow: true,
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+    }));
+    const nodes = oi.find(".node");
+    const win = nodes.at(1);
+
+    // Make sure we target the window object.
+    expect(win.find(".objectBox-Window").exists()).toBeTruthy();
+    expect(win.hasClass("lessen")).toBeFalsy();
   });
 
   it("does not load properties if getObjectProperties returns a truthy element", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-is-window.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-is-window.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const gripWindowStubs = require("../../../reps/stubs/window");
+
+const {
+  createNode,
+  nodeIsWindow,
+} = require("../../utils");
+
+const createRootNode = value => createNode(null, "root", "/", {value});
+describe("nodeIsWindow", () => {
+  it("returns true for Window", () => {
+    expect(nodeIsWindow(
+      createRootNode(gripWindowStubs.get("Window")))
+    ).toBe(true);
+  });
+});

--- a/packages/devtools-reps/src/object-inspector/utils.js
+++ b/packages/devtools-reps/src/object-inspector/utils.js
@@ -140,6 +140,17 @@ function nodeIsPrototype(
   return getType(item) === NODE_TYPES.PROTOTYPE;
 }
 
+function nodeIsWindow(
+  item: Node
+) : boolean {
+  const value = getValue(item);
+  if (!value) {
+    return false;
+  }
+
+  return value.class == "Window";
+}
+
 function nodeHasAccessors(item: Node) : boolean {
   return !!getNodeGetter(item) || !!getNodeSetter(item);
 }
@@ -634,7 +645,9 @@ module.exports = {
   nodeIsPrimitive,
   nodeIsPromise,
   nodeIsPrototype,
+  nodeIsWindow,
   nodeSupportsBucketing,
+  setNodeChildren,
   sortProperties,
   NODE_TYPES,
   // Export for testing purpose.


### PR DESCRIPTION
This is done to fill the need of the debugger Scopes panel,
since the global Window object is always shown.