### PR TITLE
Add styling to the tree

### DIFF
--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -3,11 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .tree {
-  --tree-indent-width: 1em;
   --arrow-width: 10px;
   --arrow-single-margin: 5px;
   --arrow-total-width: calc(var(--arrow-width) + var(--arrow-single-margin));
-  --arrow-fill-color: var(--theme-splitter-color);
+  --arrow-fill-color: var(--theme-splitter-color, #9B9B9B);
+  --tree-indent-width: 1em;
+  --tree-indent-border-color: #A2D1FF;
+  --tree-indent-border-width: 1px;
+  --tree-node-hover-background-color: #F0F9FE;
+  --tree-node-focus-color: white;
+  --tree-node-focus-background-color: var(--theme-selection-background, #0a84ff);
   overflow: auto;
 }
 
@@ -32,14 +37,17 @@
 }
 
 .tree .tree-node {
-  padding: 0 0.25em;
-  position: relative;
   cursor: pointer;
 }
 
+.tree .tree-node:not(.focused):hover {
+  background-color: var(--tree-node-hover-background-color);
+}
+
 .tree .tree-node.focused {
-  color: white;
-  background-color: var(--theme-selection-background);
+  color: var(--tree-node-focus-color);
+  background-color: var(--tree-node-focus-background-color);
+  --arrow-fill-color: currentColor;
 }
 
 .arrow svg {

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -79,10 +79,37 @@ const TreeNode = createFactory(createClass({
       })
       : null;
 
-    const indentWidth = `calc(
-      (var(--tree-indent-width) * ${depth})
+    const treeIndentWidthVar = "var(--tree-indent-width)";
+    const treeBorderColorVar = "var(--tree-indent-border-color, black)";
+    const treeBorderWidthVar = "var(--tree-indent-border-width, 1px)";
+
+    const paddingInlineStart = `calc(
+      (${treeIndentWidthVar} * ${depth})
       ${(hasChildren ? "" : "+ var(--arrow-total-width)")}
     )`;
+
+    // This is the computed border that will mimic a border on tree nodes.
+    // This allow us to have as many "borders" as we need without adding
+    // specific elements for that purpose only.
+    // it's a gradient with "hard stops" which will give us as much plain
+    // lines as we need given the depth of the node.
+    // The gradient uses CSS custom properties so everything is customizable
+    // by consumers if needed.
+    const backgroundBorder = depth === 0
+      ? null
+      : "linear-gradient(90deg, " +
+          Array.from({length: depth}).map((_, i) => {
+            const indentWidth = `(${i} * ${treeIndentWidthVar})`;
+            const alignIndent = `(var(--arrow-width) / 2)`;
+            const start = `calc(${indentWidth} + ${alignIndent})`;
+            const end = `calc(${indentWidth} + ${alignIndent} + ${treeBorderWidthVar})`;
+
+            return `transparent ${start},
+              ${treeBorderColorVar} ${start},
+              ${treeBorderColorVar} ${end},
+              transparent ${end}`;
+          }).join(",") +
+        ")";
 
     let ariaExpanded;
     if (this.props.hasChildren) {
@@ -94,9 +121,10 @@ const TreeNode = createFactory(createClass({
 
     return dom.div(
       {
-        className: "tree-node",
+        className: "tree-node" + (focused ? " focused" : ""),
         style: {
-          paddingInlineStart: indentWidth,
+          paddingInlineStart,
+          backgroundImage: backgroundBorder,
         },
         onClick: this.props.onClick,
         role: "treeitem",
@@ -151,13 +179,20 @@ function oncePerAnimationFrame(fn) {
  * "traditional" tree or as rows in a table or anything else. It doesn't
  * restrict you to only one certain kind of tree.
  *
- * The tree comes with basic styling for the indent and the arrow size and color.
- * All of this can be customize on the customer end overriding the following
+ * The tree comes with basic styling for the indent, the arrow, as well as hovered
+ * and focused styles.
+ * All of this can be customize on the customer end, by overriding the following
  * CSS custom properties :
- *   --tree-indent-width: the width of a 1-level-deep item.
  *   --arrow-width: the width of the arrow.
  *   --arrow-single-margin: the end margin between the arrow and the item that follows.
  *   --arrow-fill-color: the fill-color of the arrow.
+ *   --tree-indent-width: the width of a 1-level-deep item.
+ *   --tree-indent-border-color: the color of the indent border.
+ *   --tree-indent-border-width: the width of the indent border.
+ *   --tree-node-hover-background-color: the background color of a hovered node.
+ *   --tree-node-focus-color: the color of a focused node.
+ *   --tree-node-focus-background-color: the background color of a focused node.
+ *
  *
  * ### Example Usage
  *

--- a/packages/devtools-components/stories/tree.js
+++ b/packages/devtools-components/stories/tree.js
@@ -118,9 +118,7 @@ function renderTree(props) {
         getChildren: x => TEST_TREE.children[x],
         renderItem: (x, depth, focused, arrow, expanded) => dom.div({},
           arrow,
-          focused ? "[" : null,
           x,
-          focused ? "]" : null
         ),
         getRoots: () => ["A"],
         getKey: x => "key-" + x,


### PR DESCRIPTION
This PR is mainly about adding a fake border to the tree, as well as proper focused and hover styling, which match [the devtools photon guideline](https://docs.google.com/document/d/1AJ7oHC7akXJiliheHjhFc4fTonaN31Eo_P2M8gssL8s/edit#heading=h.o8ous6wzxnb5): 

![screen shot 2017-09-12 at 14 53 35](https://user-images.githubusercontent.com/578107/30326853-2e632620-97ca-11e7-9c57-65abf0ca7464.png)

The border is added with a linear-gradient background-image so we can avoid to have dedicated html elements to only have borders and width.
Everything relies on CSS custom properties so consumers can change whatever they want by overiding the properties in their CSS (i'm thinking about the source tree in the debugger that might not need border ? ).

CI is still failing because lerna make devtools-reps use the devtools-components from the tree instead of the one from npm, but everything is green locally.