### PR TITLE
Avoid space between contexty menu and its submenu (bug 1384965)

### DIFF
--- a/packages/devtools-contextmenu/menu.js
+++ b/packages/devtools-contextmenu/menu.js
@@ -111,7 +111,7 @@ function showSubMenu(subMenu, menuItemNode, popup) {
     let subMenuNode = menuItemNode.querySelector("menupopup");
     let { top } = menuItemNode.getBoundingClientRect();
     let { left, width } = popup.getBoundingClientRect();
-    subMenuNode.style.setProperty("left", `${left + width}px`);
+    subMenuNode.style.setProperty("left", `${left + width - 1}px`);
     subMenuNode.style.setProperty("top", `${top}px`);
 
     let subMenuItemNodes = menuItemNode


### PR DESCRIPTION
See bug 1384965 for more details:
https://bugzilla.mozilla.org/show_bug.cgi?id=1384965

Honza