### PR TITLE
Bump node version

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -27,7 +27,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">=6.9.0"
+    "node": ">=7.0.0"
   },
   "dependencies": {
     "amd-loader": "0.0.8",


### PR DESCRIPTION
updates the minimum node version to 7.x. We need this because we use Object.keys i think.

This also prettifies development.server :P