### PR TITLE
Update devtools-reps package.json

### DIFF
--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "devtools-config": "^0.0.15",
-    "devtools-launchpad": "^0.0.92",
+    "devtools-launchpad": "^0.0.96",
     "devtools-license-check": "^0.2.0",
     "enzyme": "^2.8.2",
     "eslint": "^3.12.0",
@@ -44,7 +44,8 @@
     "jest-cli": "^20.0.4",
     "jest-flow-transform": "^1.0.1",
     "react-addons-test-utils": "=15.3.2",
-    "redux-logger": "=3.0.6"
+    "redux-logger": "=3.0.6",
+    "svg-inline-loader": "^0.8.0"
   },
   "jest": {
     "rootDir": "src",
@@ -53,7 +54,8 @@
       "/node_modules/",
       "<rootDir>/test/",
       "<rootDir>/reps/tests/test-helpers",
-      "<rootDir>/utils/tests/fixtures/"
+      "<rootDir>/utils/tests/fixtures/",
+      "<rootDir>/object-inspector/tests/__mocks__/"
     ],
     "transformIgnorePatterns": ["node_modules/(?!devtools-)"],
     "transform": {

--- a/packages/devtools-reps/yarn.lock
+++ b/packages/devtools-reps/yarn.lock
@@ -1494,19 +1494,19 @@ devtools-config@^0.0.15:
   version "0.0.15"
   resolved "https://registry.yarnpkg.com/devtools-config/-/devtools-config-0.0.15.tgz#1fbe75be3f4dc1159603927fc1dfa64d1d9f1202"
 
-devtools-connection@^0.0.6:
+devtools-connection@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/devtools-connection/-/devtools-connection-0.0.7.tgz#1ec211018dc863079adb5422cf398f1201078c39"
+
+devtools-contextmenu@^0.0.6:
   version "0.0.6"
-  resolved "https://registry.yarnpkg.com/devtools-connection/-/devtools-connection-0.0.6.tgz#06431a8e4882033409a9d90c2720832cb51b86eb"
-
-devtools-contextmenu@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/devtools-contextmenu/-/devtools-contextmenu-0.0.5.tgz#12e5bf4829fe03b5b226ebc26630ca90ba6da229"
+  resolved "https://registry.yarnpkg.com/devtools-contextmenu/-/devtools-contextmenu-0.0.6.tgz#03ebe541f283b0b7ccc00a4641e6eb1b7fff95f8"
   dependencies:
-    devtools-modules "^0.0.30"
+    devtools-modules "^0.0.31"
 
-devtools-launchpad@^0.0.92:
-  version "0.0.92"
-  resolved "https://registry.yarnpkg.com/devtools-launchpad/-/devtools-launchpad-0.0.92.tgz#d00fff78b25fd26fd443c6b5b6806eaf7478f792"
+devtools-launchpad@^0.0.96:
+  version "0.0.96"
+  resolved "https://registry.yarnpkg.com/devtools-launchpad/-/devtools-launchpad-0.0.96.tgz#5390ccccbbe06d25f488e66d4511bc94b4807ba7"
   dependencies:
     amd-loader "0.0.8"
     autoprefixer "^7.1.2"
@@ -1533,9 +1533,9 @@ devtools-launchpad@^0.0.92:
     co "=4.6.0"
     css-loader "^0.26.1"
     devtools-config "^0.0.15"
-    devtools-connection "^0.0.6"
-    devtools-contextmenu "^0.0.5"
-    devtools-modules "^0.0.30"
+    devtools-connection "^0.0.7"
+    devtools-contextmenu "^0.0.6"
+    devtools-modules "^0.0.31"
     devtools-sprintf-js "^1.0.3"
     devtools-utils "^0.0.5"
     eslint "^3.12.0"
@@ -1563,12 +1563,11 @@ devtools-launchpad@^0.0.92:
     react-dom "=15.3.2"
     react-hot-loader "^1.3.1"
     react-immutable-proptypes "^2.1.0"
-    react-inlinesvg "^0.5.3"
     react-redux "4.4.5"
     redux "3.5.2"
     selenium-webdriver "=3.3.0"
     style-loader "^0.18.2"
-    svg-inline-loader "^0.8.0"
+    url-loader "^0.5.9"
     webpack "^3.3.0"
     webpack-dev-middleware "^1.11.0"
     webpack-env-loader-plugin "^1.0.0"
@@ -1581,9 +1580,9 @@ devtools-license-check@^0.2.0:
   dependencies:
     license-checker "^9.0.3"
 
-devtools-modules@^0.0.30:
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.30.tgz#ea15e73a51f2965455df007ade8e440653f29637"
+devtools-modules@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.31.tgz#06749ffa7b78cf2826467ffcce9d2edbbba3ced7"
   dependencies:
     jest "^19.0.2"
 
@@ -2091,7 +2090,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -2546,14 +2545,6 @@ http-signature@~1.1.0:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-httpplease@^0.16:
-  version "0.16.4"
-  resolved "https://registry.yarnpkg.com/httpplease/-/httpplease-0.16.4.tgz#d382ebe230ef5079080b4e9ffebf316a9e75c0da"
-  dependencies:
-    urllite "~0.5.0"
-    xmlhttprequest "*"
-    xtend "~3.0.0"
 
 https-browserify@0.0.1:
   version "0.0.1"
@@ -3745,7 +3736,7 @@ mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
-mime@>=1.2.9, mime@^1.3.4:
+mime@1.3.x, mime@>=1.2.9, mime@^1.3.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
@@ -4016,7 +4007,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.3.3, once@^1.4, once@^1.4.0:
+once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -4696,14 +4687,6 @@ react-hot-loader@^1.3.1:
 react-immutable-proptypes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
-
-react-inlinesvg@^0.5.3:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/react-inlinesvg/-/react-inlinesvg-0.5.5.tgz#811c75decd392eaef682346751418c2fd911af42"
-  dependencies:
-    fbjs "^0.8"
-    httpplease "^0.16"
-    once "^1.4"
 
 react-redux@4.4.5:
   version "4.4.5"
@@ -5593,6 +5576,13 @@ unzip-response@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
 
+url-loader@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-0.5.9.tgz#cc8fea82c7b906e7777019250869e569e995c295"
+  dependencies:
+    loader-utils "^1.0.2"
+    mime "1.3.x"
+
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
@@ -5605,12 +5595,6 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
-
-urllite@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/urllite/-/urllite-0.5.0.tgz#1b7bb9ca3fb0db9520de113466bbcf7cc341451a"
-  dependencies:
-    xtend "~4.0.0"
 
 user-home@^1.1.1:
   version "1.1.1"
@@ -5905,17 +5889,9 @@ xmlbuilder@^4.1.0:
   dependencies:
     lodash "^4.0.0"
 
-xmlhttprequest@*:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xtend@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-3.0.0.tgz#5cce7407baf642cba7becda568111c493f59665a"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Bump up the launchpad
Add direct "svg-inline-loader" dependency since we use it and we were retrieving it from another dependency, which isn't ideal.
Tweak the jest config for the upcoming ObjectInspector patch