### PR TITLE
Add source-utils from m-c into devtools-modules

### DIFF
--- a/packages/devtools-modules/src/source-utils.js
+++ b/packages/devtools-modules/src/source-utils.js
@@ -1,0 +1,365 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// TODO : Localize this (was l10n.getStr("frame.unknownSource"))
+const UNKNOWN_SOURCE_STRING = "(unknown)";
+
+// Character codes used in various parsing helper functions.
+const CHAR_CODE_A = "a".charCodeAt(0);
+const CHAR_CODE_B = "b".charCodeAt(0);
+const CHAR_CODE_C = "c".charCodeAt(0);
+const CHAR_CODE_D = "d".charCodeAt(0);
+const CHAR_CODE_E = "e".charCodeAt(0);
+const CHAR_CODE_F = "f".charCodeAt(0);
+const CHAR_CODE_H = "h".charCodeAt(0);
+const CHAR_CODE_I = "i".charCodeAt(0);
+const CHAR_CODE_J = "j".charCodeAt(0);
+const CHAR_CODE_L = "l".charCodeAt(0);
+const CHAR_CODE_M = "m".charCodeAt(0);
+const CHAR_CODE_N = "n".charCodeAt(0);
+const CHAR_CODE_O = "o".charCodeAt(0);
+const CHAR_CODE_P = "p".charCodeAt(0);
+const CHAR_CODE_R = "r".charCodeAt(0);
+const CHAR_CODE_S = "s".charCodeAt(0);
+const CHAR_CODE_T = "t".charCodeAt(0);
+const CHAR_CODE_U = "u".charCodeAt(0);
+const CHAR_CODE_W = "w".charCodeAt(0);
+const CHAR_CODE_COLON = ":".charCodeAt(0);
+const CHAR_CODE_DASH = "-".charCodeAt(0);
+const CHAR_CODE_L_SQUARE_BRACKET = "[".charCodeAt(0);
+const CHAR_CODE_SLASH = "/".charCodeAt(0);
+const CHAR_CODE_CAP_S = "S".charCodeAt(0);
+
+// The cache used in the `parseURL` function.
+const gURLStore = new Map();
+// The cache used in the `getSourceNames` function.
+const gSourceNamesStore = new Map();
+
+/**
+* Takes a string and returns an object containing all the properties
+* available on an URL instance, with additional properties (fileName),
+* Leverages caching.
+*
+* @param {String} location
+* @return {Object?} An object containing most properties available
+*                   in https://developer.mozilla.org/en-US/docs/Web/API/URL
+*/
+
+function parseURL(location) {
+  let url = gURLStore.get(location);
+
+  if (url !== void 0) {
+    return url;
+  }
+
+  try {
+    url = new URL(location);
+   // The callers were generally written to expect a URL from
+   // sdk/url, which is subtly different.  So, work around some
+   // important differences here.
+    url = {
+     href: url.href,
+     protocol: url.protocol,
+     host: url.host,
+     hostname: url.hostname,
+     port: url.port || null,
+     pathname: url.pathname,
+     search: url.search,
+     hash: url.hash,
+     username: url.username,
+     password: url.password,
+     origin: url.origin,
+    };
+
+   // Definitions:
+   // Example: https://foo.com:8888/file.js
+   // `hostname`: "foo.com"
+   // `host`: "foo.com:8888"
+    let isChrome = isChromeScheme(location);
+
+    url.fileName = url.pathname ?
+     (url.pathname.slice(url.pathname.lastIndexOf("/") + 1) || "/") :
+     "/";
+
+    if (isChrome) {
+      url.hostname = null;
+      url.host = null;
+    }
+
+    gURLStore.set(location, url);
+    return url;
+  } catch (e) {
+    gURLStore.set(location, null);
+    return null;
+  }
+}
+
+/**
+* Parse a source into a short and long name as well as a host name.
+*
+* @param {String} source
+*        The source to parse. Can be a URI or names like "(eval)" or
+*        "self-hosted".
+* @return {Object}
+*         An object with the following properties:
+*           - {String} short: A short name for the source.
+*             - "http://page.com/test.js#go?q=query" -> "test.js"
+*           - {String} long: The full, long name for the source, with
+              hash/query stripped.
+*             - "http://page.com/test.js#go?q=query" -> "http://page.com/test.js"
+*           - {String?} host: If available, the host name for the source.
+*             - "http://page.com/test.js#go?q=query" -> "page.com"
+*/
+function getSourceNames(source) {
+  let data = gSourceNamesStore.get(source);
+
+  if (data) {
+    return data;
+  }
+
+  let short, long, host;
+  const sourceStr = source ? String(source) : "";
+
+ // If `data:...` uri
+  if (isDataScheme(sourceStr)) {
+    let commaIndex = sourceStr.indexOf(",");
+    if (commaIndex > -1) {
+     // The `short` name for a data URI becomes `data:` followed by the actual
+     // encoded content, omitting the MIME type, and charset.
+      short = `data:${sourceStr.substring(commaIndex + 1)}`.slice(0, 100);
+      let result = { short, long: sourceStr };
+      gSourceNamesStore.set(source, result);
+      return result;
+    }
+  }
+
+ // If Scratchpad URI, like "Scratchpad/1"; no modifications,
+ // and short/long are the same.
+  if (isScratchpadScheme(sourceStr)) {
+    let result = { short: sourceStr, long: sourceStr };
+    gSourceNamesStore.set(source, result);
+    return result;
+  }
+
+  const parsedUrl = parseURL(sourceStr);
+
+  if (!parsedUrl) {
+   // Malformed URI.
+    long = sourceStr;
+    short = sourceStr.slice(0, 100);
+  } else {
+    host = parsedUrl.host;
+
+    long = parsedUrl.href;
+    if (parsedUrl.hash) {
+      long = long.replace(parsedUrl.hash, "");
+    }
+    if (parsedUrl.search) {
+      long = long.replace(parsedUrl.search, "");
+    }
+
+    short = parsedUrl.fileName;
+   // If `short` is just a slash, and we actually have a path,
+   // strip the slash and parse again to get a more useful short name.
+   // e.g. "http://foo.com/bar/" -> "bar", rather than "/"
+    if (short === "/" && parsedUrl.pathname !== "/") {
+      short = parseURL(long.replace(/\/$/, "")).fileName;
+    }
+  }
+
+  if (!short) {
+    if (!long) {
+      long = UNKNOWN_SOURCE_STRING;
+    }
+    short = long.slice(0, 100);
+  }
+
+  let result = { short, long, host };
+  gSourceNamesStore.set(source, result);
+  return result;
+}
+
+// For the functions below, we assume that we will never access the location
+// argument out of bounds, which is indeed the vast majority of cases.
+//
+// They are written this way because they are hot. Each frame is checked for
+// being content or chrome when processing the profile.
+
+function isColonSlashSlash(location, i = 0) {
+  return location.charCodeAt(++i) === CHAR_CODE_COLON &&
+        location.charCodeAt(++i) === CHAR_CODE_SLASH &&
+        location.charCodeAt(++i) === CHAR_CODE_SLASH;
+}
+
+/**
+* Checks for a Scratchpad URI, like "Scratchpad/1"
+*/
+function isScratchpadScheme(location, i = 0) {
+  return location.charCodeAt(i) === CHAR_CODE_CAP_S &&
+        location.charCodeAt(++i) === CHAR_CODE_C &&
+        location.charCodeAt(++i) === CHAR_CODE_R &&
+        location.charCodeAt(++i) === CHAR_CODE_A &&
+        location.charCodeAt(++i) === CHAR_CODE_T &&
+        location.charCodeAt(++i) === CHAR_CODE_C &&
+        location.charCodeAt(++i) === CHAR_CODE_H &&
+        location.charCodeAt(++i) === CHAR_CODE_P &&
+        location.charCodeAt(++i) === CHAR_CODE_A &&
+        location.charCodeAt(++i) === CHAR_CODE_D &&
+        location.charCodeAt(++i) === CHAR_CODE_SLASH;
+}
+
+function isDataScheme(location, i = 0) {
+  return location.charCodeAt(i) === CHAR_CODE_D &&
+        location.charCodeAt(++i) === CHAR_CODE_A &&
+        location.charCodeAt(++i) === CHAR_CODE_T &&
+        location.charCodeAt(++i) === CHAR_CODE_A &&
+        location.charCodeAt(++i) === CHAR_CODE_COLON;
+}
+
+function isContentScheme(location, i = 0) {
+  let firstChar = location.charCodeAt(i);
+
+  switch (firstChar) {
+   // "http://" or "https://"
+    case CHAR_CODE_H:
+      if (location.charCodeAt(++i) === CHAR_CODE_T &&
+         location.charCodeAt(++i) === CHAR_CODE_T &&
+         location.charCodeAt(++i) === CHAR_CODE_P) {
+        if (location.charCodeAt(i + 1) === CHAR_CODE_S) {
+          ++i;
+        }
+        return isColonSlashSlash(location, i);
+      }
+      return false;
+
+   // "file://"
+    case CHAR_CODE_F:
+      if (location.charCodeAt(++i) === CHAR_CODE_I &&
+         location.charCodeAt(++i) === CHAR_CODE_L &&
+         location.charCodeAt(++i) === CHAR_CODE_E) {
+        return isColonSlashSlash(location, i);
+      }
+      return false;
+
+   // "app://"
+    case CHAR_CODE_A:
+      if (location.charCodeAt(++i) == CHAR_CODE_P &&
+         location.charCodeAt(++i) == CHAR_CODE_P) {
+        return isColonSlashSlash(location, i);
+      }
+      return false;
+
+   // "blob:"
+    case CHAR_CODE_B:
+      if (
+       location.charCodeAt(++i) == CHAR_CODE_L &&
+       location.charCodeAt(++i) == CHAR_CODE_O &&
+       location.charCodeAt(++i) == CHAR_CODE_B &&
+       location.charCodeAt(++i) == CHAR_CODE_COLON
+     ) {
+        return isContentScheme(location, i + 1);
+      }
+      return false;
+
+    default:
+      return false;
+  }
+}
+
+function isChromeScheme(location, i = 0) {
+  let firstChar = location.charCodeAt(i);
+
+  switch (firstChar) {
+   // "chrome://"
+    case CHAR_CODE_C:
+      if (location.charCodeAt(++i) === CHAR_CODE_H &&
+         location.charCodeAt(++i) === CHAR_CODE_R &&
+         location.charCodeAt(++i) === CHAR_CODE_O &&
+         location.charCodeAt(++i) === CHAR_CODE_M &&
+         location.charCodeAt(++i) === CHAR_CODE_E) {
+        return isColonSlashSlash(location, i);
+      }
+      return false;
+
+   // "resource://"
+    case CHAR_CODE_R:
+      if (location.charCodeAt(++i) === CHAR_CODE_E &&
+         location.charCodeAt(++i) === CHAR_CODE_S &&
+         location.charCodeAt(++i) === CHAR_CODE_O &&
+         location.charCodeAt(++i) === CHAR_CODE_U &&
+         location.charCodeAt(++i) === CHAR_CODE_R &&
+         location.charCodeAt(++i) === CHAR_CODE_C &&
+         location.charCodeAt(++i) === CHAR_CODE_E) {
+        return isColonSlashSlash(location, i);
+      }
+      return false;
+
+   // "jar:file://"
+    case CHAR_CODE_J:
+      if (location.charCodeAt(++i) === CHAR_CODE_A &&
+         location.charCodeAt(++i) === CHAR_CODE_R &&
+         location.charCodeAt(++i) === CHAR_CODE_COLON &&
+         location.charCodeAt(++i) === CHAR_CODE_F &&
+         location.charCodeAt(++i) === CHAR_CODE_I &&
+         location.charCodeAt(++i) === CHAR_CODE_L &&
+         location.charCodeAt(++i) === CHAR_CODE_E) {
+        return isColonSlashSlash(location, i);
+      }
+      return false;
+
+    default:
+      return false;
+  }
+}
+
+function isWASM(location, i = 0) {
+  return (
+   // "wasm-function["
+   location.charCodeAt(i) === CHAR_CODE_W &&
+   location.charCodeAt(++i) === CHAR_CODE_A &&
+   location.charCodeAt(++i) === CHAR_CODE_S &&
+   location.charCodeAt(++i) === CHAR_CODE_M &&
+   location.charCodeAt(++i) === CHAR_CODE_DASH &&
+   location.charCodeAt(++i) === CHAR_CODE_F &&
+   location.charCodeAt(++i) === CHAR_CODE_U &&
+   location.charCodeAt(++i) === CHAR_CODE_N &&
+   location.charCodeAt(++i) === CHAR_CODE_C &&
+   location.charCodeAt(++i) === CHAR_CODE_T &&
+   location.charCodeAt(++i) === CHAR_CODE_I &&
+   location.charCodeAt(++i) === CHAR_CODE_O &&
+   location.charCodeAt(++i) === CHAR_CODE_N &&
+   location.charCodeAt(++i) === CHAR_CODE_L_SQUARE_BRACKET
+ );
+}
+
+/**
+* A utility method to get the file name from a sourcemapped location
+* The sourcemap location can be in any form. This method returns a
+* formatted file name for different cases like Windows or OSX.
+* @param source
+* @returns String
+*/
+function getSourceMappedFile(source) {
+ // If sourcemapped source is a OSX path, return
+ // the characters after last "/".
+ // If sourcemapped source is a Windowss path, return
+ // the characters after last "\\".
+  if (source.lastIndexOf("/") >= 0) {
+    source = source.slice(source.lastIndexOf("/") + 1);
+  } else if (source.lastIndexOf("\\") >= 0) {
+    source = source.slice(source.lastIndexOf("\\") + 1);
+  }
+  return source;
+}
+
+module.exports = {
+  parseURL,
+  getSourceNames,
+  isScratchpadScheme,
+  isChromeScheme,
+  isContentScheme,
+  isWASM,
+  isDataScheme,
+  getSourceMappedFile,
+};

