### PR TITLE
Get babelExcludes from options

### DIFF
--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -32,9 +32,9 @@ module.exports = (webpackConfig, envConfig, options) => {
       let excludedRe = new RegExp(`(${excludedPaths.join("|")})`);
       let excluded = !!request.match(excludedRe);
 
-      if (webpackConfig.babelExcludes) {
+      if (options.babelExcludes) {
         // If the tool defines an additional exclude regexp for Babel.
-        excluded = excluded || !!request.match(webpackConfig.babelExcludes);
+        excluded = excluded || !!request.match(options.babelExcludes);
       }
       return excluded && !request.match(/node_modules(\/|\\)devtools-/);
     },


### PR DESCRIPTION
Since the webpack 3 update, if you add a babelExcludes to the webpack config
you get an error message stating that you tried to pass in an unknown property.
This patch uses the new options argument as a way to pass babelExcludes.