### PR TITLE
Sync changes from m-c in devtools-connection

### DIFF
--- a/packages/devtools-connection/src/debugger/client.js
+++ b/packages/devtools-connection/src/debugger/client.js
@@ -2750,6 +2750,30 @@ ObjectClient.prototype = {
   ),
 
   /**
+   * Request a SymbolIteratorClient instance to enumerate symbols in an object.
+   *
+   * @param onResponse function Called with the request's response.
+   */
+  enumSymbols: DebuggerClient.requester({
+    type: "enumSymbols"
+  }, {
+    before: function (packet) {
+      if (this._grip.type !== "object") {
+        throw new Error("enumSymbols is only valid for objects grips.");
+      }
+      return packet;
+    },
+    after: function (response) {
+      if (response.iterator) {
+        return {
+          iterator: new SymbolIteratorClient(this._client, response.iterator)
+        };
+      }
+      return response;
+    }
+  }),
+
+  /**
    * Request the property descriptor of the object's specified property.
    *
    * @param aName string The name of the requested property.
@@ -2969,6 +2993,61 @@ PropertyIteratorClient.prototype = {
     },
     {},
   ),
+};
+
+/**
+ * A SymbolIteratorClient provides a way to access to symbols
+ * of an object efficiently, slice by slice.
+ *
+ * @param client DebuggerClient
+ *        The debugger client parent.
+ * @param grip Object
+ *        A SymbolIteratorActor grip returned by the protocol via
+ *        TabActor.enumSymbols request.
+ */
+function SymbolIteratorClient(client, grip) {
+  this._grip = grip;
+  this._client = client;
+  this.request = this._client.request;
+}
+
+SymbolIteratorClient.prototype = {
+  get actor() {
+    return this._grip.actor;
+  },
+
+  /**
+   * Get the total number of symbols available in the iterator.
+   */
+  get count() {
+    return this._grip.count;
+  },
+
+  /**
+   * Get a set of following symbols.
+   *
+   * @param start Number
+   *        The index of the first symbol to fetch.
+   * @param count Number
+   *        The number of symbols to fetch.
+   * @param callback Function
+   *        The function called when we receive the symbols.
+   */
+  slice: DebuggerClient.requester({
+    type: "slice",
+    start: args(0),
+    count: args(1)
+  }, {}),
+
+  /**
+   * Get all the symbols.
+   *
+   * @param callback Function
+   *        The function called when we receive the symbols.
+   */
+  all: DebuggerClient.requester({
+    type: "all"
+  }, {}),
 };
 
 /**


### PR DESCRIPTION
**Add ObjectClient.enumSymbols function**

This feature was introduced in [Bug 1392614](https://bugzilla.mozilla.org/show_bug.cgi\?id\=1392614).
Here, we only add the ObjectClient part so we can use it in the launchpad.

**Sync fix from [Bug 1392954](https://bugzilla.mozilla.org/show_bug.cgi%5C?id%5C=1392954)**

Basically this allow us to use plain promises when working with ObjectClient functions


