### PR TITLE
Handle Proxy target and handler in ObjectInspector.

### DIFF
--- a/packages/devtools-reps/src/launchpad/samples.js
+++ b/packages/devtools-reps/src/launchpad/samples.js
@@ -111,6 +111,17 @@ let samples = {
     "new Promise(() => {})"
   ],
 
+  proxy: [`
+    var handler = {
+        get: function(target, name) {
+            return name in target ?
+                target[name] :
+                37;
+        }
+    };
+    new Proxy({a: 1}, handler);
+  `],
+
   regexp: [
     "new RegExp('^[-]?[0-9]+[\.]?[0-9]+$')"
   ],

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ObjectInspector - Proxy renders Proxy as expected 1`] = `
+"<ObjectInspector roots={{...}} autoExpandDepth={1} mode={[symbol]} getObjectProperties={[Function]} loadObjectProperties={[Function]}>
+  <Tree className=\\"\\" autoExpandAll={true} autoExpandDepth={1} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree \\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} style={{...}}>
+      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={true} hasChildren={true} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
+        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
+          <div className=\\"node object-node\\" style={{...}} onClick={[Function]} onDoubleClick={{...}}>
+            <InlineSVG className=\\"arrow expanded\\" src=\\"<svg></svg>\\" element=\\"i\\" raw={false}>
+              <i className=\\"arrow expanded\\" src={{...}} dangerouslySetInnerHTML={{...}} />
+            </InlineSVG>
+            <span data-link-actor-id=\\"server1.conn1.child1/obj47\\" className=\\"objectBox objectBox-object\\">
+              <span className=\\"objectTitle\\">
+                Proxy
+              </span>
+              <span className=\\"objectLeftBrace\\">
+                 { 
+              </span>
+              <span className=\\"nodeName\\">
+                &lt;target&gt;
+              </span>
+              <span className=\\"objectEqual\\">
+                : 
+              </span>
+              <span data-link-actor-id=\\"server1.conn1.child1/obj48\\" className=\\"objectBox objectBox-object\\">
+                <span className=\\"objectLeftBrace\\">
+                  {
+                </span>
+                <span className=\\"more-ellipsis\\" title=\\"more…\\">
+                  …
+                </span>
+                <span className=\\"objectRightBrace\\">
+                  }
+                </span>
+              </span>
+              , 
+              <span className=\\"nodeName\\">
+                &lt;handler&gt;
+              </span>
+              <span className=\\"objectEqual\\">
+                : 
+              </span>
+              <span data-link-actor-id=\\"server1.conn1.child1/obj49\\" className=\\"objectBox objectBox-array\\">
+                <span className=\\"arrayLeftBracket\\">
+                  [
+                </span>
+                <span className=\\"more-ellipsis\\" title=\\"more…\\">
+                  …
+                </span>
+                <span className=\\"arrayRightBracket\\">
+                  ]
+                </span>
+                <span className=\\"arrayProperties\\" role=\\"group\\" />
+              </span>
+              <span className=\\"objectRightBrace\\">
+                 }
+              </span>
+            </span>
+          </div>
+          <button style={{...}} />
+        </div>
+      </TreeNode>
+      <TreeNode index={1} item={{...}} depth={1} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
+        <div className=\\"tree-node div tree-node-odd\\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
+          <div className=\\"node object-node\\" style={{...}} onClick={[Function]} onDoubleClick={{...}}>
+            <InlineSVG className=\\"arrow\\" src=\\"<svg></svg>\\" element=\\"i\\" raw={false}>
+              <i className=\\"arrow\\" src={{...}} dangerouslySetInnerHTML={{...}} />
+            </InlineSVG>
+            <span className=\\"object-label\\" onClick={{...}}>
+              &lt;target&gt;
+            </span>
+            <span className=\\"object-delimiter\\">
+               : 
+            </span>
+            <span data-link-actor-id=\\"server1.conn1.child1/obj48\\" className=\\"objectBox objectBox-object\\">
+              <span className=\\"objectTitle\\">
+                Object
+              </span>
+              <span className=\\"objectLeftBrace\\">
+                 { 
+              </span>
+              <span className=\\"more-ellipsis\\" title=\\"more…\\">
+                …
+              </span>
+              <span className=\\"objectRightBrace\\">
+                 }
+              </span>
+            </span>
+          </div>
+          <button style={{...}} />
+        </div>
+      </TreeNode>
+      <TreeNode index={2} item={{...}} depth={1} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
+        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
+          <div className=\\"node object-node\\" style={{...}} onClick={[Function]} onDoubleClick={{...}}>
+            <InlineSVG className=\\"arrow\\" src=\\"<svg></svg>\\" element=\\"i\\" raw={false}>
+              <i className=\\"arrow\\" src={{...}} dangerouslySetInnerHTML={{...}} />
+            </InlineSVG>
+            <span className=\\"object-label\\" onClick={{...}}>
+              &lt;handler&gt;
+            </span>
+            <span className=\\"object-delimiter\\">
+               : 
+            </span>
+            <span data-link-actor-id=\\"server1.conn1.child1/obj49\\" className=\\"objectBox objectBox-array\\">
+              <span className=\\"objectTitle\\">
+                Array 
+              </span>
+              <span className=\\"arrayLeftBracket\\">
+                [ 
+              </span>
+              <span className=\\"more-ellipsis\\" title=\\"more…\\">
+                …
+              </span>
+              <span className=\\"arrayRightBracket\\">
+                 ]
+              </span>
+              <span className=\\"arrayProperties\\" role=\\"group\\" />
+            </span>
+          </div>
+          <button style={{...}} />
+        </div>
+      </TreeNode>
+    </div>
+  </Tree>
+</ObjectInspector>"
+`;

--- a/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ /* global jest */
+
+const { mount } = require("enzyme");
+const React = require("react");
+const { createFactory } = React;
+const ObjectInspector = createFactory(require("../../index"));
+const { MODE } = require("../../../reps/constants");
+const stub = require("../../../reps/stubs/grip").get("testProxy");
+
+function generateDefaults(overrides) {
+  return Object.assign({
+    roots: [{
+      path: "root",
+      contents: {value: stub}
+    }],
+    autoExpandDepth: 1,
+    mode: MODE.LONG,
+    getObjectProperties: actor => null,
+  }, overrides);
+}
+
+describe("ObjectInspector - Proxy", () => {
+  it("renders Proxy as expected", () => {
+    const loadObjectProperties = jest.fn();
+
+    const props = generateDefaults({
+      loadObjectProperties,
+    });
+    const oi = mount(ObjectInspector(props));
+    expect(oi.debug()).toMatchSnapshot();
+
+    const nodes = oi.find(".node");
+    /*
+     * The OI should look like:
+     * ▶︎ Proxy
+     *   ▶︎ <target> : Object { … }
+     *   ▶︎ <handler> : Array [ … ]
+     */
+    expect(nodes.length).toBe(3);
+
+    // The root should be expandable.
+    const rootNode = nodes.first();
+    expect(rootNode.find(".arrow").exists()).toBeTruthy();
+    expect(rootNode.text()).toMatch(/^Proxy/);
+
+    const targetNode = nodes.at(1);
+    expect(targetNode.find(".arrow").exists()).toBeTruthy();
+    expect(targetNode.text()).toBe("<target> : Object { … }");
+
+    const handlerNode = nodes.at(2);
+    expect(handlerNode.find(".arrow").exists()).toBeTruthy();
+    expect(handlerNode.text()).toBe("<handler> : Array [ … ]");
+
+    // loadObjectProperties should not have been called.
+    expect(loadObjectProperties.mock.calls.length).toBe(0);
+  });
+
+  it("calls loadObjectProperties when <target> and <handler> nodes are clicked", () => {
+    const loadObjectProperties = jest.fn();
+
+    const props = generateDefaults({
+      loadObjectProperties,
+    });
+    const oi = mount(ObjectInspector(props));
+    const nodes = oi.find(".node");
+
+    const targetNode = nodes.at(1);
+    targetNode.simulate("click");
+    expect(loadObjectProperties.mock.calls.length).toBe(1);
+    expect(loadObjectProperties).toHaveBeenCalledWith(stub.proxyTarget);
+
+    const handlerNode = nodes.at(2);
+    handlerNode.simulate("click");
+
+    expect(loadObjectProperties.mock.calls.length).toBe(2);
+    expect(loadObjectProperties).toHaveBeenCalledWith(stub.proxyHandler);
+  });
+});

--- a/packages/devtools-reps/src/object-inspector/tests/utils/get-children.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/get-children.js
@@ -6,6 +6,7 @@
 const accessorStubs = require("../../../reps/stubs/accessor");
 const performanceStubs = require("../../stubs/performance");
 const gripMapStubs = require("../../../reps/stubs/grip-map");
+const gripStubs = require("../../../reps/stubs/grip");
 
 const {
   createNode,
@@ -51,6 +52,19 @@ describe("getChildren", () => {
     expect(names).toEqual(["<get>", "<set>"]);
     expect(paths).toEqual(
       [`rootpath/${SAFE_PATH_PREFIX}get`, `rootpath/${SAFE_PATH_PREFIX}set`]);
+  });
+
+  it("returns the expected nodes for Proxy", () => {
+    const nodes = getChildren({
+      item: createNode(null, "root", "rootpath", { value: gripStubs.get("testProxy")})
+    });
+
+    const names = nodes.map(n => n.name);
+    const paths = nodes.map(n => n.path);
+
+    expect(names).toEqual(["<target>", "<handler>"]);
+    expect(paths).toEqual(
+      [`rootpath/${SAFE_PATH_PREFIX}target`, `rootpath/${SAFE_PATH_PREFIX}handler`]);
   });
 
   it("uses the expected actor to get properties", () => {


### PR DESCRIPTION
Previously, when the user expanded a Proxy object, we loaded the properties
of the target, which is only half the information the user might want to see.
Now we build 2 ndoes, target and handler, that can be expanded as well so
the user can inspect the Proxy object properly.
Some tests were added to make sure we handle proxies as expected, and the
setExpanded function was refactored a bit to be more readable.