### PR TITLE
Remove type parameter in supportsObject.

### DIFF
--- a/packages/devtools-reps/src/reps/accessor.js
+++ b/packages/devtools-reps/src/reps/accessor.js
@@ -52,7 +52,7 @@ function hasSetter(object) {
   return object && object.set && object.set.type !== "undefined";
 }
 
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip !== true && (hasGetter(object) || hasSetter(object))) {
     return true;
   }

--- a/packages/devtools-reps/src/reps/array.js
+++ b/packages/devtools-reps/src/reps/array.js
@@ -132,7 +132,7 @@ function ItemRep(props) {
   );
 }
 
-function supportsObject(object, type) {
+function supportsObject(object) {
   return Array.isArray(object) ||
     Object.prototype.toString.call(object) === "[object Arguments]";
 }

--- a/packages/devtools-reps/src/reps/attribute.js
+++ b/packages/devtools-reps/src/reps/attribute.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 // Reps
 const {
+  getGripType,
   isGrip,
   wrapRender,
 } = require("./rep-utils");
@@ -49,12 +50,12 @@ function getTitle(grip) {
 }
 
 // Registration
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 
-  return (type == "Attr" && grip.preview);
+  return (getGripType(grip, noGrip) == "Attr" && grip.preview);
 }
 
 module.exports = {

--- a/packages/devtools-reps/src/reps/comment-node.js
+++ b/packages/devtools-reps/src/reps/comment-node.js
@@ -45,7 +45,7 @@ function CommentNode(props) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 // Reps
 const {
+  getGripType,
   isGrip,
   wrapRender,
 } = require("./rep-utils");
@@ -48,12 +49,12 @@ function getTitle(grip) {
 }
 
 // Registration
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 
-  return (type == "Date" && grip.preview);
+  return (getGripType(grip, noGrip) == "Date" && grip.preview);
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/document.js
+++ b/packages/devtools-reps/src/reps/document.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 // Reps
 const {
+  getGripType,
   isGrip,
   getURLDisplayString,
   wrapRender,
@@ -50,12 +51,12 @@ function getTitle(grip) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
 
-  return (object.preview && type == "HTMLDocument");
+  return (object.preview && getGripType(object, noGrip) == "HTMLDocument");
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -131,7 +131,7 @@ function getElements(grip, mode) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/error.js
+++ b/packages/devtools-reps/src/reps/error.js
@@ -6,6 +6,7 @@
 const React = require("react");
 // Utils
 const {
+  getGripType,
   isGrip,
   wrapRender,
 } = require("./rep-utils");
@@ -50,11 +51,11 @@ function ErrorRep(props) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
-  return (object.preview && type === "Error");
+  return (object.preview && getGripType(object, noGrip) === "Error");
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/event.js
+++ b/packages/devtools-reps/src/reps/event.js
@@ -86,7 +86,7 @@ function getTitle(props) {
 }
 
 // Registration
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 // Reps
 const {
+  getGripType,
   isGrip,
   cropString,
   wrapRender,
@@ -79,7 +80,8 @@ function renderParams(props) {
 }
 
 // Registration
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
+  const type = getGripType(grip, noGrip);
   if (noGrip === true || !isGrip(grip)) {
     return (type == "function");
   }

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -5,6 +5,7 @@
 // Dependencies
 const React = require("react");
 const {
+  getGripType,
   isGrip,
   wrapRender,
 } = require("./rep-utils");
@@ -189,14 +190,14 @@ function getEmptySlotsElement(number) {
   return `<${number} empty slot${number > 1 ? "s" : ""}>`;
 }
 
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }
 
   return (grip.preview && (
       grip.preview.kind == "ArrayLike" ||
-      type === "DocumentFragment"
+      getGripType(grip, noGrip) === "DocumentFragment"
     )
   );
 }

--- a/packages/devtools-reps/src/reps/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/grip-map-entry.js
@@ -44,7 +44,7 @@ function GripMapEntry(props) {
   })));
 }
 
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/grip-map.js
+++ b/packages/devtools-reps/src/reps/grip-map.js
@@ -192,7 +192,7 @@ function getEntriesIndexes(entries, max, filter) {
     }, []);
 }
 
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -311,7 +311,7 @@ function getPropValue(property) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/infinity.js
+++ b/packages/devtools-reps/src/reps/infinity.js
@@ -5,7 +5,10 @@
 // Dependencies
 const React = require("react");
 
-const { wrapRender } = require("./rep-utils");
+const {
+  getGripType,
+  wrapRender,
+} = require("./rep-utils");
 
 // Shortcuts
 const { span } = React.DOM;
