### PR TITLE
Add a prop to have ObjectInspector inline

### DIFF
--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "devtools-components": "^0.0.1",
+    "devtools-components": "^0.0.2",
     "lodash": "^4.17.2",
     "react": "=15.3.2",
     "react-dom": "=15.3.2",

--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -4,6 +4,9 @@
 
 .tree {
   overflow: auto;
+}
+
+.tree.inline {
   display: inline-block;
 }
 

--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -60,6 +60,7 @@ type Props = {
   autoExpandDepth: number,
   disabledFocus: boolean,
   itemHeight: number,
+  inline: boolean,
   mode: Mode,
   roots: Array<Node>,
   disableWrap: boolean,
@@ -373,6 +374,7 @@ class ObjectInspector extends Component {
       autoExpandDepth = 1,
       autoExpandAll = true,
       disabledFocus,
+      inline,
       itemHeight = 20,
       disableWrap = false,
     } = this.props;
@@ -392,7 +394,10 @@ class ObjectInspector extends Component {
     }
 
     return Tree({
-      className: disableWrap ? "nowrap" : "",
+      className: classnames({
+        inline,
+        nowrap: disableWrap,
+      }),
       autoExpandAll,
       autoExpandDepth,
       disabledFocus,
@@ -422,6 +427,7 @@ ObjectInspector.propTypes = {
   autoExpandDepth: PropTypes.number,
   disabledFocus: PropTypes.bool,
   disableWrap: PropTypes.bool,
+  inline: PropTypes.bool,
   roots: PropTypes.array,
   getObjectProperties: PropTypes.func.isRequired,
   loadObjectProperties: PropTypes.func.isRequired,

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ObjectInspector - classnames has the expected class 1`] = `
+<ObjectInspector
+  autoExpandDepth={0}
+  getObjectProperties={[Function]}
+  loadObjectProperties={[Function]}
+  roots={
+    Array [
+      Object {
+        "contents": Object {
+          "value": 42,
+        },
+        "name": "root",
+        "path": "root",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`ObjectInspector - classnames has the inline class when inline prop is true 1`] = `
+<ObjectInspector
+  autoExpandDepth={0}
+  getObjectProperties={[Function]}
+  inline={true}
+  loadObjectProperties={[Function]}
+  roots={
+    Array [
+      Object {
+        "contents": Object {
+          "value": 42,
+        },
+        "name": "root",
+        "path": "root",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop is true 1`] = `
+<ObjectInspector
+  autoExpandDepth={0}
+  disableWrap={true}
+  getObjectProperties={[Function]}
+  loadObjectProperties={[Function]}
+  roots={
+    Array [
+      Object {
+        "contents": Object {
+          "value": 42,
+        },
+        "name": "root",
+        "path": "root",
+      },
+    ]
+  }
+/>
+`;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
@@ -1,60 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ObjectInspector - classnames has the expected class 1`] = `
-<ObjectInspector
-  autoExpandDepth={0}
-  getObjectProperties={[Function]}
-  loadObjectProperties={[Function]}
-  roots={
-    Array [
-      Object {
-        "contents": Object {
-          "value": 42,
-        },
-        "name": "root",
-        "path": "root",
-      },
-    ]
-  }
-/>
+"<ObjectInspector autoExpandDepth={0} roots={{...}} getObjectProperties={[Function]} loadObjectProperties={[Function]}>
+  <Tree className=\\"\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree \\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} style={{...}}>
+      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
+        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
+          <div className=\\"node object-node\\" style={{...}} onClick={{...}} onDoubleClick={{...}}>
+            <span className=\\"object-label\\" onClick={{...}}>
+              root
+            </span>
+            <span className=\\"object-delimiter\\">
+               : 
+            </span>
+            <span className=\\"objectBox objectBox-number\\">
+              42
+            </span>
+          </div>
+          <button style={{...}} />
+        </div>
+      </TreeNode>
+    </div>
+  </Tree>
+</ObjectInspector>"
 `;
 
 exports[`ObjectInspector - classnames has the inline class when inline prop is true 1`] = `
-<ObjectInspector
-  autoExpandDepth={0}
-  getObjectProperties={[Function]}
-  inline={true}
-  loadObjectProperties={[Function]}
-  roots={
-    Array [
-      Object {
-        "contents": Object {
-          "value": 42,
-        },
-        "name": "root",
-        "path": "root",
-      },
-    ]
-  }
-/>
+"<ObjectInspector autoExpandDepth={0} roots={{...}} getObjectProperties={[Function]} loadObjectProperties={[Function]} inline={true}>
+  <Tree className=\\"inline\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree inline\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} style={{...}}>
+      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
+        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
+          <div className=\\"node object-node\\" style={{...}} onClick={{...}} onDoubleClick={{...}}>
+            <span className=\\"object-label\\" onClick={{...}}>
+              root
+            </span>
+            <span className=\\"object-delimiter\\">
+               : 
+            </span>
+            <span className=\\"objectBox objectBox-number\\">
+              42
+            </span>
+          </div>
+          <button style={{...}} />
+        </div>
+      </TreeNode>
+    </div>
+  </Tree>
+</ObjectInspector>"
 `;
 
 exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop is true 1`] = `
-<ObjectInspector
-  autoExpandDepth={0}
-  disableWrap={true}
-  getObjectProperties={[Function]}
-  loadObjectProperties={[Function]}
-  roots={
-    Array [
-      Object {
-        "contents": Object {
-          "value": 42,
-        },
-        "name": "root",
-        "path": "root",
-      },
-    ]
-  }
-/>
+"<ObjectInspector autoExpandDepth={0} roots={{...}} getObjectProperties={[Function]} loadObjectProperties={[Function]} disableWrap={true}>
+  <Tree className=\\"nowrap\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree nowrap\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} style={{...}}>
+      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
+        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
+          <div className=\\"node object-node\\" style={{...}} onClick={{...}} onDoubleClick={{...}}>
+            <span className=\\"object-label\\" onClick={{...}}>
+              root
+            </span>
+            <span className=\\"object-delimiter\\">
+               : 
+            </span>
+            <span className=\\"objectBox objectBox-number\\">
+              42
+            </span>
+          </div>
+          <button style={{...}} />
+        </div>
+      </TreeNode>
+    </div>
+  </Tree>
+</ObjectInspector>"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/classnames.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/classnames.js
@@ -23,32 +23,29 @@ function generateDefaults(overrides) {
 describe("ObjectInspector - classnames", () => {
   it("has the expected class", () => {
     const props = generateDefaults();
-    const oi = ObjectInspector(props);
-    const wrapper = mount(oi);
+    const wrapper = mount(ObjectInspector(props));
 
     expect(wrapper.hasClass("tree")).toBeTruthy();
     expect(wrapper.hasClass("inline")).toBeFalsy();
     expect(wrapper.hasClass("nowrap")).toBeFalsy();
-    expect(oi).toMatchSnapshot();
+    expect(wrapper.debug()).toMatchSnapshot();
   });
 
   it("has the nowrap class when disableWrap prop is true", () => {
     const props = generateDefaults({
       disableWrap: true,
     });
-    const oi = ObjectInspector(props);
-    const wrapper = mount(oi);
+    const wrapper = mount(ObjectInspector(props));
     expect(wrapper.hasClass("nowrap")).toBeTruthy();
-    expect(oi).toMatchSnapshot();
+    expect(wrapper.debug()).toMatchSnapshot();
   });
 
   it("has the inline class when inline prop is true", () => {
     const props = generateDefaults({
       inline: true,
     });
-    const oi = ObjectInspector(props);
-    const wrapper = mount(oi);
+    const wrapper = mount(ObjectInspector(props));
     expect(wrapper.hasClass("inline")).toBeTruthy();
-    expect(oi).toMatchSnapshot();
+    expect(wrapper.debug()).toMatchSnapshot();
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/component/classnames.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/classnames.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { mount } = require("enzyme");
+const React = require("react");
+const { createFactory } = React;
+const ObjectInspector = createFactory(require("../../index"));
+
+function generateDefaults(overrides) {
+  return Object.assign({
+    autoExpandDepth: 0,
+    roots: [{
+      path: "root",
+      name: "root",
+      contents: {value: 42}
+    }],
+    getObjectProperties: () => {},
+    loadObjectProperties: () => {},
+  }, overrides);
+}
+
+describe("ObjectInspector - classnames", () => {
+  it("has the expected class", () => {
+    const props = generateDefaults();
+    const oi = ObjectInspector(props);
+    const wrapper = mount(oi);
+
+    expect(wrapper.hasClass("tree")).toBeTruthy();
+    expect(wrapper.hasClass("inline")).toBeFalsy();
+    expect(wrapper.hasClass("nowrap")).toBeFalsy();
+    expect(oi).toMatchSnapshot();
+  });
+
+  it("has the nowrap class when disableWrap prop is true", () => {
+    const props = generateDefaults({
+      disableWrap: true,
+    });
+    const oi = ObjectInspector(props);
+    const wrapper = mount(oi);
+    expect(wrapper.hasClass("nowrap")).toBeTruthy();
+    expect(oi).toMatchSnapshot();
+  });
+
+  it("has the inline class when inline prop is true", () => {
+    const props = generateDefaults({
+      inline: true,
+    });
+    const oi = ObjectInspector(props);
+    const wrapper = mount(oi);
+    expect(wrapper.hasClass("inline")).toBeTruthy();
+    expect(oi).toMatchSnapshot();
+  });
+});

--- a/packages/devtools-reps/yarn.lock
+++ b/packages/devtools-reps/yarn.lock
@@ -242,10 +242,6 @@ async@^2.1.2, async@^2.1.4, async@^2.4.1:
   dependencies:
     lodash "^4.14.0"
 
-async@~0.2.6:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1490,9 +1486,9 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-devtools-components@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/devtools-components/-/devtools-components-0.0.1.tgz#b81c05235667ce6fa07e0ae51f593cd73e709fb6"
+devtools-components@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/devtools-components/-/devtools-components-0.0.2.tgz#4eb22cb5140e65741b00b79a7f76454ff56fa501"
 
 devtools-config@^0.0.15:
   version "0.0.15"
@@ -1682,11 +1678,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.2.7:
-  version "1.3.14"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz#64af0f9efd3c3c6acd57d71f83b49ca7ee9c4b43"
-
-electron-to-chromium@^1.3.16:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.16:
   version "1.3.16"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz#d0e026735754770901ae301a21664cba45d92f7d"
 
@@ -2565,11 +2557,11 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-iconv-lite@0.4.13, iconv-lite@~0.4.13:
+iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@0.4.15:
+iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -4512,15 +4504,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.2.tgz#5c4fea589f0ac3b00caa75b1cbc3a284195b7e5d"
-  dependencies:
-    chalk "^1.1.3"
-    source-map "^0.5.6"
-    supports-color "^3.2.3"
-
-postcss@^6.0.2, postcss@^6.0.6:
+postcss@^6.0.1, postcss@^6.0.2, postcss@^6.0.6:
   version "6.0.8"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.8.tgz#89067a9ce8b11f8a84cbc5117efc30419a0857b3"
   dependencies:
@@ -5556,16 +5540,7 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.6:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
-  dependencies:
-    async "~0.2.6"
-    source-map "~0.5.1"
-    uglify-to-browserify "~1.0.0"
-    yargs "~3.10.0"
-
-uglify-js@^2.8.27, uglify-js@^2.8.29:
+uglify-js@^2.6, uglify-js@^2.8.27, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
This adds an `inline` class to the tree which display the tree as `inline-block`, which might be useful for some consumer (e.g. the console where you can have multiple ObjectInspectors side by side; even if for now we are using flexbox to lay out them).
This changes needed devtools-components 0.0.2 for the Tree component to handle the classname override.

Also, this was a good opportunity to add tests for the class names in the object inspector.