--- a/packages/devtools-modules/src/tests/source-utils.js
+++ b/packages/devtools-modules/src/tests/source-utils.js
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const {
+  getSourceMappedFile,
+  getSourceNames,
+  isChromeScheme,
+  isContentScheme,
+  isDataScheme,
+  isScratchpadScheme,
+  isWASM,
+  parseURL,
+} = require("../source-utils");
+
+describe("source-utils", () => {
+  const CHROME_URLS = [
+    "chrome://foo",
+    "resource://baz",
+    "jar:file:///Users/root"
+  ];
+  const CONTENT_URLS = [
+    "http://mozilla.org",
+    "https://mozilla.org",
+    "file:///Users/root",
+    "app://fxosapp",
+    "blob:http://mozilla.org",
+    "blob:https://mozilla.org"
+  ];
+
+  it("parse URLs", () => {
+    let parsed = parseURL("https://foo.com:8888/boo/bar.js?q=query");
+
+    expect(parsed.fileName).toBe("bar.js");
+    expect(parsed.host).toBe("foo.com:8888");
+    expect(parsed.hostname).toBe("foo.com");
+    expect(parsed.port).toBe("8888");
+    expect(parsed.href).toBe("https://foo.com:8888/boo/bar.js?q=query");
+
+    parsed = parseURL("https://foo.com");
+    expect(parsed.host).toBe("foo.com");
+    expect(parsed.hostname).toBe("foo.com");
+
+    expect(parseURL("self-hosted")).toBe(null);
+  });
+
+  it("isContentScheme", () => {
+    for (let url of CHROME_URLS) {
+      expect(isContentScheme(url)).toBe(false);
+    }
+    for (let url of CONTENT_URLS) {
+      expect(isContentScheme(url)).toBe(true);
+    }
+  });
+
+  it("isChromeScheme", () => {
+    for (let url of CHROME_URLS) {
+      expect(isChromeScheme(url)).toBe(true);
+    }
+    for (let url of CONTENT_URLS) {
+      expect(isChromeScheme(url)).toBe(false);
+    }
+  });
+
+  it("isWASM", () => {
+    expect(isWASM("wasm-function[66240] (?:13870536)")).toBe(true);
+    expect(isWASM(CHROME_URLS[0])).toBe(false);
+  });
+
+  it("isDataScheme", () => {
+    const dataURI = "data:text/html;charset=utf-8,<!DOCTYPE html></html>";
+    expect(isDataScheme(dataURI)).toBe(true);
+
+    for (let url of CHROME_URLS) {
+      expect(isDataScheme(url)).toBe(false);
+    }
+    for (let url of CONTENT_URLS) {
+      expect(isDataScheme(url)).toBe(false);
+    }
+  });
+
+  it("isScratchpadTheme", () => {
+    expect(isScratchpadScheme("Scratchpad/1")).toBe(true);
+    expect(isScratchpadScheme("Scratchpad/20")).toBe(true);
+    expect(isScratchpadScheme("http://www.mozilla.org")).toBe(false);
+  });
+
+  it("getSourceMappedFile", () => {
+    expect(getSourceMappedFile("baz.js")).toBe("baz.js");
+    expect(getSourceMappedFile("/foo/bar/baz.js")).toBe("baz.js");
+    expect(getSourceMappedFile("Z:\\foo\\bar\\baz.js")).toBe("baz.js");
+  });
+
+  it("getSourceNames", () => {
+    // Check length
+    const longMalformedURL = `example.com${"/a".repeat(100)}/file.js`;
+    expect(getSourceNames(longMalformedURL).short.length).toBeLessThanOrEqual(100);
+
+    expect(getSourceNames("http://example.com/foo/bar/baz/boo.js")).toEqual({
+      short: "boo.js",
+      long: "http://example.com/foo/bar/baz/boo.js",
+      host: "example.com"
+    });
+
+    expect(getSourceNames("self-hosted")).toEqual({
+      short: "self-hosted",
+      long: "self-hosted",
+      host: undefined
+    });
+
+    expect(getSourceNames("")).toEqual({
+      short: "(unknown)",
+      long: "(unknown)",
+      host: undefined
+    });
+
+    // Test shortening data URIs, stripping mime/charset
+    const dataURI = "data:text/html;charset=utf-8,<!DOCTYPE html></html>";
+    expect(getSourceNames(dataURI)).toEqual({
+      short: "data:<!DOCTYPE html></html>",
+      long: "data:text/html;charset=utf-8,<!DOCTYPE html></html>",
+      host: undefined
+    });
+
+    // Test shortening data URIs and that the `short` result is capped
+    let longDataURI = `data:image/png;base64,${"a".repeat(100)}`;
+    let longDataURIShort = getSourceNames(longDataURI).short;
+    expect(longDataURIShort.length).toBeLessThanOrEqual(100);
+    expect(longDataURIShort.substr(0, 10)).toBe("data:aaaaa");
+
+    // Test simple URL and cache retrieval by calling the same input multiple times.
+    let testUrl = "http://example.com/foo/bar/baz/boo.js";
+    expect(getSourceNames(testUrl)).toEqual({
+      short: "boo.js",
+      long: testUrl,
+      host: "example.com"
+    });
+    expect(getSourceNames(testUrl)).toEqual({
+      short: "boo.js",
+      long: testUrl,
+      host: "example.com"
+    });
+
+    // Check query and hash and port
+    expect(getSourceNames("http://example.com:8888/foo/bar/baz.js?q=query#go")).toEqual({
+      short: "baz.js",
+      long: "http://example.com:8888/foo/bar/baz.js",
+      host: "example.com:8888"
+    });
+
+    // Trailing "/" with nothing beyond host
+    expect(getSourceNames("http://example.com/")).toEqual({
+      short: "/",
+      long: "http://example.com/",
+      host: "example.com"
+    });
+
+    // Trailing "/"
+    expect(getSourceNames("http://example.com/foo/bar/")).toEqual({
+      short: "bar",
+      long: "http://example.com/foo/bar/",
+      host: "example.com"
+    });
+
+    // Non-extension ending
+    expect(getSourceNames("http://example.com/bar")).toEqual({
+      short: "bar",
+      long: "http://example.com/bar",
+      host: "example.com"
+    });
+
+    // Check query
+    expect(getSourceNames("http://example.com/foo.js?bar=1&baz=2")).toEqual({
+      short: "foo.js",
+      long: "http://example.com/foo.js",
+      host: "example.com"
+    });
+
+    // Check query with trailing slash
+    expect(getSourceNames("http://example.com/foo/?bar=1&baz=2")).toEqual({
+      short: "foo",
+      long: "http://example.com/foo/",
+      host: "example.com"
+    });
+  });
+});

