### PR TITLE
Improve bucketing

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-numerical-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-numerical-properties.js
@@ -130,10 +130,10 @@ describe("makeNodesForProperties", () => {
       "[900…999]",
     ]);
     expect(firstBucketPaths[0]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_0-99`,
+      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_0-99`
     );
     expect(firstBucketPaths[firstBucketPaths.length - 1]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_900-999`,
+      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_900-999`
     );
 
     const lastBucketNodes = nodes[nodes.length - 2].contents;
@@ -145,10 +145,10 @@ describe("makeNodesForProperties", () => {
       "10200",
     ]);
     expect(lastBucketPaths[0]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_10000-10200/${SAFE_PATH_PREFIX}bucket_10000-10099`,
+      `root/${SAFE_PATH_PREFIX}bucket_10000-10200/${SAFE_PATH_PREFIX}bucket_10000-10099`
     );
     expect(lastBucketPaths[lastBucketPaths.length - 1]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_10000-10200/10200`,
+      `root/${SAFE_PATH_PREFIX}bucket_10000-10200/10200`
     );
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-numerical-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-numerical-properties.js
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const {
+  makeNodesForProperties,
+  SAFE_PATH_PREFIX,
+} = require("../../utils");
+const gripArrayStubs = require("../../../reps/stubs/grip-array");
+
+const root = {
+  path: "root",
+  contents: {
+    value: gripArrayStubs.get("testBasic")
+  }
+};
+
+describe("makeNodesForProperties", () => {
+  it("handles simple numerical buckets", () => {
+    let objProps = { ownProperties: {}, prototype: {} };
+    for (let i = 0; i < 331; i++) {
+      objProps.ownProperties[i] = { value: {} };
+    }
+    const nodes = makeNodesForProperties(objProps, root);
+
+    const names = nodes.map(n => n.name);
+    const paths = nodes.map(n => n.path);
+
+    expect(names).toEqual([
+      "[0…99]",
+      "[100…199]",
+      "[200…299]",
+      "[300…330]",
+      "__proto__"
+    ]);
+
+    expect(paths).toEqual([
+      `root/${SAFE_PATH_PREFIX}bucket_0-99`,
+      `root/${SAFE_PATH_PREFIX}bucket_100-199`,
+      `root/${SAFE_PATH_PREFIX}bucket_200-299`,
+      `root/${SAFE_PATH_PREFIX}bucket_300-330`,
+      "root/__proto__"
+    ]);
+  });
+
+  it("does not create a numerical bucket for a single node", () => {
+    let objProps = { ownProperties: {}, prototype: {} };
+    for (let i = 0; i <= 100; i++) {
+      objProps.ownProperties[i] = { value: {} };
+    }
+    const nodes = makeNodesForProperties(objProps, root);
+
+    const names = nodes.map(n => n.name);
+    const paths = nodes.map(n => n.path);
+
+    expect(names).toEqual([
+      "[0…99]",
+      "100",
+      "__proto__"
+    ]);
+
+    expect(paths).toEqual([
+      `root/${SAFE_PATH_PREFIX}bucket_0-99`,
+      `root/100`,
+      "root/__proto__"
+    ]);
+  });
+
+  it("does create a numerical bucket for two node", () => {
+    let objProps = { ownProperties: {}, prototype: {} };
+    for (let i = 0; i <= 101; i++) {
+      objProps.ownProperties[i] = { value: {} };
+    }
+    const nodes = makeNodesForProperties(objProps, root);
+
+    const names = nodes.map(n => n.name);
+    const paths = nodes.map(n => n.path);
+
+    expect(names).toEqual([
+      "[0…99]",
+      "[100…101]",
+      "__proto__"
+    ]);
+
+    expect(paths).toEqual([
+      `root/${SAFE_PATH_PREFIX}bucket_0-99`,
+      `root/${SAFE_PATH_PREFIX}bucket_100-101`,
+      "root/__proto__"
+    ]);
+  });
+
+  it("creates sub-buckets when needed", () => {
+    let objProps = { ownProperties: {}, prototype: {} };
+    for (let i = 0; i <= 10200; i++) {
+      objProps.ownProperties[i] = { value: {} };
+    }
+    const nodes = makeNodesForProperties(objProps, root);
+
+    const names = nodes.map(n => n.name);
+
+    expect(names).toEqual([
+      "[0…999]",
+      "[1000…1999]",
+      "[2000…2999]",
+      "[3000…3999]",
+      "[4000…4999]",
+      "[5000…5999]",
+      "[6000…6999]",
+      "[7000…7999]",
+      "[8000…8999]",
+      "[9000…9999]",
+      "[10000…10200]",
+      "__proto__"
+    ]);
+
+    const firstBucketNodes = nodes[0].contents;
+    const firstBucketNames = firstBucketNodes.map(n => n.name);
+    const firstBucketPaths = firstBucketNodes.map(n => n.path);
+
+    expect(firstBucketNames).toEqual([
+      "[0…99]",
+      "[100…199]",
+      "[200…299]",
+      "[300…399]",
+      "[400…499]",
+      "[500…599]",
+      "[600…699]",
+      "[700…799]",
+      "[800…899]",
+      "[900…999]",
+    ]);
+    expect(firstBucketPaths[0]).toEqual(
+      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_0-99`,
+    );
+    expect(firstBucketPaths[firstBucketPaths.length - 1]).toEqual(
+      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_900-999`,
+    );
+
+    const lastBucketNodes = nodes[nodes.length - 2].contents;
+    const lastBucketNames = lastBucketNodes.map(n => n.name);
+    const lastBucketPaths = lastBucketNodes.map(n => n.path);
+    expect(lastBucketNames).toEqual([
+      "[10000…10099]",
+      "[10100…10199]",
+      "10200",
+    ]);
+    expect(lastBucketPaths[0]).toEqual(
+      `root/${SAFE_PATH_PREFIX}bucket_10000-10200/${SAFE_PATH_PREFIX}bucket_10000-10099`,
+    );
+    expect(lastBucketPaths[lastBucketPaths.length - 1]).toEqual(
+      `root/${SAFE_PATH_PREFIX}bucket_10000-10200/10200`,
+    );
+  });
+});

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -202,34 +202,6 @@ describe("makeNodesForProperties", () => {
     ]);
   });
 
