### PR TITLE
Remove extra space after object delimiter in ObjectInspector nodes.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -17,3 +17,7 @@
 .tree.object-inspector .lessen .object-label * {
   color: var(--theme-comment);
 }
+
+.object-inspector .object-delimiter {
+  color: var(--theme-comment);
+}

--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -456,7 +456,7 @@ class ObjectInspector extends Component {
         )
         : null,
       hasLabel && hasValue
-        ? dom.span({ className: "object-delimiter" }, " : ")
+        ? dom.span({ className: "object-delimiter" }, ": ")
         : null,
       hasValue
         ? objectValue

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/basic.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/basic.js.snap
@@ -10,6 +10,6 @@ exports[`ObjectInspector - renders renders as expected 4`] = `"▶︎ {…}"`;
 
 exports[`ObjectInspector - renders renders as expected when not provided a name 1`] = `"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }"`;
 
-exports[`ObjectInspector - renders renders objects as expected when provided a name 1`] = `"▶︎ myproperty : Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }"`;
+exports[`ObjectInspector - renders renders objects as expected when provided a name 1`] = `"▶︎ myproperty: Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }"`;
 
-exports[`ObjectInspector - renders renders primitives as expected when provided a name 1`] = `"  myproperty : 42"`;
+exports[`ObjectInspector - renders renders primitives as expected when provided a name 1`] = `"  myproperty: 42"`;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
@@ -11,7 +11,7 @@ exports[`ObjectInspector - classnames has the expected class 1`] = `
               root
             </span>
             <span className=\\"object-delimiter\\">
-               : 
+              : 
             </span>
             <span className=\\"objectBox objectBox-number\\">
               42
@@ -35,7 +35,7 @@ exports[`ObjectInspector - classnames has the inline class when inline prop is t
               root
             </span>
             <span className=\\"object-delimiter\\">
-               : 
+              : 
             </span>
             <span className=\\"objectBox objectBox-number\\">
               42
@@ -59,7 +59,7 @@ exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop
               root
             </span>
             <span className=\\"object-delimiter\\">
