### PR TITLE
Do not force Rep render on root when it has a name.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -383,8 +383,12 @@ class ObjectInspector extends Component {
     } = this.state;
 
     let roots = this.getRoots();
-    if (roots.length === 1 && nodeIsPrimitive(roots[0])) {
-      return this.renderGrip(roots[0], this.props);
+    if (roots.length === 1) {
+      const root = roots[0];
+      const name = root && root.name;
+      if (nodeIsPrimitive(root) && (name === null || typeof name === "undefined")) {
+        return this.renderGrip(root, this.props);
+      }
     }
 
     return Tree({

--- a/packages/devtools-reps/src/object-inspector/tests/component/basic.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/basic.js
@@ -87,7 +87,7 @@ describe("ObjectInspector - renders", () => {
     expect(oi.html()).toEqual(renderRep(MODE.TINY).html());
   });
 
-  it("renders as expected when provided a name", () => {
+  it("renders objects as expected when provided a name", () => {
     const object = gripRepStubs.get("testMoreThanMaxProps");
     const name = "myproperty";
 
@@ -99,6 +99,25 @@ describe("ObjectInspector - renders", () => {
         contents: {
           value: object
         }
+      }],
+      getObjectProperties: () => {},
+      loadObjectProperties: () => {},
+      mode: MODE.SHORT,
+    }));
+
+    expect(oi.find(".object-label").text()).toEqual(name);
+  });
+
+  it("renders primitives as expected when provided a name", () => {
+    const value = 42;
+    const name = "myproperty";
+
+    const oi = mount(ObjectInspector({
+      autoExpandDepth: 0,
+      roots: [{
+        path: "root",
+        name,
+        contents: {value}
       }],
       getObjectProperties: () => {},
       loadObjectProperties: () => {},


### PR DESCRIPTION
We were always rendering a simple rep when the value of the root node was a primitive.
**But,** this was messing with the watch expressions panel in the debugger, since we **do** want to see the name there (e.g. `3 + 1: 4`).