@@ -29,7 +32,8 @@ function InfinityRep(props) {
   );
 }
 
-function supportsObject(object, type) {
+function supportsObject(object, noGrip = false) {
+  const type = getGripType(object, noGrip);
   return type == "Infinity" || type == "-Infinity";
 }
 

--- a/packages/devtools-reps/src/reps/long-string.js
+++ b/packages/devtools-reps/src/reps/long-string.js
@@ -57,7 +57,7 @@ function LongStringRep(props) {
   return span(config, formattedString);
 }
 
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/nan.js
+++ b/packages/devtools-reps/src/reps/nan.js
@@ -5,7 +5,10 @@
 // Dependencies
 const React = require("react");
 
-const { wrapRender } = require("./rep-utils");
+const {
+  getGripType,
+  wrapRender,
+} = require("./rep-utils");
 
 // Shortcuts
 const { span } = React.DOM;
@@ -21,8 +24,8 @@ function NaNRep(props) {
   );
 }
 
-function supportsObject(object, type) {
-  return type == "NaN";
+function supportsObject(object, noGrip = false) {
+  return getGripType(object, noGrip) == "NaN";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/null.js
+++ b/packages/devtools-reps/src/reps/null.js
@@ -21,7 +21,7 @@ function Null(props) {
   );
 }
 
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/number.js
+++ b/packages/devtools-reps/src/reps/number.js
@@ -5,7 +5,10 @@
 // Dependencies
 const React = require("react");
 
-const { wrapRender } = require("./rep-utils");
+const {
+  getGripType,
+  wrapRender,
+} = require("./rep-utils");
 
 // Shortcuts
 const { span } = React.DOM;
@@ -38,8 +41,8 @@ function stringify(object) {
   return (isNegativeZero ? "-0" : String(object));
 }
 
-function supportsObject(object, type) {
-  return ["boolean", "number", "-0"].includes(type);
+function supportsObject(object, noGrip = false) {
+  return ["boolean", "number", "-0"].includes(getGripType(object, noGrip));
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/object-with-text.js
+++ b/packages/devtools-reps/src/reps/object-with-text.js
@@ -42,7 +42,7 @@ function getDescription(grip) {
 }
 
 // Registration
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/object-with-url.js
+++ b/packages/devtools-reps/src/reps/object-with-url.js
@@ -48,7 +48,7 @@ function getDescription(grip) {
 }
 
 // Registration
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/object.js
+++ b/packages/devtools-reps/src/reps/object.js
@@ -200,7 +200,7 @@ function getFilteredObject(object, max, filter) {
   return filteredObject;
 }
 
-function supportsObject(object, type) {
+function supportsObject(object) {
   return true;
 }
 

--- a/packages/devtools-reps/src/reps/promise.js
+++ b/packages/devtools-reps/src/reps/promise.js
@@ -6,6 +6,7 @@
 const React = require("react");
 // Dependencies
 const {
+  getGripType,
   isGrip,
   wrapRender,
 } = require("./rep-utils");
@@ -100,11 +101,11 @@ function getProps(props, promiseState) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
-  return type === "Promise";
+  return getGripType(object, noGrip) === "Promise";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/promise.js
+++ b/packages/devtools-reps/src/reps/promise.js
@@ -105,7 +105,7 @@ function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
-  return getGripType(object, noGrip) === "Promise";
+  return getGripType(object, noGrip) == "Promise";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/regexp.js
+++ b/packages/devtools-reps/src/reps/regexp.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 // Reps
 const {
+  getGripType,
   isGrip,
   wrapRender,
 } = require("./rep-utils");
@@ -34,12 +35,12 @@ function getSource(grip) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
 
-  return (type == "RegExp");
+  return getGripType(object, noGrip) == "RegExp";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/rep-utils.js
+++ b/packages/devtools-reps/src/reps/rep-utils.js
@@ -333,6 +333,28 @@ function getGripPreviewItems(grip) {
   return [];
 }
 
+/**
+ * Get the type of an object.
+ *
+ * @param {Object} Grip from which we want the type.
+ * @param {boolean} noGrip true if the object is not a grip.
+ * @return {boolean}
+ */
+function getGripType(object, noGrip) {
+  let type = typeof object;
+  if (type == "object" && object instanceof String) {
+    type = "string";
+  } else if (object && type == "object" && object.type && noGrip !== true) {
+    type = object.type;
+  }
+
+  if (isGrip(object)) {
+    type = object.class;
+  }
+
+  return type;
+}
+
 module.exports = {
   isGrip,
   cropString,
@@ -347,4 +369,5 @@ module.exports = {
   getURLDisplayString,
   maybeEscapePropertyName,
   getGripPreviewItems,
+  getGripType,
 };

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 require("./reps.css");
-const { isGrip } = require("./rep-utils");
 
 // Load all existing rep templates
 const Undefined = require("./undefined");
@@ -105,24 +104,13 @@ const Rep = function (props) {
  * @param noGrip {Boolean} If true, will only check reps not made for remote objects.
  */
 function getRep(object, defaultRep = Obj, noGrip = false) {
-  let type = typeof object;
-  if (type == "object" && object instanceof String) {
-    type = "string";
-  } else if (object && type == "object" && object.type && noGrip !== true) {
-    type = object.type;
-  }
-
-  if (isGrip(object)) {
-    type = object.class;
-  }
-
   for (let i = 0; i < reps.length; i++) {
     let rep = reps[i];
     try {
       // supportsObject could return weight (not only true/false
       // but a number), which would allow to priorities templates and
       // support better extensibility.
-      if (rep.supportsObject(object, type, noGrip)) {
+      if (rep.supportsObject(object, noGrip)) {
         return rep.rep;
       }
     } catch (err) {

--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 const {
   escapeString,
+  getGripType,
   rawCropString,
   sanitizeString,
   wrapRender,
@@ -55,8 +56,8 @@ function StringRep(props) {
   return span(config, text);
 }
 
-function supportsObject(object, type) {
-  return (type == "string");
+function supportsObject(object, noGrip = false) {
+  return getGripType(object, noGrip) == "string";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/stylesheet.js
+++ b/packages/devtools-reps/src/reps/stylesheet.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 // Reps
 const {
+  getGripType,
   isGrip,
   getURLDisplayString,
   wrapRender
@@ -48,12 +49,12 @@ function getLocation(grip) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
 
-  return (type == "CSSStyleSheet");
+  return getGripType(object, noGrip) == "CSSStyleSheet";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/symbol.js
+++ b/packages/devtools-reps/src/reps/symbol.js
@@ -5,7 +5,10 @@
 // Dependencies
 const React = require("react");
 
-const { wrapRender } = require("./rep-utils");
+const {
+  getGripType,
+  wrapRender,
+} = require("./rep-utils");
 
 // Shortcuts
 const { span } = React.DOM;
@@ -27,8 +30,8 @@ function SymbolRep(props) {
   return span({className}, `Symbol(${name || ""})`);
 }
 
-function supportsObject(object, type) {
-  return (type == "symbol");
+function supportsObject(object, noGrip = false) {
+  return getGripType(object, noGrip) == "symbol";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/text-node.js
+++ b/packages/devtools-reps/src/reps/text-node.js
@@ -95,7 +95,7 @@ function getTitle(grip) {
 }
 
 // Registration
-function supportsObject(grip, type, noGrip = false) {
+function supportsObject(grip, noGrip = false) {
   if (noGrip === true || !isGrip(grip)) {
     return false;
   }

--- a/packages/devtools-reps/src/reps/undefined.js
+++ b/packages/devtools-reps/src/reps/undefined.js
@@ -5,7 +5,10 @@
 // Dependencies
 const React = require("react");
 
-const { wrapRender } = require("./rep-utils");
+const {
+  getGripType,
+  wrapRender,
+} = require("./rep-utils");
 
 // Shortcuts
 const { span } = React.DOM;
@@ -21,12 +24,13 @@ const Undefined = function () {
   );
 };
 
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true) {
     return false;
   }
 
-  return (object && object.type && object.type == "undefined") || type == "undefined";
+  return (object && object.type && object.type == "undefined")
+    || getGripType(object, noGrip) == "undefined";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/window.js
+++ b/packages/devtools-reps/src/reps/window.js
@@ -7,6 +7,7 @@ const React = require("react");
 
 // Reps
 const {
+  getGripType,
   isGrip,
   getURLDisplayString,
   wrapRender
@@ -64,12 +65,12 @@ function getLocation(object) {
 }
 
 // Registration
-function supportsObject(object, type, noGrip = false) {
+function supportsObject(object, noGrip = false) {
   if (noGrip === true || !isGrip(object)) {
     return false;
   }
 
-  return (object.preview && type == "Window");
+  return (object.preview && getGripType(object, noGrip) == "Window");
 }
 
 // Exports from this module


### PR DESCRIPTION
Fixes #554.
This removes the type parameter from supportsObject so those functions
can be used by another consumer than getRep.
The type computation is moved to its own function in utils.