### PR TITLE
Convert Error to string when worker method fails

### DIFF
--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-utils",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "DevTools Utils",
   "main": "index.js",
   "scripts": {

--- a/packages/devtools-utils/src/tests/worker-utils.js
+++ b/packages/devtools-utils/src/tests/worker-utils.js
@@ -69,7 +69,7 @@ describe("worker utils", () => {
 
     expect(postMessageMock.mock.calls[0][0]).toEqual({
       id: 53,
-      error: new Error("failed"),
+      error: "Error: failed",
     });
   });
 });

--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -67,13 +67,17 @@ function workerHandler(publicInterface: Object) {
       if (response instanceof Promise) {
         response.then(
           val => self.postMessage({ id, response: val }),
-          err => self.postMessage({ id, error: err })
+          // Error can't be sent via postMessage, so be sure to
+          // convert to string.
+          err => self.postMessage({ id, error: err.toString() })
         );
       } else {
         self.postMessage({ id, response });
       }
     } catch (error) {
-      self.postMessage({ id, error });
+      // Error can't be sent via postMessage, so be sure to convert to
+      // string.
+      self.postMessage({ id, error: error.toString() });
     }
   };
 }


### PR DESCRIPTION
Error can't be sent using postMessage.
See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
This patch converts errors to strings before reporting them.
