### PR TITLE
Use arrow and styles from the Tree component

### DIFF
--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "devtools-components": "^0.0.2",
+    "devtools-components": "^0.0.4",
     "lodash": "^4.17.2",
     "react": "=15.3.2",
     "react-dom": "=15.3.2",

--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -1,69 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-.tree {
-  overflow: auto;
-}
-
-.tree.inline {
-  display: inline-block;
-}
-
-.tree.nowrap {
-  white-space: nowrap;
-}
-
-.tree.noselect {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none;
-}
-
-.tree button {
-  display: block;
-}
-
-.tree .node {
-  padding: 0 0.25em;
-  position: relative;
-  cursor: pointer;
-}
-
-.tree .node.focused {
-  color: white;
-  background-color: var(--theme-selection-background);
-}
-
-.arrow svg {
-  fill: var(--theme-splitter-color);
-  transition: transform 0.125s ease;
-  width: 10px;
-  margin-inline-end: 5px;
-  transform: rotate(-90deg);
-}
-
-html[dir="rtl"] .arrow svg,
-.arrow svg:dir(rtl),
-.arrow svg:-moz-locale-dir(rtl) {
-  transform: rotate(90deg);
-}
-
-.arrow.expanded.expanded svg {
-  transform: rotate(0deg);
-}
-
-.object-label, .object-label * {
+.tree.object-inspector .object-label, .object-label * {
   color: var(--theme-highlight-blue);
 }
 
-.tree .node .unavailable {
+.tree.object-inspector .node .unavailable {
   color: var(--theme-content-color3);
 }
 
 .lessen {
   opacity: 0.6;
 }
-

--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -15,7 +15,7 @@ const Tree = createFactory(Components.Tree);
 require("./index.css");
 
 const classnames = require("classnames");
-const Svg = require("../shared/images/Svg");
+
 const {
   REPS: {
     Rep,
@@ -395,9 +395,6 @@ class ObjectInspector extends Component {
     const hasLabel = label !== null && typeof label !== "undefined";
     const hasValue = typeof objectValue !== "undefined";
 
-    const SINGLE_INDENT_WIDTH = 15;
-    const indentWidth = (depth + (isPrimitive ? 1 : 0)) * SINGLE_INDENT_WIDTH;
-
     const {
       onDoubleClick,
       onLabelClick,
@@ -418,15 +415,12 @@ class ObjectInspector extends Component {
               )
           )
         }),
-        style: {
-          marginLeft: indentWidth
-        },
-        onClick: isPrimitive === false
-          ? e => {
-            e.stopPropagation();
+        onClick: e => {
+          e.stopPropagation();
+          if (isPrimitive === false) {
             this.setExpanded(item, !expanded);
           }
-          : null,
+        },
         onDoubleClick: onDoubleClick
           ? e => {
             e.stopPropagation();
@@ -438,13 +432,7 @@ class ObjectInspector extends Component {
           }
           : null
       },
-      isPrimitive === false
-        ? Svg("arrow", {
-          className: classnames({
-            expanded: expanded
-          })
-        })
-        : null,
+      arrow,
       hasLabel
         ? dom.span(
           {
@@ -513,6 +501,7 @@ class ObjectInspector extends Component {
       className: classnames({
         inline,
         nowrap: disableWrap,
+        "object-inspector": true,
       }),
       autoExpandAll,
       autoExpandDepth,
@@ -520,6 +509,7 @@ class ObjectInspector extends Component {
       itemHeight,
 
       isExpanded: item => expandedPaths.has(this.getKey(item)),
+      isExpandable: item => nodeIsPrimitive(item) === false,
       focused: focusedItem,
 
       getRoots: this.getRoots,

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
@@ -2,11 +2,11 @@
 
 exports[`ObjectInspector - classnames has the expected class 1`] = `
 "<ObjectInspector autoExpandDepth={0} roots={{...}} createObjectClient={[Function]}>
-  <Tree className=\\"\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
-    <div className=\\"tree \\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} style={{...}}>
-      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
-        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
-          <div className=\\"node object-node\\" data-depth={0} style={{...}} onClick={{...}} onDoubleClick={{...}}>
+  <Tree className=\\"object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]}>
+          <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
             <span className=\\"object-label\\" onClick={{...}}>
               root
             </span>
@@ -17,7 +17,6 @@ exports[`ObjectInspector - classnames has the expected class 1`] = `
               42
             </span>
           </div>
-          <button style={{...}} />
         </div>
       </TreeNode>
     </div>
@@ -27,11 +26,11 @@ exports[`ObjectInspector - classnames has the expected class 1`] = `
 
 exports[`ObjectInspector - classnames has the inline class when inline prop is true 1`] = `
 "<ObjectInspector autoExpandDepth={0} roots={{...}} createObjectClient={[Function]} inline={true}>
-  <Tree className=\\"inline\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
-    <div className=\\"tree inline\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} style={{...}}>
-      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
-        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
-          <div className=\\"node object-node\\" data-depth={0} style={{...}} onClick={{...}} onDoubleClick={{...}}>
+  <Tree className=\\"inline object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree inline object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]}>
+          <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
             <span className=\\"object-label\\" onClick={{...}}>
               root
             </span>
@@ -42,7 +41,6 @@ exports[`ObjectInspector - classnames has the inline class when inline prop is t
               42
             </span>
           </div>
-          <button style={{...}} />
         </div>
       </TreeNode>
     </div>
@@ -52,11 +50,11 @@ exports[`ObjectInspector - classnames has the inline class when inline prop is t
 
 exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop is true 1`] = `
 "<ObjectInspector autoExpandDepth={0} roots={{...}} createObjectClient={[Function]} disableWrap={true}>
-  <Tree className=\\"nowrap\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
-    <div className=\\"tree nowrap\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} style={{...}}>
-      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} hasChildren={false} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]}>
-        <div className=\\"tree-node div \\" onFocus={[Function]} onClick={[Function]} onBlur={[undefined]} style={{...}}>
-          <div className=\\"node object-node\\" data-depth={0} style={{...}} onClick={{...}} onDoubleClick={{...}}>
+  <Tree className=\\"nowrap object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree nowrap object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]}>
+          <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
             <span className=\\"object-label\\" onClick={{...}}>
               root
             </span>
@@ -67,7 +65,6 @@ exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop
               42
             </span>
           </div>
-          <button style={{...}} />
         </div>
       </TreeNode>
     </div>

--- a/packages/devtools-reps/src/object-inspector/tests/test-utils.js
+++ b/packages/devtools-reps/src/object-inspector/tests/test-utils.js
@@ -19,9 +19,9 @@
  *
  */
 function formatObjectInspector(wrapper) {
-  return wrapper.find(".node")
+  return wrapper.find(".tree-node")
     .map(node => {
-      const indentStr = "|  ".repeat(node.prop("data-depth") || 0);
+      const indentStr = "|  ".repeat(node.prop("aria-level") || 0);
       const arrow = node.find(".arrow");
       let arrowStr = "  ";
       if (arrow.exists()) {

--- a/packages/devtools-reps/src/shared/images/Svg.js
+++ b/packages/devtools-reps/src/shared/images/Svg.js
@@ -6,7 +6,6 @@ const React = require("react");
 const InlineSVG = require("svg-inline-react");
 
 const svg = {
-  "arrow": require("./arrow.svg"),
   "open-inspector": require("./open-inspector.svg"),
 };
 

--- a/packages/devtools-reps/src/shared/images/arrow.svg
+++ b/packages/devtools-reps/src/shared/images/arrow.svg
@@ -1,6 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <path d="M8 13.4c-.5 0-.9-.2-1.2-.6L.4 5.2C0 4.7-.1 4.3.2 3.7S1 3 1.6 3h12.8c.6 0 1.2.1 1.4.7.3.6.2 1.1-.2 1.6l-6.4 7.6c-.3.4-.7.5-1.2.5z"/>
-</svg>

--- a/packages/devtools-reps/yarn.lock
+++ b/packages/devtools-reps/yarn.lock
@@ -1604,9 +1604,12 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-devtools-components@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/devtools-components/-/devtools-components-0.0.2.tgz#4eb22cb5140e65741b00b79a7f76454ff56fa501"
+devtools-components@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/devtools-components/-/devtools-components-0.0.4.tgz#68ae84d5a5fb73b05b842380eed48d77a997576c"
+  dependencies:
+    svg-inline-loader "^0.8.0"
+    svg-inline-react "^1.0.2"
 
 devtools-config@^0.0.15:
   version "0.0.15"


### PR DESCRIPTION
This allow us to remove our custom arrow and custom styles.
We add an extra `object-inspector` classname on the tree so we can override CSS properties safely