### PR TITLE
Add a isExpandable prop callback to the Tree component

### DIFF
--- a/packages/devtools-components/src/tests/__snapshots__/tree.js.snap
+++ b/packages/devtools-components/src/tests/__snapshots__/tree.js.snap
@@ -691,3 +691,8 @@ exports[`Tree renders as expected with collapsed nodes 1`] = `
 |  ▼ N
 |  |    O"
 `;
+
+exports[`Tree uses isExpandable prop if it exists to render tree nodes 1`] = `
+"▶︎ A
+  M"
+`;

--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -295,6 +295,13 @@ describe("Tree", () => {
       expect(arrow.hasClass("expanded")).toBe(false);
     });
   });
+
+  it("uses isExpandable prop if it exists to render tree nodes", () => {
+    const wrapper = mountTree({
+      isExpandable: item => item === "A"
+    });
+    expect(formatTree(wrapper)).toMatchSnapshot();
+  });
 });
 
 function getTreeNodes(wrapper) {


### PR DESCRIPTION
Previously, the Tree component relied on the length of the result of `getChildren` to know if a node was expandable and render an arrow in front of it.
But it might happen in some consumer that a node **is** expandable but `getChildren` returns an empty array at the moment.
This is the case for the ObjectInspector where properties are lazily loaded, so at the time we render the tree, some nodes might not have children _yet_ .
Adding this `isExpandable` prop gives the consumer the ability to tell if a given node is expandable or not, since it's the one that knows the logic better.

This PR adds a test as well as test to make sure the prop works as intended. 