-               : 
+              : 
             </span>
             <span className=\\"objectBox objectBox-number\\">
               42

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
@@ -12,53 +12,53 @@ exports[`ObjectInspector - entries calls ObjectClient.enumEntries when an <entri
 
 exports[`ObjectInspector - entries does not call enumEntries if entries are already loaded 1`] = `
 "▼ Map
-|    size : 2
+|    size: 2
 |  ▼ <entries>
-|  |  ▼ 0 : \\"key-0\\" → \\"value-0\\"
-|  |  |    <key> : \\"key-0\\"
-|  |  |    <value> : \\"value-0\\"
-|  |  ▼ 1 : \\"key-1\\" → \\"value-1\\"
-|  |  |    <key> : \\"key-1\\"
-|  |  |    <value> : \\"value-1\\"
-|  |  ▼ 2 : \\"key-2\\" → \\"value-2\\"
-|  |  |    <key> : \\"key-2\\"
-|  |  |    <value> : \\"value-2\\"
-|  |  ▼ 3 : \\"key-3\\" → \\"value-3\\"
-|  |  |    <key> : \\"key-3\\"
-|  |  |    <value> : \\"value-3\\"
-|  |  ▼ 4 : \\"key-4\\" → \\"value-4\\"
-|  |  |    <key> : \\"key-4\\"
-|  |  |    <value> : \\"value-4\\"
-|  |  ▼ 5 : \\"key-5\\" → \\"value-5\\"
-|  |  |    <key> : \\"key-5\\"
-|  |  |    <value> : \\"value-5\\"
-|  |  ▼ 6 : \\"key-6\\" → \\"value-6\\"
-|  |  |    <key> : \\"key-6\\"
-|  |  |    <value> : \\"value-6\\"
-|  |  ▼ 7 : \\"key-7\\" → \\"value-7\\"
-|  |  |    <key> : \\"key-7\\"
-|  |  |    <value> : \\"value-7\\"
-|  |  ▼ 8 : \\"key-8\\" → \\"value-8\\"
-|  |  |    <key> : \\"key-8\\"
-|  |  |    <value> : \\"value-8\\"
-|  |  ▼ 9 : \\"key-9\\" → \\"value-9\\"
-|  |  |    <key> : \\"key-9\\"
-|  |  |    <value> : \\"value-9\\"
-|  |  ▼ 10 : \\"key-10\\" → \\"value-10\\"
-|  |  |    <key> : \\"key-10\\"
-|  |  |    <value> : \\"value-10\\"
-|  ▼ __proto__ : {…}"
+|  |  ▼ 0: \\"key-0\\" → \\"value-0\\"
+|  |  |    <key>: \\"key-0\\"
+|  |  |    <value>: \\"value-0\\"
+|  |  ▼ 1: \\"key-1\\" → \\"value-1\\"
+|  |  |    <key>: \\"key-1\\"
+|  |  |    <value>: \\"value-1\\"
+|  |  ▼ 2: \\"key-2\\" → \\"value-2\\"
+|  |  |    <key>: \\"key-2\\"
+|  |  |    <value>: \\"value-2\\"
+|  |  ▼ 3: \\"key-3\\" → \\"value-3\\"
+|  |  |    <key>: \\"key-3\\"
+|  |  |    <value>: \\"value-3\\"
+|  |  ▼ 4: \\"key-4\\" → \\"value-4\\"
+|  |  |    <key>: \\"key-4\\"
+|  |  |    <value>: \\"value-4\\"
+|  |  ▼ 5: \\"key-5\\" → \\"value-5\\"
+|  |  |    <key>: \\"key-5\\"
+|  |  |    <value>: \\"value-5\\"
+|  |  ▼ 6: \\"key-6\\" → \\"value-6\\"
+|  |  |    <key>: \\"key-6\\"
+|  |  |    <value>: \\"value-6\\"
+|  |  ▼ 7: \\"key-7\\" → \\"value-7\\"
+|  |  |    <key>: \\"key-7\\"
+|  |  |    <value>: \\"value-7\\"
+|  |  ▼ 8: \\"key-8\\" → \\"value-8\\"
+|  |  |    <key>: \\"key-8\\"
+|  |  |    <value>: \\"value-8\\"
+|  |  ▼ 9: \\"key-9\\" → \\"value-9\\"
+|  |  |    <key>: \\"key-9\\"
+|  |  |    <value>: \\"value-9\\"
+|  |  ▼ 10: \\"key-10\\" → \\"value-10\\"
+|  |  |    <key>: \\"key-10\\"
+|  |  |    <value>: \\"value-10\\"
+|  ▼ __proto__: {…}"
 `;
 
 exports[`ObjectInspector - entries renders Object with entries as expected 1`] = `
 "▼ Map
-|    size : 2
+|    size: 2
 |  ▼ <entries>
-|  |  ▼ 0 : Symbol(a) → \\"value-a\\"
-|  |  |    <key> : Symbol(a)
-|  |  |    <value> : \\"value-a\\"
-|  |  ▼ 1 : Symbol(b) → \\"value-b\\"
-|  |  |    <key> : Symbol(b)
-|  |  |    <value> : \\"value-b\\"
-|  ▼ __proto__ : {…}"
+|  |  ▼ 0: Symbol(a) → \\"value-a\\"
+|  |  |    <key>: Symbol(a)
+|  |  |    <value>: \\"value-a\\"
+|  |  ▼ 1: Symbol(b) → \\"value-b\\"
+|  |  |    <key>: Symbol(b)
+|  |  |    <value>: \\"value-b\\"
+|  ▼ __proto__: {…}"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ObjectInspector - getters & setters renders getters and setters as expected 1`] = `
-"▼ x : Getter & Setter
-|  ▶︎ <get> : function get x()
-|  ▶︎ <set> : function set x()"
+"▼ x: Getter & Setter
+|  ▶︎ <get>: function get x()
+|  ▶︎ <set>: function set x()"
 `;
 
 exports[`ObjectInspector - getters & setters renders getters as expected 1`] = `
-"▼ x : Getter
-|  ▶︎ <get> : function get x()"
+"▼ x: Getter
+|  ▶︎ <get>: function get x()"
 `;
 
 exports[`ObjectInspector - getters & setters renders setters as expected 1`] = `
-"▼ x : Setter
-|  ▶︎ <set> : function set x()"
+"▼ x: Setter
+|  ▶︎ <set>: function set x()"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ObjectInspector - Proxy renders Proxy as expected 1`] = `
 "▼ Proxy
-|  ▶︎ <target> : Object { … }
-|  ▶︎ <handler> : Array [ … ]
-|    __proto__ : Object {  }"
+|  ▶︎ <target>: Object { … }
+|  ▶︎ <handler>: Array [ … ]
+|    __proto__: Object {  }"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/state.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/state.js.snap
@@ -7,9 +7,9 @@ exports[`ObjectInspector - state has the expected expandedPaths state 1`] = `
 
 exports[`ObjectInspector - state has the expected expandedPaths state 2`] = `
 "▼ {…}
-|    a : 1
-|    Symbol() : \\"hello\\"
-|  ▶︎ __proto__ : Object { … }
+|    a: 1
+|    Symbol(): \\"hello\\"
+|  ▶︎ __proto__: Object { … }
 ▶︎ Proxy { <target>: {…}, <handler>: […] }"
 `;
 
@@ -21,18 +21,18 @@ exports[`ObjectInspector - state has the expected expandedPaths state 3`] = `
 exports[`ObjectInspector - state has the expected expandedPaths state 4`] = `
 "▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 ▼ Proxy
-|  ▶︎ <target> : Object { … }
-|  ▶︎ <handler> : Array [ … ]"
+|  ▶︎ <target>: Object { … }
+|  ▶︎ <handler>: Array [ … ]"
 `;
 
 exports[`ObjectInspector - state has the expected expandedPaths state 5`] = `
 "▼ {…}
-|    a : 1
-|    Symbol() : \\"hello\\"
-|  ▶︎ __proto__ : Object { … }
+|    a: 1
+|    Symbol(): \\"hello\\"
+|  ▶︎ __proto__: Object { … }
 ▼ Proxy
-|  ▶︎ <target> : Object { … }
-|  ▶︎ <handler> : Array [ … ]"
+|  ▶︎ <target>: Object { … }
+|  ▶︎ <handler>: Array [ … ]"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a node 1`] = `
@@ -42,7 +42,7 @@ exports[`ObjectInspector - state has the expected state when expanding a node 1`
 
 exports[`ObjectInspector - state has the expected state when expanding a node 2`] = `
 "▼ {…}