--- a/packages/devtools-utils/src/network-request.js
+++ b/packages/devtools-utils/src/network-request.js
@@ -12,7 +12,7 @@ function networkRequest(url: string, opts: any) {
     fetch(`/get?url=${url}`).then(res => {
       if (res.status >= 200 && res.status < 300) {
         return res.text()
-          .then(text => ({ content: text }))
+          .then(text => ({ content: text }));
       }
       return Promise.reject(new Error(`failed to request ${url}`));
     }),

--- a/packages/devtools-utils/src/tests/.eslintrc
+++ b/packages/devtools-utils/src/tests/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "jest": true
+  }
+}

--- a/packages/devtools-utils/src/tests/network-request.js
+++ b/packages/devtools-utils/src/tests/network-request.js
@@ -3,41 +3,40 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 jest.useFakeTimers();
-const networkRequest = require("../network-request")
+const networkRequest = require("../network-request");
 
 function fetch(status, text) {
   return () => Promise.resolve({
     status,
     text: () => Promise.resolve(text)
-  })
+  });
 }
 
 describe("network request", () => {
   beforeEach(() => {
-    global.fetch = jest.fn()
+    global.fetch = jest.fn();
   });
 
   it("successful fetch", async () => {
     global.fetch.mockImplementation(fetch(200, "Yay"));
     const res = await networkRequest("foo");
     expect(res).toEqual({content: "Yay"});
-  })
+  });
 
   it("failed fetch", async () => {
     global.fetch.mockImplementation(fetch(400, "Sad"));
     try {
-      const res = await networkRequest("foo");
+      await networkRequest("foo");
     } catch (e) {
       expect(e.message).toEqual("failed to request foo");
     }
-  })
+  });
 
   it("timed out fetch", async () => {
     global.fetch.mockImplementation(() => (new Promise((resolve) => {})));
 
-    const res = networkRequest("foo")
-    .catch(e => expect(e.message).toEqual("Connect timeout error"));
+    networkRequest("foo").catch(e => expect(e.message).toEqual("Connect timeout error"));
 
     jest.runAllTimers();
-  })
-})
+  });
+});


### PR DESCRIPTION
This takes the code from https://hg.mozilla.org/mozilla-central/file/018b3829d0a7/devtools/client/shared/source-utils.js and https://hg.mozilla.org/mozilla-central/file/018b3829d0a7/devtools/client/shared/test/unit/test_source-utils.js for the test. The test was converted to jest.

This is needed so we can import Stacktrace and Frames component from mozilla-central as well