### PR TITLE
Fix make node for properties

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -84,6 +84,25 @@ describe("makeNodesForProperties", () => {
     expect(paths).toEqual(["root/bar", "root/baz", "root/foo", "root/__proto__"]);
   });
 
+  it("does not include unrelevant properties", () => {
+    const nodes = makeNodesForProperties(
+      {
+        ownProperties: {
+          foo: undefined,
+          bar: null,
+          baz: {}
+        },
+      },
+      root
+    );
+
+    const names = nodes.map(n => n.name);
+    const paths = nodes.map(n => n.path);
+
+    expect(names).toEqual([]);
+    expect(paths).toEqual([]);
+  });
+
   it("sorts keys", () => {
     const nodes = makeNodesForProperties(
       {

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -506,12 +506,15 @@ function makeNodesForProperties(
   let allProperties = Object.assign({}, ownProperties, safeGetterValues);
 
   // Ignore properties that are neither non-concrete nor getters/setters.
-  const propertiesNames = sortProperties(Object.keys(allProperties)).filter(name =>
-    allProperties[name].hasOwnProperty("value")
-    || allProperties[name].hasOwnProperty("getterValue")
-    || allProperties[name].hasOwnProperty("get")
-    || allProperties[name].hasOwnProperty("set")
-  );
+  const propertiesNames = sortProperties(Object.keys(allProperties)).filter(name => {
+    if (!allProperties[name]) {
+      return false;
+    }
+
+    const properties = Object.getOwnPropertyNames(allProperties[name]);
+    return properties
+      .some(property => ["value", "getterValue", "get", "set"].includes(property));
+  });
 
   let nodes = [];
   if (parentValue && parentValue.class == "Window") {


### PR DESCRIPTION
The filter was failing if a property was undefined or null.
I need to check how we can get those kind of values, but at the moment, this hotfix will eliminate them