### PR TITLE
Fix function render.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -255,7 +255,10 @@ class ObjectInspector extends Component {
       nodeIsFunction(item)
       && !nodeIsGetter(item)
       && !nodeIsSetter(item)
-      && this.props.mode === MODE.TINY
+      && (
+        this.props.mode === MODE.TINY
+        || !this.props.mode
+      )
     ) {
       objectValue = undefined;
       label = this.renderGrip(

--- a/packages/devtools-reps/src/object-inspector/tests/component/function.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/function.js
@@ -15,7 +15,6 @@ function generateDefaults(overrides) {
     autoExpandDepth: 1,
     getObjectProperties: () => {},
     loadObjectProperties: () => {},
-    mode: MODE.TINY,
   }, overrides);
 }
 


### PR DESCRIPTION
There were a bug when the mode was not defined.
We default to TINY mode in such case, but we didn't
handled that case for function render.