### PR TITLE
Use fetch in privileged-network-request and inhibit caching

### DIFF
--- a/packages/devtools-utils/src/privileged-network-request.js
+++ b/packages/devtools-utils/src/privileged-network-request.js
@@ -2,36 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-function networkRequest(url, opts) {
-  return new Promise((resolve, reject) => {
-    try {
-      const req = new XMLHttpRequest();
+// @flow
 
-      req.addEventListener("readystatechange", () => {
-        if (req.readyState === XMLHttpRequest.DONE) {
-          if (req.status === 200) {
-            resolve({ content: req.responseText });
-          } else {
-            let text = req.statusText || "invalid URL";
-            reject(text);
-          }
-        }
-      });
-
-      // Not working yet.
-      // if (!opts.loadFromCache) {
-      //   req.channel.loadFlags = (
-      //     Components.interfaces.nsIRequest.LOAD_BYPASS_CACHE |
-      //       Components.interfaces.nsIRequest.INHIBIT_CACHING |
-      //       Components.interfaces.nsIRequest.LOAD_ANONYMOUS
-      //   );
-      // }
-
-      req.open("GET", url);
-      req.send();
-    } catch (e) {
-      reject(e.toString());
+function networkRequest(url: string, opts: any) {
+  return fetch(url, {
+    cache: opts.loadFromCache ? "default" : "no-cache",
+  }).then(res => {
+    if (res.status >= 200 && res.status < 300) {
+      return res.text()
+        .then(text => ({ content: text }));
     }
+    return Promise.reject(new Error(`failed to fetch ${url}`));
   });
 }
 


### PR DESCRIPTION
This change privileged-network-request to use fetch rather than
XMLHttpRequest; and also changes it to respect the "loadFromCache"
option.  Fixes #551.