### PR TITLE
Update lanuchpad config

### DIFF
--- a/packages/devtools-launchpad/webpack.config.devtools.js
+++ b/packages/devtools-launchpad/webpack.config.devtools.js
@@ -5,8 +5,6 @@ const { NormalModuleReplacementPlugin } = webpack;
 const { DefinePlugin } = webpack;
 
 const nativeMapping = {
-  "./src/source-editor": "devtools/client/sourceeditor/editor",
-  "./test-flag": "devtools/shared/flags",
   react: "devtools/client/shared/vendor/react",
   "react-dom": "devtools/client/shared/vendor/react-dom",
 };
@@ -14,7 +12,7 @@ const nativeMapping = {
 const rootDir = path.join(__dirname, "../..");
 const outputPath = process.env.OUTPUT_PATH;
 
-module.exports = (webpackConfig, envConfig) => {
+module.exports = (webpackConfig, envConfig, options) => {
   if (outputPath) {
     webpackConfig.output.path = outputPath;
   }
@@ -31,8 +29,9 @@ module.exports = (webpackConfig, envConfig) => {
     }
 
     // Any matching paths here won't be included in the bundle.
-    if (nativeMapping[mod]) {
-      const mapping = nativeMapping[mod];
+    const excludeMap = (options && options.excludeMap) || nativeMapping;
+    if (excludeMap[mod]) {
+      const mapping = excludeMap[mod];
 
       if (webpackConfig.externalsRequire) {
         // If the tool defines "externalsRequire" in the webpack config, wrap

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -12,7 +12,7 @@ const defaultBabelPlugins = [
   "transform-async-to-generator"
 ];
 
-module.exports = (webpackConfig, envConfig) => {
+module.exports = (webpackConfig, envConfig, options) => {
   setConfig(envConfig);
 
   webpackConfig.context = path.resolve(__dirname, "src");
@@ -126,14 +126,6 @@ module.exports = (webpackConfig, envConfig) => {
         fallback: "style-loader",
         use: [
           { loader: "css-loader", options: { importLoaders: 1 } },
-          {
-            loader: "postcss-loader",
-            options: {
-              config: {
-                path: path.resolve(__dirname, "postcss.config.js")
-              }
-            }
-          }
         ]
       })
     });
@@ -142,7 +134,7 @@ module.exports = (webpackConfig, envConfig) => {
   }
 
   if (isFirefoxPanel()) {
-    webpackConfig = require("./webpack.config.devtools")(webpackConfig, envConfig);
+    webpackConfig = require("./webpack.config.devtools")(webpackConfig, envConfig, options);
   }
 
   // NOTE: This is only needed to fix a bug with chrome devtools' debugger and

--- a/packages/devtools-source-editor/examples/index.js
+++ b/packages/devtools-source-editor/examples/index.js
@@ -5,7 +5,7 @@
 const SourceEditor = require("../src/source-editor");
 
 require("devtools-launchpad/src/lib/themes/light-theme.css");
-require("devtools-launchpad/src/lib/themes/dark-theme.css");
+require("devtools-modules/src/themes/dark-theme.css");
 require("devtools-launchpad/src/lib/themes/firebug-theme.css");
 require("./index.css");
 require("../src/source-editor.css");

--- a/packages/devtools-source-editor/examples/index.js
+++ b/packages/devtools-source-editor/examples/index.js
@@ -4,9 +4,9 @@
 
 const SourceEditor = require("../src/source-editor");
 
-require("devtools-launchpad/src/lib/themes/light-theme.css");
+require("devtools-modules/src/themes/light-theme.css");
 require("devtools-modules/src/themes/dark-theme.css");
-require("devtools-launchpad/src/lib/themes/firebug-theme.css");
+require("devtools-modules/src/themes/firebug-theme.css");
 require("./index.css");
 require("../src/source-editor.css");
 


### PR DESCRIPTION
* add an extra `options` option for passing exclude mappings so the debugger can decide what to exclude
* drop postcss from production builds. we don't want to add prefixes or drop `inline-start` props