### PR TITLE
Replace the simplified prop check with TINY mode.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -251,12 +251,16 @@ class ObjectInspector extends Component {
       objectValue = dom.span({ className: "unavailable" }, "(optimized away)");
     } else if (nodeIsMissingArguments(item) || unavailable) {
       objectValue = dom.span({ className: "unavailable" }, "(unavailable)");
-    } else if (nodeIsFunction(item) && !nodeIsGetter(item) && !nodeIsSetter(item)) {
+    } else if (
+      nodeIsFunction(item)
+      && !nodeIsGetter(item)
+      && !nodeIsSetter(item)
+      && this.props.mode === MODE.TINY
+    ) {
       objectValue = undefined;
       label = this.renderGrip(
         item,
         Object.assign({}, this.props, {
-          simplified: depth !== 0,
           functionName: label
         })
       );

--- a/packages/devtools-reps/src/object-inspector/tests/component/function.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/function.js
@@ -10,11 +10,19 @@ const { MODE } = require("../../../reps/constants");
 
 const functionStubs = require("../../../reps/stubs/function");
 
+function generateDefaults(overrides) {
+  return Object.assign({
+    autoExpandDepth: 1,
+    getObjectProperties: () => {},
+    loadObjectProperties: () => {},
+    mode: MODE.TINY,
+  }, overrides);
+}
+
 describe("ObjectInspector - functions", () => {
   it("renders named function properties as expected", () => {
     const stub = functionStubs.get("Named");
-    const oi = mount(ObjectInspector({
-      autoExpandDepth: 1,
+    const oi = mount(ObjectInspector(generateDefaults({
       roots: [{
         path: "root",
         name: "x",
@@ -24,10 +32,7 @@ describe("ObjectInspector - functions", () => {
           contents: {value: stub}
         }]
       }],
-      getObjectProperties: () => {},
-      loadObjectProperties: () => {},
-      mode: MODE.LONG,
-    }));
+    })));
 
     const nodes = oi.find(".node");
 
@@ -37,8 +42,7 @@ describe("ObjectInspector - functions", () => {
 
   it("renders anon function properties as expected", () => {
     const stub = functionStubs.get("Anon");
-    const oi = mount(ObjectInspector({
-      autoExpandDepth: 1,
+    const oi = mount(ObjectInspector(generateDefaults({
       roots: [{
         path: "root",
         name: "x",
@@ -48,10 +52,7 @@ describe("ObjectInspector - functions", () => {
           contents: {value: stub}
         }]
       }],
-      getObjectProperties: () => {},
-      loadObjectProperties: () => {},
-      mode: MODE.LONG,
-    }));
+    })));
 
     const nodes = oi.find(".node");
 
@@ -60,24 +61,21 @@ describe("ObjectInspector - functions", () => {
     expect(functionNode.text()).toBe("fn()");
   });
 
-  it("renders top-level functions as expected", () => {
+  it("renders non-TINY mode functions as expected", () => {
     const stub = functionStubs.get("Named");
-    const oi = mount(ObjectInspector({
-      autoExpandDepth: 1,
+    const oi = mount(ObjectInspector(generateDefaults({
       roots: [{
         path: "root",
         name: "x",
         contents: {value: stub}
       }],
-      getObjectProperties: () => {},
-      loadObjectProperties: () => {},
       mode: MODE.LONG,
-    }));
+    })));
 
     const nodes = oi.find(".node");
 
     const functionNode = nodes.first();
     // It should have the name of the property.
-    expect(functionNode.text()).toBe("function testName()");
+    expect(functionNode.text()).toBe("x : function testName()");
   });
 });

--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -12,6 +12,7 @@ const {
   cropString,
   wrapRender,
 } = require("./rep-utils");
+const { MODE } = require("./constants");
 
 // Shortcuts
 const { span } = React.DOM;
@@ -35,7 +36,7 @@ function FunctionRep(props) {
       // appearing in the wrong direction
       dir: "ltr",
     },
-      getTitle(props, grip),
+      getTitle(grip, props),
       getFunctionName(grip, props),
       "(",
       ...renderParams(props),
@@ -44,21 +45,21 @@ function FunctionRep(props) {
   );
 }
 
-function getTitle(props, grip) {
+function getTitle(grip, props) {
   const {
-    simplified
+    mode
   } = props;
 
-  if (simplified === true && !grip.isGenerator && !grip.isAsync) {
+  if (mode === MODE.TINY && !grip.isGenerator && !grip.isAsync) {
     return null;
   }
 
-  let title = simplified === true
+  let title = mode === MODE.TINY
     ? ""
     : "function ";
 
   if (grip.isGenerator) {
-    title = simplified === true
+    title = mode === MODE.TINY
       ? "* "
       : "function* ";
   }

--- a/packages/devtools-reps/src/reps/tests/function.js
+++ b/packages/devtools-reps/src/reps/tests/function.js
@@ -28,10 +28,10 @@ describe("Function - Named", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("function testName(a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
     }).text()).toBe("testName()");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("testName(a, b, c)");
 
@@ -53,10 +53,10 @@ describe("Function - User named", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("function testUserName(a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
     }).text()).toBe("testUserName()");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("testUserName(a, b, c)");
   });
@@ -76,10 +76,10 @@ describe("Function - Var named", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("function testVarName(a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
     }).text()).toBe("testVarName()");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("testVarName(a, b, c)");
   });
@@ -99,10 +99,10 @@ describe("Function - Anonymous", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("function (a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
     }).text()).toBe("()");
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("(a, b, c)");
   });
@@ -125,10 +125,10 @@ describe("Function - Long name", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe(`function ${functionName}(a, b, c)`);
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
     }).text()).toBe(`${functionName}()`);
     expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe(`${functionName}(a, b, c)`);
   });