-|    __proto__ : Object {  }
+|    __proto__: Object {  }
 ▶︎ Proxy { <target>: {…}, <handler>: […] }"
 `;
 
@@ -54,16 +54,16 @@ exports[`ObjectInspector - state has the expected state when expanding a proxy n
 exports[`ObjectInspector - state has the expected state when expanding a proxy node 2`] = `
 "▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 ▼ Proxy
-|  ▶︎ <target> : Object { … }
-|  ▶︎ <handler> : Array [ … ]
-|  ▶︎ __proto__ : Object {  }"
+|  ▶︎ <target>: Object { … }
+|  ▶︎ <handler>: Array [ … ]
+|  ▶︎ __proto__: Object {  }"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a proxy node 3`] = `
 "▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 ▼ Proxy
-|  ▶︎ <target> : Object { … }
-|  ▶︎ <handler> : Array [ … ]
-|  ▼ __proto__ : {}
-|  |  ▶︎ __proto__ : Object {  }"
+|  ▶︎ <target>: Object { … }
+|  ▶︎ <handler>: Array [ … ]
+|  ▼ __proto__: {}
+|  |  ▶︎ __proto__: Object {  }"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/function.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/function.js
@@ -76,6 +76,6 @@ describe("ObjectInspector - functions", () => {
 
     const functionNode = nodes.first();
     // It should have the name of the property.
-    expect(functionNode.text()).toBe("x : function testName()");
+    expect(functionNode.text()).toBe("x: function testName()");
   });
 });


### PR DESCRIPTION
Fixes #675

This is more consistent with the way we already render objects in Reps.