### PR TITLE
Unify the way how KeyShortcuts is exported with m-c

### DIFF
--- a/packages/devtools-modules/index.js
+++ b/packages/devtools-modules/index.js
@@ -6,7 +6,7 @@ const Menu = require("./src/menu");
 const MenuItem = require("./src/menu/menu-item");
 const { PrefsHelper } = require("./src/prefs");
 const Services = require("./src/Services");
-const { KeyShortcuts } = require("./src/key-shortcuts");
+const KeyShortcuts = require("./src/key-shortcuts");
 const { ZoomKeys } = require("./src/zoom-keys");
 const EventEmitter = require("./src/utils/event-emitter");
 

--- a/packages/devtools-modules/src/key-shortcuts.js
+++ b/packages/devtools-modules/src/key-shortcuts.js
@@ -240,4 +240,4 @@ KeyShortcuts.prototype = {
     this.eventEmitter.off(key, listener);
   },
 };
-exports.KeyShortcuts = KeyShortcuts;
+module.exports = KeyShortcuts;


### PR DESCRIPTION
This is also related to bug 1388368

KeyShortcuts object should be exported the same way as in m-c, so it's easily exchangeable.

Honza
 