@@ -141,7 +141,7 @@ describe("Function - Async function", () => {
     expect(renderRep(object, { mode: undefined }).text())
       .toBe("async function waitUntil2017()");
     expect(renderRep(object, { mode: MODE.TINY }).text())
-      .toBe("async function waitUntil2017()");
+      .toBe("async waitUntil2017()");
     expect(renderRep(object, { mode: MODE.SHORT }).text())
       .toBe("async function waitUntil2017()");
     expect(renderRep(object, { mode: MODE.LONG }).text())
@@ -153,10 +153,7 @@ describe("Function - Async function", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("async function waitUntil2017(a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
-    }).text()).toBe("async waitUntil2017()");
-    expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("async waitUntil2017(a, b, c)");
   });
@@ -169,7 +166,7 @@ describe("Function - Anonymous async function", () => {
     expect(renderRep(object, { mode: undefined }).text())
       .toBe("async function ()");
     expect(renderRep(object, { mode: MODE.TINY }).text())
-      .toBe("async function ()");
+      .toBe("async ()");
     expect(renderRep(object, { mode: MODE.SHORT }).text())
       .toBe("async function ()");
     expect(renderRep(object, { mode: MODE.LONG }).text())
@@ -181,10 +178,7 @@ describe("Function - Anonymous async function", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("async function (a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
-    }).text()).toBe("async ()");
-    expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("async (a, b, c)");
   });
@@ -197,7 +191,7 @@ describe("Function - Generator function", () => {
     expect(renderRep(object, { mode: undefined }).text())
       .toBe("function* fib()");
     expect(renderRep(object, { mode: MODE.TINY }).text())
-      .toBe("function* fib()");
+      .toBe("* fib()");
     expect(renderRep(object, { mode: MODE.SHORT }).text())
       .toBe("function* fib()");
     expect(renderRep(object, { mode: MODE.LONG }).text())
@@ -209,10 +203,7 @@ describe("Function - Generator function", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("function* fib(a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
-    }).text()).toBe("* fib()");
-    expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("* fib(a, b, c)");
   });
@@ -225,7 +216,7 @@ describe("Function - Anonymous generator function", () => {
     expect(renderRep(object, { mode: undefined }).text())
       .toBe("function* ()");
     expect(renderRep(object, { mode: MODE.TINY }).text())
-      .toBe("function* ()");
+      .toBe("* ()");
     expect(renderRep(object, { mode: MODE.SHORT }).text())
       .toBe("function* ()");
     expect(renderRep(object, { mode: MODE.LONG }).text())
@@ -237,10 +228,7 @@ describe("Function - Anonymous generator function", () => {
     expect(renderRep(object, { parameterNames: ["a", "b", "c"] }).text())
       .toBe("function* (a, b, c)");
     expect(renderRep(object, {
-      simplified: true,
-    }).text()).toBe("* ()");
-    expect(renderRep(object, {
-      simplified: true,
+      mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("* (a, b, c)");
   });

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -495,7 +495,7 @@ describe("Grip - Object with symbol properties", () => {
     expect(renderRep({ mode: MODE.LONG }).text())
       .toBe(`Object { x: 10, Symbol(): "first unnamed symbol", ` +
             `Symbol(): "second unnamed symbol", Symbol(named): "named symbol", ` +
-            `Symbol(Symbol.iterator): function () }`);
+            `Symbol(Symbol.iterator): () }`);
   });
 });
 


### PR DESCRIPTION
We introduced a simplified prop to functions in order to not display the function keyword on some object.
This seems to be redundant with the concept of mode. So here we drop the prop, and do the same check with the TINY mode.