### PR TITLE
Don't add root actors to the state of the ObjectInspector.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -315,8 +315,15 @@ class ObjectInspector extends Component {
           const nextLoading = new Map(prevState.loading);
           nextLoading.delete(path);
 
+          const isRoot = this.props.roots.some(root => {
+            const rootValue = getValue(root);
+            return rootValue && rootValue.actor === value.actor;
+          });
+
           return {
-            actors: (new Set(prevState.actors)).add(value.actor),
+            actors: isRoot
+              ? prevState.actors
+              : (new Set(prevState.actors)).add(value.actor),
             loadedProperties: (new Map(prevState.loadedProperties)).set(path, response),
             loading: nextLoading,
           };

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/state.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/state.js.snap
@@ -42,7 +42,14 @@ exports[`ObjectInspector - state has the expected state when expanding a node 1`
 
 exports[`ObjectInspector - state has the expected state when expanding a node 2`] = `
 "▼ {…}
-|    __proto__: Object {  }
+|  ▶︎ __proto__: Object {  }
+▶︎ Proxy { <target>: {…}, <handler>: […] }"
+`;
+
+exports[`ObjectInspector - state has the expected state when expanding a node 3`] = `
+"▼ {…}
+|  ▼ __proto__: {}
+|  |  ▶︎ __proto__: Object {  }
 ▶︎ Proxy { <target>: {…}, <handler>: […] }"
 `;
 

--- a/packages/devtools-reps/src/object-inspector/tests/component/release-actors.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/release-actors.js
@@ -11,9 +11,9 @@ const ObjectInspector = createFactory(require("../../index"));
 const repsPath = "../../../reps";
 const gripRepStubs = require(`${repsPath}/stubs/grip`);
 const ObjectClient = require("../__mocks__/object-client");
+const stub = gripRepStubs.get("testMoreThanMaxProps");
 
 function generateDefaults(overrides) {
-  const stub = gripRepStubs.get("testMoreThanMaxProps");
   return Object.assign({
     autoExpandDepth: 0,
     roots: [{
@@ -29,7 +29,6 @@ function generateDefaults(overrides) {
 describe("release actors", () => {
   it("release actors when unmount", () => {
     const releaseActor = jest.fn();
-    // The window node should have the "lessen" class when collapsed.
     const props = generateDefaults({
       releaseActor,
     });


### PR DESCRIPTION
The actors property on the ObjectInspector state keep track of all the actors that need to be
released when we're done with the component. The problem of releasing the root actor is that
if the comsumer of the OI was simply hidden, and then shown again, the user would not be
able to expand the objectInspector.
Here we don't track root actors so the consumer handle the lifetime of the root actors it handles.
This causes no issues for non-root actors, since the ObjectInspector is unmounted, if the user
want to expand it again after a hide/show cycle again, we'll end up creating new ObjectClient (and
thus actors).