### PR TITLE
Make a little space between a label and submenu arrow (bug 1384892)

### DIFF
--- a/packages/devtools-contextmenu/menu.css
+++ b/packages/devtools-contextmenu/menu.css
@@ -10,6 +10,7 @@ menu {
 menu > menuitem::after {
   content: "►";
   float: right;
+  padding-left: 5px;
 }
 
 menu > menupopup {


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1384892

Honza