### PR TITLE
Issue #580 : switch to type String for Json prefs

### DIFF
--- a/packages/devtools-modules/src/Services.js
+++ b/packages/devtools-modules/src/Services.js
@@ -101,6 +101,11 @@ PrefBranch.prototype = {
     }
   },
 
+  /** @see nsIPrefBranch.getStringPref.  */
+  getStringPref: function() {
+    return this.getCharPref.apply(this, arguments);
+  },
+
   /** @see nsIPrefBranch.setCharPref.  */
   setCharPref: function(prefName, value) {
     if (typeof value !== "string") {
@@ -111,6 +116,11 @@ PrefBranch.prototype = {
       throw new Error(`${prefName} does not have string type`);
     }
     thePref._set(value);
+  },
+
+  /** @see nsIPrefBranch.setStringPref.  */
+  setStringPref: function() {
+    return this.setCharPref.apply(this, arguments);
   },
 
   /** @see nsIPrefBranch.getIntPref.  */

--- a/packages/devtools-modules/src/prefs.js
+++ b/packages/devtools-modules/src/prefs.js
@@ -105,7 +105,7 @@ function map(self, cache, accessorName, prefType, prefsRoot, prefName,
                     "on the instance.");
   }
   if (prefType == "Json") {
-    map(self, cache, accessorName, "Char", prefsRoot, prefName, {
+    map(self, cache, accessorName, "String", prefsRoot, prefName, {
       in: JSON.parse,
       out: JSON.stringify
     });

--- a/packages/devtools-modules/src/tests/prefs-helper.js
+++ b/packages/devtools-modules/src/tests/prefs-helper.js
@@ -1,0 +1,37 @@
+const { PrefsHelper } = require("../prefs");
+const Services = require("../Services");
+const pref = Services.pref;
+
+describe("prefs helper", () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("supports fallback values", () => {
+    pref("devtools.valid", "{\"valid\": true}");
+    pref("devtools.invalid", "{not valid at all]");
+    pref("devtools.nodefault", "{not valid at all]");
+    pref("devtools.validnodefault", "{\"nodefault\": true}");
+
+    const prefs = new PrefsHelper("devtools", {
+      valid: ["Json", "valid", {valid: true}],
+      invalid: ["Json", "invalid", {}],
+      nodefault: ["Json", "nodefault"],
+      validnodefault: ["Json", "validnodefault"],
+    });
+
+    // Valid Json pref should return the actual value
+    expect(prefs.valid).toEqual({valid: true});
+
+    // Invalid Json pref with a fallback shoud return the fallback value
+    expect(prefs.invalid).toEqual({});
+
+    // Invalid Json pref with no fallback should throw
+    expect(() => prefs.nodefault).toThrow();
+
+    // Valid Json pref with no fallback should return the value
+    expect(prefs.validnodefault).toEqual({nodefault: true});
+  });
+});

--- a/packages/devtools-modules/src/tests/services-prefs.js
+++ b/packages/devtools-modules/src/tests/services-prefs.js
@@ -45,6 +45,11 @@ describe("services prefs shim", () => {
       "bool pref has user value");
     expect(Services.prefs.prefHasUserValue("devtools.branch1.somestring")).toBe(false,
       "string pref does not have user value");
+
+    // String prefs actually differ from Char prefs in the real implementation of
+    // Services.prefs, but for this shim, both are using the same implementation.
+    Services.prefs.setStringPref("devtools.branch1.somerealstring", "abcdef");
+    expect(Services.prefs.getStringPref("devtools.branch1.somerealstring")).toBe("abcdef");
   });
 
   it("can call savePrefFile without crashing", () => {


### PR DESCRIPTION
I tested locally this change by modifying the corresponding code in the debugger bundle, and my breakpoints, tabs, expressions were still the ones from the previous session (which means that changing the type from Char to String didn't seem to create any issue).

Note that this won't fix existing bad preferences, such as the one that triggered https://bugzilla.mozilla.org/show_bug.cgi?id=1388825 , since the issue occurs on save. 