### PR TITLE
Add formatting for stack trace

### DIFF
--- a/packages/devtools-reps/src/reps/error.js
+++ b/packages/devtools-reps/src/reps/error.js
@@ -36,18 +36,116 @@ function ErrorRep(props) {
     : `${name}: ${preview.message}`;
 
   if (preview.stack && props.mode !== MODE.TINY) {
+    let formattedStack = formatTrace(parseStack(preview.stack));
     /*
       * Since Reps are used in the JSON Viewer, we can't localize
       * the "Stack trace" label (defined in debugger.properties as
       * "variablesViewErrorStacktrace" property), until Bug 1317038 lands.
       */
-    content = `${content}\nStack trace:\n${preview.stack}`;
+    content = `${content}\nStack trace:\n${formattedStack}`;
   }
 
   return span({
     "data-link-actor-id": object.actor,
     className: "objectBox-stackTrace"
   }, content);
+}
+
+/**
+ * String utility to ensure that strings are a specified length. Strings
+ * that are too long are truncated to the max length and the last char is
+ * set to "_". Strings that are too short are padded with spaces.
+ *
+ * @param {string} str
+ *        The string to format to the correct length
+ * @param {number} maxLen
+ *        The maximum allowed length of the returned string
+ * @param {number} minLen (optional)
+ *        The minimum allowed length of the returned string. If undefined,
+ *        then maxLen will be used
+ * @param {object} options (optional)
+ *        An object allowing format customization. Allowed customizations:
+ *          'truncate' - can take the value "start" to truncate strings from
+ *             the start as opposed to the end or "center" to truncate
+ *             strings in the center.
+ *          'align' - takes an alignment when padding is needed for MinLen,
+ *             either "start" or "end".  Defaults to "start".
+ * @return {string}
+ *        The original string formatted to fit the specified lengths
+ */
+function fmt(str, maxLen, minLen, options) {
+  if (minLen == null) {
+    minLen = maxLen;
+  }
+  if (str == null) {
+    str = "";
+  }
+  if (str.length > maxLen) {
+    if (options && options.truncate == "start") {
+      return "_" + str.substring(str.length - maxLen + 1);
+    } else if (options && options.truncate == "center") {
+      let start = str.substring(0, (maxLen / 2));
+
+      let end = str.substring((str.length - (maxLen / 2)) + 1);
+      return start + "_" + end;
+    }
+    return str.substring(0, maxLen - 1) + "_";
+  }
+  if (str.length < minLen && options) {
+    let padding = Array(minLen - str.length + 1).join(" ");
+    str = (options.align === "end") ? padding + str : str + padding;
+  }
+  return str;
+}
+
+/**
+ * Parse a stack trace, returning an array of stack frame objects, where
+ * each has filename/lineNumber/functionName members
+ *
+ * @param {string} stack
+ *        The serialized stack trace
+ * @return {object[]}
+ *        Array of { functionName: "...", lineNumber: NNN, ... } objects
+ */
+function parseStack(stack) {
+  let trace = [];
+  stack.split("\n").forEach((line) => {
+    if (!line) {
+      return;
+    }
+
+    const parsedStack = line.match(/(.*)?@(.*):(\d+):(\d+)/);
+
+    trace.push({
+      functionName: parsedStack[1],
+      location: parsedStack[2],
+      lineNumber: parsedStack[3],
+      columnNumber: parsedStack[4]
+    });
+  });
+
+  return trace;
+}
+
+/**
+ * Take the output from parseStack() and convert it to nice readable
+ * output
+ *
+ * @param {object[]} trace
+ *        Array of trace objects as created by parseStack()
+ * @return {string} Multi line report of the stack trace
+ */
+function formatTrace(trace) {
+  let result = "";
+
+  trace.forEach((line) => {
+    result += (fmt(line.functionName, 75, 0, { truncate: "center" }) + " @ " +
+               fmt(line.location, 20, 20, { truncate: "start" }) + " " +
+               fmt(line.lineNumber, 5, 5) + " : " +
+               fmt(line.columnNumber, 5, 5)).trim() + "\n";
+  });
+
+  return result;
 }
 
 // Registration

--- a/packages/devtools-reps/src/reps/tests/error.js
+++ b/packages/devtools-reps/src/reps/tests/error.js
@@ -32,7 +32,7 @@ describe("Error - Simple error", () => {
     expect(renderedComponent.text()).toEqual(
       "Error: Error message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:1:13\n"
+      "@ debugger eval code   1 : 13\n"
     );
     expectActorAttribute(renderedComponent, stub.actor);
   });
@@ -72,9 +72,9 @@ describe("Error - Multi line stack error", () => {
     expect(renderedComponent.text()).toEqual(
       "Error: bar\n" +
       "Stack trace:\n" +
-      "errorBar@debugger eval code:6:15\n" +
-      "errorFoo@debugger eval code:3:3\n" +
-      "@debugger eval code:8:1\n"
+      "errorBar @ debugger eval code   6 : 15\n" +
+      "errorFoo @ debugger eval code   3 : 3\n" +
+      "@ debugger eval code   8 : 1\n"
     );
   });
 
@@ -129,7 +129,7 @@ describe("Error - Eval error", () => {
     expect(renderedComponent.text()).toEqual(
       "EvalError: EvalError message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:10:13\n"
+      "@ debugger eval code   10 : 13\n"
     );
   });
 
@@ -159,7 +159,7 @@ describe("Error - Internal error", () => {
     expect(renderedComponent.text()).toEqual(
       "InternalError: InternalError message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:11:13\n"
+      "@ debugger eval code   11 : 13\n"
     );
   });
 
@@ -189,7 +189,7 @@ describe("Error - Range error", () => {
     expect(renderedComponent.text()).toEqual(
       "RangeError: RangeError message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:12:13\n"
+      "@ debugger eval code   12 : 13\n"
     );
   });
 
@@ -219,7 +219,7 @@ describe("Error - Reference error", () => {
     expect(renderedComponent.text()).toEqual(
       "ReferenceError: ReferenceError message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:13:13\n"
+      "@ debugger eval code   13 : 13\n"
     );
   });
 
@@ -249,7 +249,7 @@ describe("Error - Syntax error", () => {
     expect(renderedComponent.text()).toEqual(
       "SyntaxError: SyntaxError message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:14:13\n"
+      "@ debugger eval code   14 : 13\n"
     );
   });
 
@@ -279,7 +279,7 @@ describe("Error - Type error", () => {
     expect(renderedComponent.text()).toEqual(
       "TypeError: TypeError message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:15:13\n"
+      "@ debugger eval code   15 : 13\n"
     );
   });
 
@@ -309,7 +309,7 @@ describe("Error - URI error", () => {
     expect(renderedComponent.text()).toEqual(
       "URIError: URIError message\n" +
       "Stack trace:\n" +
-      "@debugger eval code:16:13\n"
+      "@ debugger eval code   16 : 13\n"
     );
   });
 


### PR DESCRIPTION
Not sure if this is what you expected for #448, but here I give it a try.

Associated Issue: #448 

### Summary of Changes

* Import `fmt` from m-c
* Implement `parseStack` using `match` and regex
* Import `formatTrace` from m-c with some minor changes

### Test Plan

Updated the test file `error.js` based on the output changes