### PR TITLE
Expose ObjectInspector utils

### DIFF
--- a/packages/devtools-reps/src/index.js
+++ b/packages/devtools-reps/src/index.js
@@ -5,6 +5,7 @@
 const { MODE } = require("./reps/constants");
 const { REPS, getRep } = require("./reps/rep");
 const ObjectInspector = require("./object-inspector/");
+const ObjectInspectorUtils = require("./object-inspector/utils");
 
 const {
   parseURLEncodedText,
@@ -22,4 +23,5 @@ module.exports = {
   parseURLParams,
   getGripPreviewItems,
   ObjectInspector,
+  ObjectInspectorUtils,
 };


### PR DESCRIPTION
This is needed for the debugger which uses the `getChildren` function in its Preview component.