### PR TITLE
Remove theme namespaces

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -77,6 +77,7 @@
     "node-static": "^0.7.7",
     "postcss": "^6.0.6",
     "postcss-bidirection": "^2.4.0",
+    "postcss-class-namespace": "^0.1.0",
     "postcss-loader": "^2.0.6",
     "properties-parser": "^0.3.1",
     "ps-node": "^0.1.4",

--- a/packages/devtools-launchpad/postcss.config.js
+++ b/packages/devtools-launchpad/postcss.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  plugins: [require("postcss-bidirection"), require("autoprefixer")]
+  plugins: [
+    require("postcss-bidirection"),
+    require("autoprefixer"),
+    require("postcss-class-namespace")()
+  ]
 };

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -3923,7 +3923,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4648,6 +4648,13 @@ postcss-calc@^5.2.0:
     postcss "^5.0.2"
     postcss-message-helpers "^2.0.0"
     reduce-css-calc "^1.2.6"
+
+postcss-class-namespace@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-class-namespace/-/postcss-class-namespace-0.1.0.tgz#b5f7be4373c0d1458760b60cab838ca6212362ca"
+  dependencies:
+    lodash "^4.13.1"
+    postcss "^5.0.10"
 
 postcss-colormin@^2.1.8:
   version "2.2.2"

--- a/packages/devtools-modules/src/themes/dark-theme.css
+++ b/packages/devtools-modules/src/themes/dark-theme.css
@@ -8,43 +8,42 @@
 @import url(toolbars.css);
 @import url(tooltips.css);
 
-.theme-dark body {
-  margin: 0;
-}
+@namespace theme-dark;
 
