### PR TITLE
Support symmetric locations

### DIFF
--- a/packages/devtools-source-map/package.json
+++ b/packages/devtools-source-map/package.json
@@ -6,7 +6,8 @@
   "author": "J. Ryan Stinnett <jryans@gmail.com>",
   "repository": "github:devtools-html/devtools-core",
   "bugs": "https://github.com/devtools-html/devtools-core/issues",
-  "homepage": "https://github.com/devtools-html/devtools-core/tree/master/packages/devtools-source-map#readme",
+  "homepage":
+    "https://github.com/devtools-html/devtools-core/tree/master/packages/devtools-source-map#readme",
   "main": "src/index.js",
   "scripts": {
     "copy-assets": "node bin/copy-assets",
@@ -29,7 +30,11 @@
   "jest": {
     "rootDir": "src",
     "testMatch": ["**/tests/**/*.js"],
-    "testPathIgnorePatterns": ["/node_modules/", "/tests/fixtures/"],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/tests/fixtures/",
+      "<rootDir>/tests/helpers.js"
+    ],
     "transformIgnorePatterns": [],
     "setupFiles": [],
     "moduleNameMapper": {}

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -68,9 +68,8 @@ async function getGeneratedLocation(
 
   return {
     sourceId: generatedSourceId,
-    line: line,
-    // Treat 0 as no column so that line breakpoints work correctly.
-    column: column === 0 ? undefined : column
+    line,
+    column
   };
 }
 
@@ -84,19 +83,19 @@ async function getOriginalLocation(location: Location): Promise<Location> {
     return location;
   }
 
-  const { source: url, line, column } = map.originalPositionFor({
+  const { source: sourceUrl, line, column } = map.originalPositionFor({
     line: location.line,
-    column: location.column == null ? Infinity : location.column
+    column: location.column == null ? 0 : location.column
   });
 
-  if (url == null) {
+  if (sourceUrl == null) {
     // No url means the location didn't map.
     return location;
   }
 
   return {
-    sourceId: generatedToOriginalId(location.sourceId, url),
-    sourceUrl: url,
+    sourceId: generatedToOriginalId(location.sourceId, sourceUrl),
+    sourceUrl,
     line,
     column
   };

--- a/packages/devtools-source-map/src/tests/fixtures/if.js
+++ b/packages/devtools-source-map/src/tests/fixtures/if.js
@@ -1,0 +1,12 @@
+function componentWillReceiveProps(nextProps) {
+	console.log('start');
+    const { selectedSource } = nextProps;
+
+    if (
+      nextProps.startPanelSize !== this.props.startPanelSize ||
+      nextProps.endPanelSize !== this.props.endPanelSize
+    ) {
+      this.state.editor.codeMirror.setSize();
+    }
+	console.log('done');
+}

--- a/packages/devtools-source-map/src/tests/fixtures/if.out.js
+++ b/packages/devtools-source-map/src/tests/fixtures/if.out.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function componentWillReceiveProps(nextProps) {
+  console.log('start');
+  var selectedSource = nextProps.selectedSource;
+
+
+  if (nextProps.startPanelSize !== this.props.startPanelSize || nextProps.endPanelSize !== this.props.endPanelSize) {
+    this.state.editor.codeMirror.setSize();
+  }
+  console.log('done');
+}
+
+//# sourceMappingURL=if.out.js.map

--- a/packages/devtools-source-map/src/tests/fixtures/if.out.js.map
+++ b/packages/devtools-source-map/src/tests/fixtures/if.out.js.map
@@ -1,0 +1,7 @@
+{
+    "version":3,
+    "sources":["if.js"],
+    "names":[],
+    "mappings":";;AAAA,SAAS,yBAAT,CAAmC,SAAnC,EAA8C;AAC7C,UAAQ,GAAR,CAAY,OAAZ;AAD6C,MAElC,cAFkC,GAEf,SAFe,CAElC,cAFkC;;;AAI1C,MACE,UAAU,cAAV,KAA6B,KAAK,KAAL,CAAW,cAAxC,IACA,UAAU,YAAV,KAA2B,KAAK,KAAL,CAAW,YAFxC,EAGE;AACA,SAAK,KAAL,CAAW,MAAX,CAAkB,UAAlB,CAA6B,OAA7B;AACD;AACJ,UAAQ,GAAR,CAAY,MAAZ;AACA","file":"if.out.js",
+    "sourcesContent":["function componentWillReceiveProps(nextProps) {\n\tconsole.log('start');\n    const { selectedSource } = nextProps;\n\n    if (\n      nextProps.startPanelSize !== this.props.startPanelSize ||\n      nextProps.endPanelSize !== this.props.endPanelSize\n    ) {\n      this.state.editor.codeMirror.setSize();\n    }\n\tconsole.log('done');\n}\n"]
+}

--- a/packages/devtools-source-map/src/tests/helpers.js
+++ b/packages/devtools-source-map/src/tests/helpers.js
@@ -1,0 +1,42 @@
+const { isOriginalId } = require("../utils");
+const { getOriginalURLs } = require("../source-map");
+
+const fs = require("fs");
+const path = require("path");
+
+function formatLocations(locs) {
+  return locs.map(formatLocation).join(" -> ");
+}
+
+function formatLocation(loc) {
+  const label = isOriginalId(loc.sourceId) ? "O" : "G";
+  const col = loc.column === undefined ? "u" : loc.column;
+  return `${label}[${loc.line}, ${col}]`;
+}
+
+function getMap(_path) {
+  const mapPath = path.join(__dirname, _path);
+  return fs.readFileSync(mapPath, "utf8");
+}
+
+async function setupBundleFixture(name) {
+  const source = {
+    id: `${name}.js`,
+    sourceMapURL: `${name}.js.map`,
+    url: `http://example.com/${name}.js`
+  };
+
+  require("devtools-utils/src/network-request").mockImplementationOnce(() => {
+    const content = getMap(`fixtures/${name}.js.map`);
+    return { content };
+  });
+
+  return await getOriginalURLs(source);
+}
+
+module.exports = {
+  formatLocations,
+  formatLocation,
+  setupBundleFixture,
+  getMap
+};

--- a/packages/devtools-source-map/src/tests/locations.js
+++ b/packages/devtools-source-map/src/tests/locations.js
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+jest.mock("devtools-utils/src/network-request");
+const {
+  getOriginalURLs,
+  hasMappedSource,
+  getOriginalLocation,
+  getGeneratedLocation,
+  clearSourceMaps
+} = require("../source-map");
+
+const {
+  formatLocations,
+  formatLocation,
+  setupBundleFixture,
+  getMap
+} = require("./helpers");
+
+describe("getOriginalLocation", async () => {
+  beforeEach(() => {
+    clearSourceMaps();
+  });
+
+  test("maps a generated location", async () => {
+    await setupBundleFixture("bundle");
+    const location = {
+      sourceId: "bundle.js",
+      line: 49
+    };
+
+    const originalLocation = await getOriginalLocation(location);
+    expect(originalLocation).toEqual({
+      column: 0,
+      line: 3,
+      sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a",
+      sourceUrl: "webpack:///entry.js"
+    });
+  });
+
+  test("does not map an original location", async () => {
+    const location = {
+      column: 0,
+      line: 3,
+      sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a",
+      sourceUrl: "webpack:///entry.js"
+    };
+    const originalLocation = await getOriginalLocation(location);
+    expect(originalLocation).toEqual(originalLocation);
+  });
+});
+
+describe("getGeneratedLocation", async () => {
+  beforeEach(() => {
+    clearSourceMaps();
+  });
+
+  test("maps an original location", async () => {
+    await setupBundleFixture("bundle");
+    const location = {
+      column: 0,
+      line: 3,
+      sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a"
+    };
+
+    const source = {
+      url: "webpack:///entry.js",
+      id: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a"
+    };
+
+    const generatedLocation = await getGeneratedLocation(location, source);
+    expect(generatedLocation).toEqual({
+      sourceId: "bundle.js",
+      line: 49,
+      column: 0
+    });
+  });
+
+  test("location mapping is symmetric", async () => {
+    // we expect symmetric mappings, which means that if
+    // we map a generated location to an original location,
+    // and then map it back, we should get the original generated value.
+    // e.g. G[8, 0] -> O[5, 4] -> G[8, 0]
+
+    await setupBundleFixture("if.out");
+
+    const genLoc1 = {
+      sourceId: "if.out.js",
+      column: 0,
+      line: 8
+    };
+
+    const ifSource = {
+      url: "if.js",
+      id: "if.out.js/originalSource-5ad3141023dae912c5f8833c7e03beeb"
+    };
+
+    const oLoc = await getOriginalLocation(genLoc1);
+    const genLoc2 = await getGeneratedLocation(oLoc, ifSource);
+
+    expect(genLoc2).toEqual({
+      sourceId: "if.out.js",
+      column: 0,
+      line: 8
+    });
+  });
+
+  test("undefined column is handled like 0 column", async () => {
+    // we expect that an undefined column will be handled like a
+    // location w/ column 0. e.g. G[8, u] -> O[5, 4] -> G[8, 0]
+
+    await setupBundleFixture("if.out");
+
+    const genLoc1 = {
+      sourceId: "if.out.js",
+      column: undefined,
+      line: 8
+    };
+
+    const ifSource = {
+      url: "if.js",
+      id: "if.out.js/originalSource-5ad3141023dae912c5f8833c7e03beeb"
+    };
+
+    const oLoc = await getOriginalLocation(genLoc1);
+    const genLoc2 = await getGeneratedLocation(oLoc, ifSource);
+    // console.log(formatLocations([genLoc1, oLoc, genLoc2]));
+
+    expect(genLoc2).toEqual({
+      sourceId: "if.out.js",
+      column: 0,
+      line: 8
+    });
+  });
+
+  test("does not map an original location", async () => {
+    const location = {
+      column: 0,
+      line: 3,
+      sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a",
+      sourceUrl: "webpack:///entry.js"
+    };
+
+    const source = {
+      url: "webpack:///entry.js",
+      id: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a"
+    };
+
+    const generatedLocation = await getGeneratedLocation(location, source);
+    expect(generatedLocation).toEqual(generatedLocation);
+  });
+});

--- a/packages/devtools-source-map/src/tests/source-map.js
+++ b/packages/devtools-source-map/src/tests/source-map.js
@@ -2,110 +2,59 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const fs = require("fs");
-const path = require("path");
-
 jest.mock("devtools-utils/src/network-request");
+let networkRequest = require("devtools-utils/src/network-request");
+
 const {
   getOriginalURLs,
   hasMappedSource,
   getOriginalLocation,
-  getGeneratedLocation
+  getGeneratedLocation,
+  clearSourceMaps
 } = require("../source-map");
 
-function getMap(_path) {
-  const mapPath = path.join(__dirname, _path);
-  return fs.readFileSync(mapPath, "utf8");
-}
-
-async function setupBundleFixture() {
-  const source = {
-    id: "bundle.js",
-    sourceMapURL: "bundle.js.map",
-    url: "http:://example.com/bundle.js"
-  };
-
-  require("devtools-utils/src/network-request").mockImplementationOnce(() => {
-    const content = getMap("fixtures/bundle.js.map");
-    return { content };
-  });
-
-  await getOriginalURLs(source);
-}
+const {
+  formatLocations,
+  formatLocation,
+  setupBundleFixture,
+  getMap
+} = require("./helpers");
 
 describe("source maps", () => {
-  test("getOriginalURLs", async () => {
-    const source = {
-      id: "bundle.js",
-      sourceMapURL: "bundle.js.map",
-      url: "http:://example.com/bundle.js"
-    };
-
-    require("devtools-utils/src/network-request").mockImplementationOnce(() => {
-      const content = getMap("fixtures/bundle.js.map");
-      return { content };
-    });
-
-    const urls = await getOriginalURLs(source);
-    expect(urls).toEqual([
-      "webpack:/webpack/bootstrap 4ef8c7ec7c1df790781e",
-      "webpack:///entry.js",
-      "webpack:///times2.js",
-      "webpack:///output.js",
-      "webpack:///opts.js"
-    ]);
+  beforeEach(() => {
+    clearSourceMaps();
   });
-
-  test("URL resolution", async () => {
-    const source = {
-      id: "absolute.js",
-      sourceMapURL: "absolute.js.map"
-    };
-
-    require("devtools-utils/src/network-request").mockImplementationOnce(() => {
-      const content = getMap("fixtures/absolute.js.map");
-      return { content };
+  describe("getOriginalURLs", () => {
+    test("absolute URL", async () => {
+      const urls = await setupBundleFixture("absolute");
+      expect(urls).toEqual(["http://example.com/cheese/heart.js"]);
     });
 
-    const urls = await getOriginalURLs(source);
-    expect(urls).toEqual(["http://example.com/cheese/heart.js"]);
-  });
-
-  test("Empty sourceRoot resolution", async () => {
-    const source = {
-      id: "empty.js",
-      url: "http://example.com/whatever/empty.js",
-      sourceMapURL: "empty.js.map"
-    };
-
-    require("devtools-utils/src/network-request").mockImplementationOnce(() => {
-      const content = getMap("fixtures/empty.js.map");
-      return { content };
+    test("source with a url", async () => {
+      const urls = await setupBundleFixture("bundle");
+      expect(urls).toEqual([
+        "webpack:/webpack/bootstrap 4ef8c7ec7c1df790781e",
+        "webpack:///entry.js",
+        "webpack:///times2.js",
+        "webpack:///output.js",
+        "webpack:///opts.js"
+      ]);
     });
 
-    const urls = await getOriginalURLs(source);
-    expect(urls).toEqual(["http://example.com/whatever/heart.js"]);
-  });
-
-  test("Non-existing sourceRoot resolution", async () => {
-    const source = {
-      id: "noroot.js",
-      url: "http://example.com/whatever/noroot.js",
-      sourceMapURL: "noroot.js.map"
-    };
-
-    require("devtools-utils/src/network-request").mockImplementationOnce(() => {
-      const content = getMap("fixtures/noroot.js.map");
-      return { content };
+    test("Empty sourceRoot resolution", async () => {
+      const urls = await setupBundleFixture("empty");
+      expect(urls).toEqual(["http://example.com/heart.js"]);
     });
 
-    const urls = await getOriginalURLs(source);
-    expect(urls).toEqual(["http://example.com/whatever/heart.js"]);
+    test("Non-existing sourceRoot resolution", async () => {
+      const urls = await setupBundleFixture("noroot");
+      expect(urls).toEqual(["http://example.com/heart.js"]);
+    });
   });
 
   describe("hasMappedSource", async () => {
     test("has original location", async () => {
-      await setupBundleFixture();
+      await setupBundleFixture("bundle");
       const location = {
         sourceId: "bundle.js",
         line: 49
@@ -124,104 +73,38 @@ describe("source maps", () => {
     });
   });
 
-  describe("getOriginalLocation", async () => {
-    test("maps a generated location", async () => {
-      await setupBundleFixture();
-      const location = {
-        sourceId: "bundle.js",
-        line: 49
-      };
-
-      const originalLocation = await getOriginalLocation(location);
-      expect(originalLocation).toEqual({
-        column: 0,
-        line: 3,
-        sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a",
-        sourceUrl: "webpack:///entry.js"
-      });
-    });
-
-    test("does not map an original location", async () => {
-      const location = {
-        column: 0,
-        line: 3,
-        sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a",
-        sourceUrl: "webpack:///entry.js"
-      };
-      const originalLocation = await getOriginalLocation(location);
-      expect(originalLocation).toEqual(originalLocation);
-    });
-  });
-
-  describe("getGeneratedLocation", async () => {
-    test("maps an original location", async () => {
-      await setupBundleFixture();
-      const location = {
-        column: 0,
-        line: 3,
-        sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a"
-      };
-
-      const source = {
-        url: "webpack:///entry.js",
-        id: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a"
-      };
-
-      const generatedLocation = await getGeneratedLocation(location, source);
-      expect(generatedLocation).toEqual({
-        sourceId: "bundle.js",
-        line: 49
-      });
-    });
-
-    test("does not map an original location", async () => {
-      const location = {
-        column: 0,
-        line: 3,
-        sourceId: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a",
-        sourceUrl: "webpack:///entry.js"
-      };
-
-      const source = {
-        url: "webpack:///entry.js",
-        id: "bundle.js/originalSource-fe2c41d3535b76c158e39ba4f3ff826a"
-      };
-
-      const generatedLocation = await getGeneratedLocation(location, source);
-      expect(generatedLocation).toEqual(generatedLocation);
-    });
-  });
-
   describe("Error handling", async () => {
-    const source = {
-      id: "missingmap.js",
-      sourceMapURL: "missingmap.js.map",
-      url: "http:://example.com/missingmap.js"
-    };
+    test("missing map", async () => {
+      const source = {
+        id: "missingmap.js",
+        sourceMapURL: "missingmap.js.map",
+        url: "http:://example.com/missingmap.js"
+      };
 
-    require("devtools-utils/src/network-request").mockImplementationOnce(() => {
-      throw new Error("Not found");
+      networkRequest.mockImplementationOnce(() => {
+        throw new Error("Not found");
+      });
+
+      let thrown = false;
+      try {
+        await getOriginalURLs(source);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).toBe(true);
+
+      const location = {
+        sourceId: "missingmap.js",
+        line: 49
+      };
+
+      thrown = false;
+      try {
+        await getOriginalLocation(location);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).toBe(false);
     });
-
-    let thrown = false;
-    try {
-      await getOriginalURLs(source);
-    } catch (e) {
-      thrown = true;
-    }
-    expect(thrown).toBe(true);
-
-    const location = {
-      sourceId: "missingmap.js",
-      line: 49
-    };
-
-    thrown = false;
-    try {
-      await getOriginalLocation(location);
-    } catch (e) {
-      thrown = true;
-    }
-    expect(thrown).toBe(false);
   });
 });

--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -40,6 +40,7 @@ function _setSourceMapRoot(
     // not contain the full sources, fall back to using the source's
     // URL, if possible.
     let parsedSourceMapURL = new URL(absSourceMapURL);
+
     if (parsedSourceMapURL.protocol === "data:" && source.url) {
       parsedSourceMapURL = new URL(source.url);
     }
@@ -76,6 +77,7 @@ function _resolveSourceMapURL(source: Source) {
 async function _resolveAndFetch(generatedSource: Source): SourceMapConsumer {
   // Fetch the sourcemap over the network and create it.
   const sourceMapURL = _resolveSourceMapURL(generatedSource);
+
   const fetched = await networkRequest(sourceMapURL, { loadFromCache: false });
 
   // Create the source map and fix it up.


### PR DESCRIPTION
fixes: https://github.com/devtools-html/debugger.html/issues/3399

### Summary of Changes

We currently have a problem where the user adds a breakpoint on line 5 of the example below at the top of the IF statement and the breakpoint slides to line 8 at the bottom of the IF statement definition.

This happens because when convert the location from original, to generated, and back to original, the location moves from line 5 to line 8. We should support symmetry in mapping where the location does not change if when we map it` toOriginal(toGeneral(oLoc))`. The analogy is 2 inches is 5.08cm and 5.08cm is 2inches. Changing units should not change the values.

```js
function componentWillReceiveProps(nextProps) {
    console.log('start');
    const { selectedSource } = nextProps;

    if (
      nextProps.startPanelSize !== this.props.startPanelSize ||
      nextProps.endPanelSize !== this.props.endPanelSize
    ) {
      this.state.editor.codeMirror.setSize();
    }
	console.log('done');
}
```

#### updates tests 
  * clears cache
  * groups test and attempts to give them names 
  * adds a test helpers file
     * adds formatLocation for nicer logging

#### logic changes

* start search for a original lines at the beginning of the line
* dont convert columns to undefined on the way out. We used to try and help the debugger by converting 0 columns to undefined, turns out this creates some problems w/ symmetry.

### Test Plan

Test going from original -> generated -> original w/ both 0 and undefined columns.