### PR TITLE
Move the theme loading to before we render our react app.

### DIFF
--- a/packages/devtools-launchpad/src/index.js
+++ b/packages/devtools-launchpad/src/index.js
@@ -99,6 +99,11 @@ function renderRoot(_React, _ReactDOM, component, _store) {
   const root = Root("launchpad-root theme-body");
   mount.appendChild(root);
 
+  if (isDevelopment()) {
+    updateConfig();
+    updateTheme();
+  }
+
   if (component.props || component.propTypes) {
     _ReactDOM.render(
       createElement(Provider, { store: _store }, createElement(component)),
@@ -106,11 +111,6 @@ function renderRoot(_React, _ReactDOM, component, _store) {
     );
   } else {
     root.appendChild(component);
-  }
-
-  if (isDevelopment()) {
-    updateConfig();
-    updateTheme();
   }
 }
 


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/2840

### Summary of Changes

* Our themes weren't loading soon enough so we would get occasional miscolored flashes. This is because we were trying to use theme variables before they existed and the browser fell back to using black. Moving this block up before the render makes sure we have our config and theme ready before rendering.