-.theme-dark {
+:root {
   background: var(--theme-body-background);
+  margin: 0;
   color: var(--theme-body-color);
 }
 
-.theme-dark .theme-sidebar {
+.theme-sidebar {
   background: var(--theme-sidebar-background);
   color: var(--theme-content-color1);
 }
 
-.theme-dark ::-moz-selection {
+::-moz-selection {
   background-color: var(--theme-selection-background);
   color: var(--theme-selection-color);
 }
 
-.theme-dark .theme-bg-darker {
+.theme-bg-darker {
   background-color: var(--theme-selection-background-semitransparent);
 }
 
-.theme-dark .theme-selected,
-.theme-dark .CodeMirror-hint-active {
+.theme-selected,
+.CodeMirror-hint-active {
   background-color: var(--theme-selection-background);
   color: var(--theme-selection-color);
 }
 
-.theme-dark .theme-bg-contrast,
-.theme-dark .variable-or-property:not([overridden])[changed] {
+.theme-bg-contrast,
+.variable-or-property:not([overridden])[changed] {
   background: var(--theme-contrast-background);
 }
 
-.theme-dark .theme-link,
-.theme-dark .cm-s-mozilla .cm-link,
-.theme-dark .cm-s-mozilla .cm-keyword {
+.theme-link,
+.cm-s-mozilla .cm-link,
+.cm-s-mozilla .cm-keyword {
   color: var(--theme-highlight-green);
 }
 
@@ -52,136 +51,136 @@
  * FIXME: http://bugzil.la/575675 CSS links without :visited set cause assertion
  * failures in debug builds.
  */
-.theme-dark .theme-link:visited,
-.theme-dark .cm-s-mozilla .cm-link:visited,
-.theme-dark .CodeMirror-Tern-type {
+.theme-link:visited,
+.cm-s-mozilla .cm-link:visited,
+.CodeMirror-Tern-type {
   color: var(--theme-highlight-blue);
 }
 
 
-.theme-dark .theme-comment,
-.theme-dark .cm-s-mozilla .cm-meta,
-.theme-dark .cm-s-mozilla .cm-hr,
-.theme-dark .cm-s-mozilla .cm-comment,
-.theme-dark .variable-or-property .token-undefined,
-.theme-dark .variable-or-property .token-null,
-.theme-dark .CodeMirror-Tern-completion-unknown:before {
+.theme-comment,
+.cm-s-mozilla .cm-meta,
+.cm-s-mozilla .cm-hr,
+.cm-s-mozilla .cm-comment,
+.variable-or-property .token-undefined,
+.variable-or-property .token-null,
+.CodeMirror-Tern-completion-unknown:before {
   color: var(--theme-comment);
 }
 
-.theme-dark .theme-gutter {
+.theme-gutter {
   background-color: var(--theme-tab-toolbar-background);
   color: var(--theme-content-color3);
   border-color: var(--theme-splitter-color);
 }
 
-.theme-dark .theme-separator {
+.theme-separator {
   border-color: var(--theme-splitter-color);
 }
 
-.theme-dark .theme-fg-color1,
-.theme-dark .cm-s-mozilla .cm-number,
-.theme-dark .variable-or-property .token-number,
-.theme-dark .variable-or-property[return] > .title > .name,
-.theme-dark .variable-or-property[scope] > .title > .name {
+.theme-fg-color1,
+.cm-s-mozilla .cm-number,
+.variable-or-property .token-number,
+.variable-or-property[return] > .title > .name,
+.variable-or-property[scope] > .title > .name {
   color: var(--theme-highlight-red);
 }
 
-.theme-dark .CodeMirror-Tern-completion-number:before {
+.CodeMirror-Tern-completion-number:before {
   background-color: #5c9966;
 }
 
-.theme-dark .theme-fg-color2,
-.theme-dark .cm-s-mozilla .cm-attribute,
-.theme-dark .cm-s-mozilla .cm-def,
-.theme-dark .cm-s-mozilla .cm-property,
-.theme-dark .cm-s-mozilla .cm-qualifier,
-.theme-dark .variables-view-variable > .title > .name {
+.theme-fg-color2,
+.cm-s-mozilla .cm-attribute,
+.cm-s-mozilla .cm-def,
+.cm-s-mozilla .cm-property,
+.cm-s-mozilla .cm-qualifier,
+.variables-view-variable > .title > .name {
   color: var(--theme-highlight-purple);
 }
 
-.theme-dark .CodeMirror-Tern-completion-object:before {
+.CodeMirror-Tern-completion-object:before {
   background-color: #3689b2;
 }
 
-.theme-dark .cm-s-mozilla .cm-unused-line {
+.cm-s-mozilla .cm-unused-line {
   text-decoration: line-through;
   text-decoration-color: #0072ab;
 }
 
-.theme-dark .cm-s-mozilla .cm-executed-line {
+.cm-s-mozilla .cm-executed-line {
   background-color: #133c26;
 }
 
-.theme-dark .theme-fg-color3,
-.theme-dark .cm-s-mozilla .cm-builtin,
-.theme-dark .cm-s-mozilla .cm-tag,
-.theme-dark .cm-s-mozilla .cm-header,
-.theme-dark .cm-s-mozilla .cm-bracket,
-.theme-dark .variables-view-property > .title > .name {
+.theme-fg-color3,
+.cm-s-mozilla .cm-builtin,
+.cm-s-mozilla .cm-tag,
+.cm-s-mozilla .cm-header,
+.cm-s-mozilla .cm-bracket,
+.variables-view-property > .title > .name {
   color: var(--theme-highlight-green);
 }
 
-.theme-dark .CodeMirror-Tern-completion-array:before {
+.CodeMirror-Tern-completion-array:before {
   background-color: var(--theme-highlight-bluegrey);
 }
 
-.theme-dark .theme-fg-color4 {
+.theme-fg-color4 {
   color: var(--theme-highlight-purple);
 }
 
-.theme-dark .theme-fg-color5 {
+.theme-fg-color5 {
   color: var(--theme-highlight-purple);
 }
 
-.theme-dark .theme-fg-color6,
-.theme-dark .cm-s-mozilla .cm-string,
-.theme-dark .cm-s-mozilla .cm-string-2,
-.theme-dark .variable-or-property .token-string,
-.theme-dark .cm-s-mozilla .cm-variable,
-.theme-dark .CodeMirror-Tern-farg {
+.theme-fg-color6,
+.cm-s-mozilla .cm-string,
+.cm-s-mozilla .cm-string-2,
+.variable-or-property .token-string,
+.cm-s-mozilla .cm-variable,
+.CodeMirror-Tern-farg {
   color: var(--theme-highlight-gray);
 }
 
-.theme-dark .CodeMirror-Tern-completion-string:before,
-.theme-dark .CodeMirror-Tern-completion-fn:before {
+.CodeMirror-Tern-completion-string:before,
+.CodeMirror-Tern-completion-fn:before {
   background-color: #b26b47;
 }
 
-.theme-dark .theme-fg-color7,
-.theme-dark .cm-s-mozilla .cm-atom,
-.theme-dark .cm-s-mozilla .cm-quote,
-.theme-dark .cm-s-mozilla .cm-error,
-.theme-dark .variable-or-property .token-boolean,
-.theme-dark .variable-or-property .token-domnode,
-.theme-dark .variable-or-property[exception] > .title > .name {
+.theme-fg-color7,
+.cm-s-mozilla .cm-atom,
+.cm-s-mozilla .cm-quote,
+.cm-s-mozilla .cm-error,
+.variable-or-property .token-boolean,
+.variable-or-property .token-domnode,
+.variable-or-property[exception] > .title > .name {
   color: var(--theme-highlight-red);
 }
 
-.theme-dark .CodeMirror-Tern-completion-bool:before {
+.CodeMirror-Tern-completion-bool:before {
   background-color: #bf5656;
 }
 
-.theme-dark .variable-or-property .token-domnode {
+.variable-or-property .token-domnode {
   font-weight: bold;
 }
 
-.theme-dark .theme-toolbar,
-.theme-dark .devtools-toolbar,
-.theme-dark .devtools-sidebar-tabs tabs,
-.theme-dark .devtools-sidebar-alltabs,
-.theme-dark .cm-s-mozilla .CodeMirror-dialog { /* General toolbar styling */
+.theme-toolbar,
+.devtools-toolbar,
+.devtools-sidebar-tabs tabs,
+.devtools-sidebar-alltabs,
+.cm-s-mozilla .CodeMirror-dialog { /* General toolbar styling */
   color: var(--theme-body-color-alt);
   background-color: var(--theme-toolbar-background);
   border-color: var(--theme-splitter-color);
 }
 
-.theme-dark .theme-fg-contrast { /* To be used for text on theme-bg-contrast */
+.theme-fg-contrast { /* To be used for text on theme-bg-contrast */
   color: black;
 }
 
-.theme-dark .ruleview-swatch,
-.theme-dark .computedview-colorswatch {
+.ruleview-swatch,
+.computedview-colorswatch {
   box-shadow: 0 0 0 1px #818181;
 }
 
@@ -189,48 +188,48 @@
  * Best effort to match the existing theme, some of the colors
  * are duplicated here to prevent weirdness in the main theme. */
 
-.theme-dark .CodeMirror.cm-s-mozilla  { /* Inherit platform specific font sizing and styles */
+.CodeMirror.cm-s-mozilla  { /* Inherit platform specific font sizing and styles */
   font-family: inherit;
   font-size: inherit;
   background: transparent;
 }
 
-.theme-dark .CodeMirror.cm-s-mozilla  pre,
-.theme-dark .cm-s-mozilla .cm-variable-2,
-.theme-dark .cm-s-mozilla .cm-variable-3,
-.theme-dark .cm-s-mozilla .cm-operator,
-.theme-dark .cm-s-mozilla .cm-special {
+.CodeMirror.cm-s-mozilla  pre,
+.cm-s-mozilla .cm-variable-2,
+.cm-s-mozilla .cm-variable-3,
+.cm-s-mozilla .cm-operator,
+.cm-s-mozilla .cm-special {
   color: var(--theme-content-color1);
 }
 
-.theme-dark .cm-s-mozilla .CodeMirror-lines .CodeMirror-cursor {
+.cm-s-mozilla .CodeMirror-lines .CodeMirror-cursor {
   border-left: solid 1px #fff;
 }
 
-.theme-dark .cm-s-mozilla.CodeMirror-focused .CodeMirror-selected { /* selected text (focused) */
+.cm-s-mozilla.CodeMirror-focused .CodeMirror-selected { /* selected text (focused) */
   background: rgb(77, 86, 103);
 }
 
-.theme-dark .cm-s-mozilla .CodeMirror-selected { /* selected text (unfocused) */
+.cm-s-mozilla .CodeMirror-selected { /* selected text (unfocused) */
   background: rgb(77, 86, 103);
 }
 
-.theme-dark .cm-s-mozilla .CodeMirror-activeline-background { /* selected color with alpha */
+.cm-s-mozilla .CodeMirror-activeline-background { /* selected color with alpha */
   background: rgba(185, 215, 253, .15);
 }
 
-.theme-dark .div.cm-s-mozilla span.CodeMirror-matchingbracket { /* highlight brackets */
+.div.cm-s-mozilla span.CodeMirror-matchingbracket { /* highlight brackets */
   outline: solid 1px rgba(255, 255, 255, .25);
   color: white;
 }
 
 /* Highlight for a line that contains an error. */
-.theme-dark .div.CodeMirror div.error-line {
+.div.CodeMirror div.error-line {
   background: rgba(255,0,0,0.2);
 }
 
 /* Generic highlighted text */
-.theme-dark .div.CodeMirror span.marked-text {
+.div.CodeMirror span.marked-text {
   background: rgba(255,255,0,0.2);
   border: 1px dashed rgba(192,192,0,0.6);
   margin-inline-start: -1px;
@@ -238,21 +237,21 @@
 }
 
 /* Highlight for evaluating current statement. */
-.theme-dark .div.CodeMirror span.eval-text {
+.div.CodeMirror span.eval-text {
   background-color: #556;
 }
 
-.theme-dark .cm-s-mozilla .CodeMirror-linenumber { /* line number text */
+.cm-s-mozilla .CodeMirror-linenumber { /* line number text */
   color: var(--theme-content-color3);
 }
 
-.theme-dark .cm-s-markup-view pre {
+.cm-s-markup-view pre {
   line-height: 1.4em;
   min-height: 1.4em;
 }
 
 /* Twisty and checkbox controls */
-.theme-dark .theme-twisty, .theme-checkbox {
+.theme-twisty, .theme-checkbox {
   width: 14px;
   height: 14px;
   background-repeat: no-repeat;
@@ -260,24 +259,24 @@
   background-size: 56px 28px;
 }
 
-.theme-dark .theme-twisty {
+.theme-twisty {
   cursor: pointer;
   background-position: -28px -14px;
 }
 
-.theme-dark .theme-twisty:-moz-focusring {
+.theme-twisty:-moz-focusring {
   outline-style: none;
 }
 
-.theme-dark .theme-twisty[open], .theme-twisty.open  {
+.theme-twisty[open], .theme-twisty.open  {
   background-position: -42px -14px;
 }
 
-.theme-dark .theme-twisty[invisible] {
+.theme-twisty[invisible] {
   visibility: hidden;
 }
 
-.theme-dark .theme-checkbox {
+.theme-checkbox {
   display: inline-block;
   border: 0;
   padding: 0;
@@ -285,19 +284,19 @@
   background-position: -28px 0;
 }
 
-.theme-dark .theme-checkbox[checked] {
+.theme-checkbox[checked] {
   background-position: -42px 0;
 }
 
 @media (min-resolution: 1.1dppx) {
-  .theme-dark ..theme-twisty, .theme-checkbox {
+  ..theme-twisty, .theme-checkbox {
     /*background-image: url("chrome://devtools/skin/images/controls@2x.png");*/
   }
 }
 
 /* XUL panel styling (see devtools/client/shared/widgets/Tooltip.js) */
 
-.theme-dark .theme-tooltip-panel .panel-arrowcontent {
+.theme-tooltip-panel .panel-arrowcontent {
   padding: 5px;
   background: rgba(19, 28, 38, .9);
   border-radius: 5px;
@@ -307,80 +306,80 @@
 
 /* Overring panel arrow images to fit with our light and dark themes */
 
-.theme-dark .theme-tooltip-panel .panel-arrow {
+.theme-tooltip-panel .panel-arrow {
   --arrow-margin: -4px;
 }
 
-:root[platform="win"].theme-dark ..theme-tooltip-panel .panel-arrow {
+:root[platform="win"]..theme-tooltip-panel .panel-arrow {
   --arrow-margin: -7px;
 }
 
-.theme-dark .theme-tooltip-panel .panel-arrow[side="top"],
-.theme-dark .theme-tooltip-panel .panel-arrow[side="bottom"] {
+.theme-tooltip-panel .panel-arrow[side="top"],
+.theme-tooltip-panel .panel-arrow[side="bottom"] {
   /*list-style-image: url("chrome://devtools/skin/tooltip/arrow-vertical-dark.png");*/
   /* !important is needed to override the popup.css rules in toolkit/themes */
   width: 39px !important;
   height: 16px !important;
 }
 
-.theme-dark .theme-tooltip-panel .panel-arrow[side="left"],
-.theme-dark .theme-tooltip-panel .panel-arrow[side="right"] {
+.theme-tooltip-panel .panel-arrow[side="left"],
+.theme-tooltip-panel .panel-arrow[side="right"] {
   /*list-style-image: url("chrome://devtools/skin/tooltip/arrow-horizontal-dark.png");*/
   /* !important is needed to override the popup.css rules in toolkit/themes */
   width: 16px !important;
   height: 39px !important;
 }
 
-.theme-dark .theme-tooltip-panel .panel-arrow[side="top"] {
+.theme-tooltip-panel .panel-arrow[side="top"] {
   margin-bottom: var(--arrow-margin);
 }
 
-.theme-dark .theme-tooltip-panel .panel-arrow[side="bottom"] {
+.theme-tooltip-panel .panel-arrow[side="bottom"] {
   margin-top: var(--arrow-margin);
 }
 
-.theme-dark .theme-tooltip-panel .panel-arrow[side="left"] {
+.theme-tooltip-panel .panel-arrow[side="left"] {
   margin-right: var(--arrow-margin);
 }
 
-.theme-dark .theme-tooltip-panel .panel-arrow[side="right"] {
+.theme-tooltip-panel .panel-arrow[side="right"] {
   margin-left: var(--arrow-margin);
 }
 
 @media (min-resolution: 1.1dppx) {
-  .theme-dark ..theme-tooltip-panel .panel-arrow[side="top"],
-  .theme-dark ..theme-tooltip-panel .panel-arrow[side="bottom"] {
+  ..theme-tooltip-panel .panel-arrow[side="top"],
+  ..theme-tooltip-panel .panel-arrow[side="bottom"] {
     /*list-style-image: url("chrome://devtools/skin/tooltip/arrow-vertical-dark@2x.png");*/
   }
 
-  .theme-dark ..theme-tooltip-panel .panel-arrow[side="left"],
-  .theme-dark ..theme-tooltip-panel .panel-arrow[side="right"] {
+  ..theme-tooltip-panel .panel-arrow[side="left"],
+  ..theme-tooltip-panel .panel-arrow[side="right"] {
     /*list-style-image: url("chrome://devtools/skin/tooltip/arrow-horizontal-dark@2x.png");*/
   }
 }
 
-.theme-dark .theme-tooltip-panel .devtools-tooltip-simple-text {
+.theme-tooltip-panel .devtools-tooltip-simple-text {
   color: white;
   border-bottom: 1px solid #434850;
 }
 
-.theme-dark .theme-tooltip-panel .devtools-tooltip-simple-text:last-child {
+.theme-tooltip-panel .devtools-tooltip-simple-text:last-child {
   border-bottom: 0;
 }
 
-.theme-dark .devtools-textinput,
-.theme-dark .devtools-searchinput,
-.theme-dark .devtools-filterinput {
+.devtools-textinput,
+.devtools-searchinput,
+.devtools-filterinput {
   background-color: rgba(24, 29, 32, 1);
   color: rgba(184, 200, 217, 1);
 }
 
-.theme-dark .CodeMirror-Tern-fname {
+.CodeMirror-Tern-fname {
   color: #f7f7f7;
 }
 
-.theme-dark .CodeMirror-hints,
-.theme-dark .CodeMirror-Tern-tooltip {
+.CodeMirror-hints,
+.CodeMirror-Tern-tooltip {
   box-shadow: 0 0 4px rgba(255, 255, 255, .3);
   background-color: #0f171f;
   color: var(--theme-body-color);

--- a/packages/devtools-modules/src/themes/firebug-theme.css
+++ b/packages/devtools-modules/src/themes/firebug-theme.css
@@ -7,52 +7,54 @@
 @import url(common.css);
 @import url(light-theme.css);
 
-:root.theme-firebug  {
+@namespace theme-firebug;
+
+:root {
   font-size: 11px;
   font-family: var(--proportional-font-family);
 }
 
 /* CodeMirror Color Syntax */
 
-.theme-firebug .cm-keyword {color: BlueViolet; font-weight: bold;}
-.theme-firebug .cm-atom {color: #219;}
-.theme-firebug .cm-number {color: #164;}
-.theme-firebug .cm-def {color: #00f;}
-.theme-firebug .cm-variable {color: black;}
-.theme-firebug .cm-variable-2 {color: black;}
-.theme-firebug .cm-variable-3 {color: black;}
-.theme-firebug .cm-property {color: black;}
-.theme-firebug .cm-operator {color: black;}
-.theme-firebug .cm-comment {color: Silver;}
-.theme-firebug .cm-string {color: Red;}
-.theme-firebug .cm-string-2 {color: Red;}
-.theme-firebug .cm-meta {color: rgb(120, 120, 120); font-style: italic;}
-.theme-firebug .cm-error {color: #f00;}
-.theme-firebug .cm-qualifier {color: #555;}
-.theme-firebug .cm-builtin {color: #30a;}
-.theme-firebug .cm-bracket {color: #997;}
-.theme-firebug .cm-tag {color: blue;}
-.theme-firebug .cm-attribute {color: rgb(0, 0, 136);}
-.theme-firebug .cm-header {color: blue;}
-.theme-firebug .cm-quote {color: #090;}
-.theme-firebug .cm-hr {color: #999;}
-.theme-firebug .cm-link {color: #00c;}
+.cm-keyword {color: BlueViolet; font-weight: bold;}
+.cm-atom {color: #219;}
+.cm-number {color: #164;}
+.cm-def {color: #00f;}
+.cm-variable {color: black;}
+.cm-variable-2 {color: black;}
+.cm-variable-3 {color: black;}
+.cm-property {color: black;}
+.cm-operator {color: black;}
+.cm-comment {color: Silver;}
+.cm-string {color: Red;}
+.cm-string-2 {color: Red;}
+.cm-meta {color: rgb(120, 120, 120); font-style: italic;}
+.cm-error {color: #f00;}
+.cm-qualifier {color: #555;}
+.cm-builtin {color: #30a;}
+.cm-bracket {color: #997;}
+.cm-tag {color: blue;}
+.cm-attribute {color: rgb(0, 0, 136);}
+.cm-header {color: blue;}
+.cm-quote {color: #090;}
+.cm-hr {color: #999;}
+.cm-link {color: #00c;}
 
-.theme-firebug .theme-fg-color3,
-.theme-firebug .cm-s-mozilla .kind-Object .cm-variable{ /* dark blue */
+.theme-fg-color3,
+.cm-s-mozilla .kind-Object .cm-variable{ /* dark blue */
   color: #006400;
   font-style: normal;
   font-weight: bold;
 }
 
-.theme-firebug .console-string {
+.console-string {
   color: #FF183C;
 }
 
 /* Variables View */
 
-.theme-firebug .variables-view-variable > .title > .name,
-.theme-firebug .variables-view-variable > .title > .value {
+.variables-view-variable > .title > .name,
+.variables-view-variable > .title > .value {
   color: var(--theme-body-color);
 }
 
@@ -65,21 +67,21 @@
 
   Use !important to override even the rule in webconsole.css that uses
   ID in the selector. */
-.theme-firebug .devtools-tabbar,
-.theme-firebug .devtools-sidebar-tabs tabs {
+.devtools-tabbar,
+.devtools-sidebar-tabs tabs {
   background-image: linear-gradient(rgba(253, 253, 253, 0.2), rgba(253, 253, 253, 0));
   border-bottom: 1px solid rgb(170, 188, 207) !important;
 }
 
-.theme-firebug .devtools-sidebar-tabs tabs {
+.devtools-sidebar-tabs tabs {
   background-color: var(--theme-tab-toolbar-background) !important;
   background-image: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2));
 }
 
 /* Add a negative bottom margin to overlap bottom border
   of the parent element (see also the next comment for 'tabs') */
-.theme-firebug .devtools-tab,
-.theme-firebug .devtools-sidebar-tabs tab {
+.devtools-tab,
+.devtools-sidebar-tabs tab {
   margin: 3px 0 -1px 0;
   padding: 2px 0 0 0;
   border: 1px solid transparent !important;
@@ -91,24 +93,24 @@
 }
 
 /* Also add negative bottom margin for side panel tabs*/
-.theme-firebug .devtools-sidebar-tabs tab {
+.devtools-sidebar-tabs tab {
 }
 
 /* In order to hide bottom-border of side panel tabs we need
  to make the parent element overflow visible, so child element
  can move one pixel down to hide the bottom border of the parent. */
-.theme-firebug .devtools-sidebar-tabs tabs {
+.devtools-sidebar-tabs tabs {
   overflow: visible;
 }
 
-.theme-firebug .devtools-tab:hover,
-.theme-firebug .devtools-sidebar-tabs tab:hover {
+.devtools-tab:hover,
+.devtools-sidebar-tabs tab:hover {
   border: 1px solid #C8C8C8 !important;
   border-bottom: 1px solid transparent;
 }
 
-.theme-firebug .devtools-tab[selected],
-.theme-firebug .devtools-sidebar-tabs tab[selected] {
+.devtools-tab[selected],
+.devtools-sidebar-tabs tab[selected] {
   background-color: rgb(247, 251, 254);
   border: 1px solid rgb(170, 188, 207) !important;
   border-bottom-width: 0 !important;
@@ -116,56 +118,56 @@
   color: inherit;
 }
 
-.theme-firebug .devtools-tab spacer,
-.theme-firebug .devtools-tab image {
+.devtools-tab spacer,
+.devtools-tab image {
   display: none;
 }
 
-.theme-firebug .toolbox-tab label {
+.toolbox-tab label {
   margin: 0;
 }
 
-.theme-firebug .devtools-sidebar-tabs tab label {
+.devtools-sidebar-tabs tab label {
   margin: 2px 0 0 0;
 }
 
 /* Use different padding for labels inside tabs on Win platform.
   Make sure this overrides the default in global.css */
-:root[platform="win"].theme-firebug .devtools-sidebar-tabs tab label {
+:root[platform="win"] .devtools-sidebar-tabs tab label {
   margin: 0 4px !important;
 }
 
-.theme-firebug #panelSideBox .devtools-tab[selected],
-.theme-firebug .devtools-sidebar-tabs tab[selected] {
+#panelSideBox .devtools-tab[selected],
+.devtools-sidebar-tabs tab[selected] {
   background-color: white;
 }
 
-.theme-firebug #panelSideBox .devtools-tab:first-child,
-.theme-firebug .devtools-sidebar-tabs tab:first-child {
+#panelSideBox .devtools-tab:first-child,
+.devtools-sidebar-tabs tab:first-child {
   margin-inline-start: 5px;
 }
 
 /* Firebug theme support for the Option (panel) tab */
 
-.theme-firebug #toolbox-tab-options {
+#toolbox-tab-options {
   margin-inline-end: 4px;
   background-color: white;
 }
 
-.theme-firebug #toolbox-tab-options::before {
+#toolbox-tab-options::before {
   display: block;
   margin: 4px 7px 0;
 }
 
-.theme-firebug #toolbox-tab-options:not([selected]):hover::before {
+#toolbox-tab-options:not([selected]):hover::before {
   filter: brightness(80%);
 }
 
 /* Toolbar */
 
-.theme-firebug .theme-toolbar,
-.theme-firebug toolbar,
-.theme-firebug .devtools-toolbar {
+.theme-toolbar,
+toolbar,
+.devtools-toolbar {
   border-bottom: 1px solid rgb(170, 188, 207) !important;
   background-color: var(--theme-tab-toolbar-background) !important;
   background-image: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2));
@@ -174,43 +176,43 @@
 
 /* The vbox for panel content also uses theme-toolbar class from some reason
  but it shouldn't have the padding as defined above, so fix it here */
-.theme-firebug #toolbox-deck > .toolbox-panel.theme-toolbar {
+#toolbox-deck > .toolbox-panel.theme-toolbar {
   padding-inline-end: 0;
 }
 
 /* Space around toolbar buttons */
-.theme-firebug .devtools-toolbar {
+.devtools-toolbar {
   padding: 3px;
 }
 
 /* The height is the same for all toolbars and side panels tabs */
-.theme-firebug .theme-toolbar,
-.theme-firebug .devtools-sidebar-tabs tabs,
-.theme-firebug .devtools-toolbar {
+.theme-toolbar,
+.devtools-sidebar-tabs tabs,
+.devtools-toolbar {
   height: 28px !important;
 }
 
 /* Do not set the fixed height for rule viewtoolbar. This toolbar
   is changing its height to show pseudo classes. */
-.theme-firebug #ruleview-toolbar-container {
+#ruleview-toolbar-container {
   height: auto !important;
 }
 
 /* The Inspector panel side panels are using both
   .devtools-toolbar and .theme-toolbar. We want the
   proportional font for all labels in these toolbars */
-.theme-firebug .devtools-toolbar label,
-.theme-firebug .devtools-toolbar .label,
-.theme-firebug .theme-toolbar label,
-.theme-firebug .theme-toolbar .label {
+.devtools-toolbar label,
+.devtools-toolbar .label,
+.theme-toolbar label,
+.theme-toolbar .label {
   font-family: var(--proportional-font-family);
 }
 
 /* Toolbar Buttons */
 
-.theme-firebug .theme-toolbar button,
-.theme-firebug .devtools-button,
-.theme-firebug toolbarbutton {
+.theme-toolbar button,
+.devtools-button,
+toolbarbutton {
   margin: 1px;
   border-radius: 2px;
   color: var(--theme-body-color);
@@ -218,17 +220,17 @@
   font-size: var(--theme-toolbar-font-size);
 }
 
-.theme-firebug .theme-toolbar button,
-.theme-firebug .devtools-button {
+.theme-toolbar button,
+.devtools-button {
   border-width: 1px !important;
   min-width: 24px;
 }
 
-.theme-firebug .devtools-toolbarbutton {
+.devtools-toolbarbutton {
   min-width: 24px;
 }
 
 
-.theme-firebug #element-picker {
+#element-picker {
   min-height: 21px;
 }

--- a/packages/devtools-modules/src/themes/light-theme.css
+++ b/packages/devtools-modules/src/themes/light-theme.css
@@ -8,43 +8,42 @@
 @import url(toolbars.css);
 @import url(tooltips.css);
 
-.theme-dark .body {
-  margin: 0;
-}
+@namespace theme-light;
 
 .theme-light {
   background: var(--theme-body-background);
   color: var(--theme-body-color);
+  margin: 0;
 }
 
-.theme-light .theme-sidebar {
+.theme-sidebar {
   background: var(--theme-sidebar-background);
   color: var(--theme-body-color);
 }
 
-.theme-light ::-moz-selection {
+::-moz-selection {
   background-color: var(--theme-selection-background);
   color: var(--theme-selection-color);
 }
 
-.theme-light .theme-bg-darker {
+.theme-bg-darker {
   background: var(--theme-selection-background-semitransparent);
 }
 
-.theme-light .theme-selected,
-.theme-light .CodeMirror-hint-active {
+.theme-selected,
+.CodeMirror-hint-active {
   background-color: var(--theme-selection-background);
   color: var(--theme-selection-color);
 }
 
-.theme-light .theme-bg-contrast,
-.theme-light .variable-or-property:not([overridden])[changed] {
+.theme-bg-contrast,
+.variable-or-property:not([overridden])[changed] {
   background: var(--theme-contrast-background);
 }
 
-.theme-light .theme-link,
-.theme-light .cm-s-mozilla .cm-link,
-.theme-light .CodeMirror-Tern-type {
+.theme-link,
+.cm-s-mozilla .cm-link,
+.CodeMirror-Tern-type {
   color: var(--theme-highlight-blue);
 }
 
@@ -52,138 +51,138 @@
  * FIXME: http://bugzil.la/575675 CSS links without :visited set cause assertion
  * failures in debug builds.
  */
-.theme-light .theme-link:visited,
-.theme-light .cm-s-mozilla .cm-link:visited {
+.theme-link:visited,
+.cm-s-mozilla .cm-link:visited {
   color: var(--theme-highlight-blue);
 }
 
-.theme-light .theme-comment,
-.theme-light .cm-s-mozilla .cm-meta,
-.theme-light .cm-s-mozilla .cm-hr,
-.theme-light .cm-s-mozilla .cm-comment,
-.theme-light .variable-or-property .token-undefined,
-.theme-light .variable-or-property .token-null,
-.theme-light .CodeMirror-Tern-completion-unknown:before {
+.theme-comment,
+.cm-s-mozilla .cm-meta,
+.cm-s-mozilla .cm-hr,
+.cm-s-mozilla .cm-comment,
+.variable-or-property .token-undefined,
+.variable-or-property .token-null,
+.CodeMirror-Tern-completion-unknown:before {
   color: var(--theme-comment);
 }
 
-.theme-light .theme-gutter {
+.theme-gutter {
   background-color: var(--theme-tab-toolbar-background);
   color: var(--theme-content-color3);
   border-color: var(--theme-splitter-color);
 }
 
-.theme-light .theme-separator { /* grey */
+.theme-separator { /* grey */
   border-color: #cddae5;
 }
 
-.theme-light .cm-s-mozilla .cm-unused-line {
+.cm-s-mozilla .cm-unused-line {
   text-decoration: line-through;
   text-decoration-color: var(--theme-highlight-bluegrey);
 }
 
-.theme-light .cm-s-mozilla .cm-executed-line {
+.cm-s-mozilla .cm-executed-line {
   background-color: #fcfffc;
 }
 
-.theme-light .theme-fg-color1,
-.theme-light .cm-s-mozilla .cm-number,
-.theme-light .variable-or-property .token-number,
-.theme-light .variable-or-property[return] > .title > .name,
-.theme-light .variable-or-property[scope] > .title > .name {
+.theme-fg-color1,
+.cm-s-mozilla .cm-number,
+.variable-or-property .token-number,
+.variable-or-property[return] > .title > .name,
+.variable-or-property[scope] > .title > .name {
   color: var(--theme-highlight-purple);
 }
 
-.theme-light .CodeMirror-Tern-completion-number:before {
+.CodeMirror-Tern-completion-number:before {
   background-color: hsl(72,100%,27%);
 }
 
-.theme-light .theme-fg-color2,
-.theme-light .cm-s-mozilla .cm-attribute,
-.theme-light .cm-s-mozilla .cm-builtin,
-.theme-light .cm-s-mozilla .cm-property,
-.theme-light .variables-view-variable > .title > .name {
+.theme-fg-color2,
+.cm-s-mozilla .cm-attribute,
+.cm-s-mozilla .cm-builtin,
+.cm-s-mozilla .cm-property,
+.variables-view-variable > .title > .name {
   color: var(--theme-highlight-red);
 }
 
-.theme-light .cm-s-mozilla .cm-def {
+.cm-s-mozilla .cm-def {
   color: var(--theme-body-color);
 }
 
-.theme-light .CodeMirror-Tern-completion-object:before {
+.CodeMirror-Tern-completion-object:before {
   background-color: hsl(208,56%,40%);
 }
 
-.theme-light .theme-fg-color3,
-.theme-light .cm-s-mozilla .cm-variable,
-.theme-light .cm-s-mozilla .cm-tag,
-.theme-light .cm-s-mozilla .cm-header,
-.theme-light .cm-s-mozilla .cm-bracket,
-.theme-light .cm-s-mozilla .cm-qualifier,
-.theme-light .variables-view-property > .title > .name {
+.theme-fg-color3,
+.cm-s-mozilla .cm-variable,
+.cm-s-mozilla .cm-tag,
+.cm-s-mozilla .cm-header,
+.cm-s-mozilla .cm-bracket,
+.cm-s-mozilla .cm-qualifier,
+.variables-view-property > .title > .name {
   color: var(--theme-highlight-blue);
 }
 
-.theme-light .CodeMirror-Tern-completion-array:before {
+.CodeMirror-Tern-completion-array:before {
   background-color: var(--theme-highlight-bluegrey);
 }
 
-.theme-light .theme-fg-color4 {
+.theme-fg-color4 {
   color: var(--theme-highlight-orange);
 }
 
-.theme-light .theme-fg-color5,
-.theme-light .cm-s-mozilla .cm-keyword {
+.theme-fg-color5,
+.cm-s-mozilla .cm-keyword {
   color: var(--theme-highlight-red);
 }
 
-.theme-light .theme-fg-color6,
-.theme-light .cm-s-mozilla .cm-string,
-.theme-light .cm-s-mozilla .cm-string-2,
-.theme-light .variable-or-property .token-string,
-.theme-light .CodeMirror-Tern-farg {
+.theme-fg-color6,
+.cm-s-mozilla .cm-string,
+.cm-s-mozilla .cm-string-2,
+.variable-or-property .token-string,
+.CodeMirror-Tern-farg {
   color: var(--theme-highlight-purple);
 }
 
-.theme-light .CodeMirror-Tern-completion-string:before,
-.theme-light .CodeMirror-Tern-completion-fn:before {
+.CodeMirror-Tern-completion-string:before,
+.CodeMirror-Tern-completion-fn:before {
   background-color: hsl(24,85%,39%);
 }
 
-.theme-light .theme-fg-color7,
-.theme-light .cm-s-mozilla .cm-atom,
-.theme-light .cm-s-mozilla .cm-quote,
-.theme-light .cm-s-mozilla .cm-error,
-.theme-light .variable-or-property .token-boolean,
-.theme-light .variable-or-property .token-domnode,
-.theme-light .variable-or-property[exception] > .title > .name {
+.theme-fg-color7,
+.cm-s-mozilla .cm-atom,
+.cm-s-mozilla .cm-quote,
+.cm-s-mozilla .cm-error,
+.variable-or-property .token-boolean,
+.variable-or-property .token-domnode,
+.variable-or-property[exception] > .title > .name {
   color: var(--theme-highlight-red);
 }
 
-.theme-light .CodeMirror-Tern-completion-bool:before {
+.CodeMirror-Tern-completion-bool:before {
   background-color: #bf5656;
 }
 
-.theme-light .variable-or-property .token-domnode {
+.variable-or-property .token-domnode {
   font-weight: bold;
 }
 
-.theme-light .theme-fg-contrast { /* To be used for text on theme-bg-contrast */
+.theme-fg-contrast { /* To be used for text on theme-bg-contrast */
   color: black;
 }
 
-.theme-light .theme-toolbar,
-.theme-light .devtools-toolbar,
-.theme-light .devtools-sidebar-tabs tabs,
-.theme-light .devtools-sidebar-alltabs,
-.theme-light .cm-s-mozilla .CodeMirror-dialog { /* General toolbar styling */
+.theme-toolbar,
+.devtools-toolbar,
+.devtools-sidebar-tabs tabs,
+.devtools-sidebar-alltabs,
+.cm-s-mozilla .CodeMirror-dialog { /* General toolbar styling */
   color: var(--theme-body-color);
   background-color: var(--theme-toolbar-background);
   border-color: var(--theme-splitter-color);
 }
 
-.theme-light .ruleview-swatch,
-.theme-light .computedview-colorswatch {
+.ruleview-swatch,
+.computedview-colorswatch {
   box-shadow: 0 0 0 1px #c4c4c4;
 }
 
@@ -191,47 +190,47 @@
  * Best effort to match the existing theme, some of the colors
  * are duplicated here to prevent weirdness in the main theme. */
 
-.theme-light .CodeMirror.cm-s-mozilla { /* Inherit platform specific font sizing and styles */
+.CodeMirror.cm-s-mozilla { /* Inherit platform specific font sizing and styles */
   font-family: inherit;
   font-size: inherit;
   background: transparent;
 }
 
-.theme-light .CodeMirror.cm-s-mozilla  pre,
-.theme-light .cm-s-mozilla .cm-variable-2,
-.theme-light .cm-s-mozilla .cm-variable-3,
-.theme-light .cm-s-mozilla .cm-operator,
-.theme-light .cm-s-mozilla .cm-special {
+.CodeMirror.cm-s-mozilla  pre,
+.cm-s-mozilla .cm-variable-2,
+.cm-s-mozilla .cm-variable-3,
+.cm-s-mozilla .cm-operator,
+.cm-s-mozilla .cm-special {
   color: var(--theme-body-color);
 }
 
-.theme-light .cm-s-mozilla .CodeMirror-lines .CodeMirror-cursor {
+.cm-s-mozilla .CodeMirror-lines .CodeMirror-cursor {
   border-left: solid 1px black;
 }
 
-.theme-light .cm-s-mozilla.CodeMirror-focused .CodeMirror-selected { /* selected text (focused) */
+.cm-s-mozilla.CodeMirror-focused .CodeMirror-selected { /* selected text (focused) */
   background: rgb(185, 215, 253);
 }
 
-.theme-light .cm-s-mozilla .CodeMirror-selected { /* selected text (unfocused) */
+.cm-s-mozilla .CodeMirror-selected { /* selected text (unfocused) */
   background: rgb(255, 255, 0);
 }
 
-.theme-light .cm-s-mozilla .CodeMirror-activeline-background { /* selected color with alpha */
+.cm-s-mozilla .CodeMirror-activeline-background { /* selected color with alpha */
   background: rgba(185, 215, 253, .35);
 }
 
-.theme-light .div.cm-s-mozilla span.CodeMirror-matchingbracket { /* highlight brackets */
+.div.cm-s-mozilla span.CodeMirror-matchingbracket { /* highlight brackets */
   outline: solid 1px rgba(0, 0, 0, .25);
   color: black;
 }
 
 /* Highlight for a line that contains an error. */
-.theme-light .div.CodeMirror div.error-line {
+.div.CodeMirror div.error-line {
   background: rgba(255,0,0,0.2);
 }
 
-.theme-light .div.CodeMirror span.marked-text {
+.div.CodeMirror span.marked-text {
   background: rgba(255,255,0,0.2);
   border: 1px dashed rgba(192,192,0,0.6);
   margin-inline-start: -1px;
@@ -239,22 +238,22 @@
 }
 
 /* Highlight for evaluating current statement. */
-.theme-light .div.CodeMirror span.eval-text {
+.div.CodeMirror span.eval-text {
   background-color: #ccd;
 }
 
-.theme-light .cm-s-mozilla .CodeMirror-linenumber { /* line number text */
+.cm-s-mozilla .CodeMirror-linenumber { /* line number text */
   color: var(--theme-content-color3);
 }
 
-.theme-light .cm-s-markup-view pre {
+.cm-s-markup-view pre {
   line-height: 1.4em;
   min-height: 1.4em;
 }
 
 /* Twisty and checkbox controls */
 
-.theme-light .theme-twisty, .theme-checkbox {
+.theme-twisty, .theme-checkbox {
   width: 14px;
   height: 14px;
   background-repeat: no-repeat;
@@ -262,33 +261,33 @@
   background-size: 56px 28px;
 }
 
-.theme-light .theme-twisty {
+.theme-twisty {
   cursor: pointer;
   background-position: 0 -14px;
 }
 
-.theme-light .theme-twisty:-moz-focusring {
+.theme-twisty:-moz-focusring {
   outline-style: none;
 }
 
-.theme-light .theme-twisty[open], .theme-twisty.open {
+.theme-twisty[open], .theme-twisty.open {
   background-position: -14px -14px;
 }
 
-.theme-light .theme-twisty[invisible] {
+.theme-twisty[invisible] {
   visibility: hidden;
 }
 
 /* Use white twisty when next to a selected item in markup view */
-.theme-light .theme-selected ~ .theme-twisty {
+.theme-selected ~ .theme-twisty {
   background-position: -28px -14px;
 }
 
-.theme-light .theme-selected ~ .theme-twisty[open] {
+.theme-selected ~ .theme-twisty[open] {
   background-position: -42px -14px;
 }
 
-.theme-light .theme-checkbox {
+.theme-checkbox {
   display: inline-block;
   border: 0;
   padding: 0;
@@ -296,19 +295,19 @@
   background-position: 0 0;
 }
 
-.theme-light .theme-checkbox[checked] {
+.theme-checkbox[checked] {
   background-position: -14px 0;
 }
 
 @media (min-resolution: 1.1dppx) {
-  .theme-dark ..theme-twisty, .theme-checkbox {
+  ..theme-twisty, .theme-checkbox {
     /* background-image: url("chrome://devtools/skin/images/controls@2x.png"); */
   }
 }
 
 /* XUL panel styling (see devtools/client/shared/widgets/Tooltip.js) */
 
-.theme-light .theme-tooltip-panel .panel-arrowcontent {
+.theme-tooltip-panel .panel-arrowcontent {
   padding: 4px;
   background: rgba(255, 255, 255, .9);
   border-radius: 5px;
@@ -318,7 +317,7 @@
 
 /* Overring panel arrow images to fit with our light and dark themes */
 
-.theme-light .theme-tooltip-panel .panel-arrow {
+.theme-tooltip-panel .panel-arrow {
   --arrow-margin: -4px;
 }
 
@@ -326,35 +325,35 @@
   --arrow-margin: -7px;
 }
 
-.theme-light .theme-tooltip-panel .panel-arrow[side="top"],
-.theme-light .theme-tooltip-panel .panel-arrow[side="bottom"] {
+.theme-tooltip-panel .panel-arrow[side="top"],
+.theme-tooltip-panel .panel-arrow[side="bottom"] {
   /* list-style-image: url("chrome://devtools/skin/tooltip/arrow-vertical-light.png"); */
   /* !important is needed to override the popup.css rules in toolkit/themes */
   width: 39px !important;
   height: 16px !important;
 }
 
-.theme-light .theme-tooltip-panel .panel-arrow[side="left"],
-.theme-light .theme-tooltip-panel .panel-arrow[side="right"] {
+.theme-tooltip-panel .panel-arrow[side="left"],
+.theme-tooltip-panel .panel-arrow[side="right"] {
   /* list-style-image: url("chrome://devtools/skin/tooltip/arrow-horizontal-light.png"); */
   /* !important is needed to override the popup.css rules in toolkit/themes */
   width: 16px !important;
   height: 39px !important;
 }
 
-.theme-light .theme-tooltip-panel .panel-arrow[side="top"] {
+.theme-tooltip-panel .panel-arrow[side="top"] {
   margin-bottom: var(--arrow-margin);
 }
 
-.theme-light .theme-tooltip-panel .panel-arrow[side="bottom"] {
+.theme-tooltip-panel .panel-arrow[side="bottom"] {
   margin-top: var(--arrow-margin);
 }
 
-.theme-light .theme-tooltip-panel .panel-arrow[side="left"] {
+.theme-tooltip-panel .panel-arrow[side="left"] {
   margin-right: var(--arrow-margin);
 }
 
-.theme-light .theme-tooltip-panel .panel-arrow[side="right"] {
+.theme-tooltip-panel .panel-arrow[side="right"] {
   margin-left: var(--arrow-margin);
 }
 
@@ -370,17 +369,17 @@
   }
 }
 
-.theme-light .theme-tooltip-panel .devtools-tooltip-simple-text {
+.theme-tooltip-panel .devtools-tooltip-simple-text {
   color: black;
   border-bottom: 1px solid #d9e1e8;
 }
 
-.theme-light .theme-tooltip-panel .devtools-tooltip-simple-text:last-child {
+.theme-tooltip-panel .devtools-tooltip-simple-text:last-child {
   border-bottom: 0;
 }
 
-.theme-light .CodeMirror-hints,
-.theme-light .CodeMirror-Tern-tooltip {
+.CodeMirror-hints,
+.CodeMirror-Tern-tooltip {
   box-shadow: 0 0 4px rgba(128, 128, 128, .5);
   background-color: var(--theme-sidebar-background);
 }


### PR DESCRIPTION
Associated Issue: #641 

### Summary of Changes

We would like to remove the theme namespacing because it is making it harder to sync. Eventually it would be nice to pull these styles from searchfox, but we don't need to do that now. 

Next steps:

1. get this working
2. see what regressions exist between themes and rectify that. I'm happy to add a script that does the diff so it's easy to see what's different and fix it.