-  // For large arrays
-  it("numerical buckets", () => {
-    let objProps = { ownProperties: {}, prototype: {} };
-    for (let i = 0; i < 331; i++) {
-      objProps.ownProperties[i] = { value: {} };
-    }
-    const nodes = makeNodesForProperties(objProps, root);
-
-    const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
-
-    expect(names).toEqual([
-      "[0…99]",
-      "[100…199]",
-      "[200…299]",
-      "[300…330]",
-      "__proto__"
-    ]);
-
-    expect(paths).toEqual([
-      `root/${SAFE_PATH_PREFIX}bucket1`,
-      `root/${SAFE_PATH_PREFIX}bucket2`,
-      `root/${SAFE_PATH_PREFIX}bucket3`,
-      `root/${SAFE_PATH_PREFIX}bucket4`,
-      "root/__proto__"
-    ]);
-  });
-
   it("quotes property names", () => {
     const nodes = makeNodesForProperties(
       {

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -11,12 +11,13 @@ const {
   nodeIsPrototype,
   SAFE_PATH_PREFIX,
 } = require("../../utils");
+const gripArrayStubs = require("../../../reps/stubs/grip-array");
 
 const root = {
   path: "root",
-  contents: { value: {
-    class: "Array"
-  }}
+  contents: {
+    value: gripArrayStubs.get("testBasic")
+  }
 };
 
 const objProperties = {

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -214,10 +214,10 @@ describe("makeNodesForProperties", () => {
     const paths = nodes.map(n => n.path);
 
     expect(names).toEqual([
-      "[0..99]",
-      "[100..199]",
-      "[200..299]",
-      "[300..331]",
+      "[0…99]",
+      "[100…199]",
+      "[200…299]",
+      "[300…330]",
       "__proto__"
     ]);
 

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-supports-bucketing.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-supports-bucketing.js
@@ -26,21 +26,18 @@ describe("nodeSupportsBucketing", () => {
     )).toBe(true);
   });
 
-  // Should pass (see https://github.com/devtools-html/devtools-core/issues/496)
   it("returns true for NodeMap", () => {
     expect(nodeSupportsBucketing(
       createRootNode(gripArrayStubs.get("testNamedNodeMap"))
     )).toBe(true);
   });
 
-  // Should pass (see https://github.com/devtools-html/devtools-core/issues/496)
   it("returns true for NodeList", () => {
     expect(nodeSupportsBucketing(
       createRootNode(gripArrayStubs.get("testNodeList"))
     )).toBe(true);
   });
 
-  // Should pass (see https://github.com/devtools-html/devtools-core/issues/496)
   it("returns true for DocumentFragment", () => {
     expect(nodeSupportsBucketing(
       createRootNode(gripArrayStubs.get("testDocumentFragment"))

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-supports-bucketing.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-supports-bucketing.js
@@ -27,21 +27,21 @@ describe("nodeSupportsBucketing", () => {
   });
 
   // Should pass (see https://github.com/devtools-html/devtools-core/issues/496)
-  it.skip("returns true for NodeMap", () => {
+  it("returns true for NodeMap", () => {
     expect(nodeSupportsBucketing(
       createRootNode(gripArrayStubs.get("testNamedNodeMap"))
     )).toBe(true);
   });
 
   // Should pass (see https://github.com/devtools-html/devtools-core/issues/496)
-  it.skip("returns true for NodeList", () => {
+  it("returns true for NodeList", () => {
     expect(nodeSupportsBucketing(
       createRootNode(gripArrayStubs.get("testNodeList"))
     )).toBe(true);
   });
 
   // Should pass (see https://github.com/devtools-html/devtools-core/issues/496)
-  it.skip("returns true for DocumentFragment", () => {
+  it("returns true for DocumentFragment", () => {
     expect(nodeSupportsBucketing(
       createRootNode(gripArrayStubs.get("testDocumentFragment"))
     )).toBe(true);

--- a/packages/devtools-reps/src/object-inspector/utils.js
+++ b/packages/devtools-reps/src/object-inspector/utils.js
@@ -6,7 +6,9 @@
 const get = require("lodash/get");
 const has = require("lodash/has");
 const { maybeEscapePropertyName } = require("../reps/rep-utils");
-const GripMapEntry = require("../reps/grip-map-entry");
+const ArrayRep = require("../reps/array");
+const GripArrayRep = require("../reps/grip-array");
+const GripMapEntryRep = require("../reps/grip-map-entry");
 
 const NODE_TYPES = {
   BUCKET: Symbol("[n…n]"),
@@ -70,7 +72,7 @@ function nodeIsEntries(item: Node) : boolean {
 }
 
 function nodeIsMapEntry(item: Node) : boolean {
-  return GripMapEntry.supportsObject(getValue(item));
+  return GripMapEntryRep.supportsObject(getValue(item));
 }
 
 function nodeHasChildren(item: Node) : boolean {
@@ -83,9 +85,10 @@ function nodeIsObject(item: Node) : boolean {
   return value && value.type === "object";
 }
 
-function nodeIsArray(item: Node) : boolean {
+function nodeIsArrayLike(item: Node) : boolean {
   const value = getValue(item);
-  return (value && value.class === "Array");
+  return GripArrayRep.supportsObject(value)
+    || ArrayRep.supportsObject(value);
 }
 
 function nodeIsFunction(item: Node) : boolean {
@@ -168,7 +171,7 @@ function nodeHasAccessors(item: Node) : boolean {
 }
 
 function nodeSupportsBucketing(item: Node) : boolean {
-  return nodeIsArray(item)
+  return nodeIsArrayLike(item)
     || nodeIsEntries(item);
 }
 
@@ -263,7 +266,7 @@ function makeNodesForEntries(
     if (preview.entries) {
       entriesNodes = preview.entries.map(([key, value], index) => {
         return createNode(item, index, `${entriesPath}/${index}`, {
-          value: GripMapEntry.createGripMapEntry(key, value)
+          value: GripMapEntryRep.createGripMapEntry(key, value)
         });
       });
     } else if (preview.items) {

--- a/packages/devtools-reps/src/object-inspector/utils.js
+++ b/packages/devtools-reps/src/object-inspector/utils.js
@@ -359,8 +359,8 @@ function makeNumericalBuckets(
   for (let i = 1; i <= numBuckets; i++) {
     const bucketKey = `${SAFE_PATH_PREFIX}bucket${i}`;
     const minKey = (i - 1) * bucketSize;
-    const maxKey = Math.min(i * bucketSize - 1, numProperties);
-    const bucketName = `[${minKey}..${maxKey}]`;
+    const maxKey = Math.min(i * bucketSize - 1, numProperties - 1);
+    const bucketName = `[${minKey}…${maxKey}]`;
     const bucketProperties = propertiesNames.slice(minKey, maxKey);
 
     const bucketNodes = bucketProperties.map(name =>

--- a/packages/devtools-reps/src/object-inspector/utils.js
+++ b/packages/devtools-reps/src/object-inspector/utils.js
@@ -402,7 +402,7 @@ function makeNumericalBuckets(
           bucketProperties,
           bucketRoot,
           ownProperties,
-          minIndex,
+          minIndex
         );
       }
       setNodeChildren(bucketRoot, bucketNodes);


### PR DESCRIPTION
Fixes #496 
Fixes #538 
Fixes #560

We use the GripArray supportsObject function to get nodes which can represents array-like objects so we cover more than plain arrays (DocumentFragment, NodeList, Typed-Arrays, …).

There was also a flaw in how we computed the last bucket label.
Also, now we don't create a bucket if there will be only one item in it.

And finally we show at most a hundred buckets per level.
When inspecting very-large arrays (> 10000 items), the UI would freeze because we were creating too much buckets at once.
This patch solves this by having at most a hundred bucket per-level, and then using sub-buckets, like we did in the VariableView.
Tests were added to ensure everything is working like it should, and since the test file was getting bigger, I created a dedicated test file for numerical properties.

