### PR TITLE
chore: add assets/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log
 .idea/
 .vscode/
 storybook-static/
+assets/
 
 packages/**/assets/build
 packages/**/configs/local.json


### PR DESCRIPTION
When running yarn install on the root of devtools-core, `lerna bootstrap` is creating an assets folder which contains a module-manifest.json file.

This should either be ignored or added to source control.