### PR TITLE
Wrap provided objectClient function calls in try/catch blocks.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/component/create-object-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/create-object-client.js
@@ -81,4 +81,16 @@ describe("createObjectClient", () => {
     }));
     expect(createObjectClient.mock.calls[0][0]).toBe(grip);
   });
+
+  it("does not fail if the ObjectClient does not have the expected functions", () => {
+    const stub = gripRepStubs.get("testMoreThanMaxProps");
+    const root = createNode(null, "root", "/", {value: stub});
+
+    const createObjectClient = x => ({});
+    mount(ObjectInspector({
+      autoExpandDepth: 1,
+      roots: [root],
+      createObjectClient,
+    }));
+  });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/component/entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/entries.js
@@ -22,10 +22,18 @@ function generateDefaults(overrides) {
   }, overrides);
 }
 
+function getEnumEntriesMock() {
+  return jest.fn(() => ({
+    iterator: {
+      slice: () => ({})
+    }
+  }));
+}
+
 describe("ObjectInspector - entries", () => {
   it("renders Object with entries as expected", async () => {
     const stub = gripMapRepStubs.get("testSymbolKeyedMap");
-    const enumEntries = jest.fn();
+    const enumEntries = getEnumEntriesMock();
 
     let oi = mount(ObjectInspector(generateDefaults({
       autoExpandDepth: 3,
@@ -54,7 +62,7 @@ describe("ObjectInspector - entries", () => {
 
   it("does not call enumEntries if entries are already loaded", () => {
     const stub = gripMapRepStubs.get("testMoreThanMaxEntries");
-    const enumEntries = jest.fn();
+    const enumEntries = getEnumEntriesMock();
 
     const wrapper = mount(ObjectInspector(generateDefaults({
       autoExpandDepth: 3,
@@ -79,7 +87,7 @@ describe("ObjectInspector - entries", () => {
 
   it("calls ObjectClient.enumEntries when an <entries> node is clicked", () => {
     const stub = gripMapRepStubs.get("testMoreThanMaxEntries");
-    const enumEntries = jest.fn();
+    const enumEntries = getEnumEntriesMock();
 
     const oi = mount(ObjectInspector(generateDefaults({
       autoExpandDepth: 1,

--- a/packages/devtools-reps/src/object-inspector/tests/component/properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/properties.js
@@ -19,10 +19,18 @@ function generateDefaults(overrides) {
   }, overrides);
 }
 
+function getEnumPropertiesMock() {
+  return jest.fn(() => ({
+    iterator: {
+      slice: () => ({})
+    }
+  }));
+}
+
 describe("ObjectInspector - properties", () => {
   it("does not load properties if properties are already loaded", () => {
     const stub = gripRepStubs.get("testMaxProps");
-    const enumProperties = jest.fn();
+    const enumProperties = getEnumPropertiesMock();
 
     mount(ObjectInspector(generateDefaults({
       autoExpandDepth: 1,
@@ -43,7 +51,7 @@ describe("ObjectInspector - properties", () => {
 
   it("calls enumProperties when expandable leaf is clicked", () => {
     const stub = gripRepStubs.get("testMaxProps");
-    const enumProperties = jest.fn();
+    const enumProperties = getEnumPropertiesMock();
 
     const oi = mount(ObjectInspector(generateDefaults({
       roots: [{

--- a/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
@@ -30,9 +30,17 @@ function generateDefaults(overrides) {
   }, overrides);
 }
 
+function getEnumPropertiesMock() {
+  return jest.fn(() => ({
+    iterator: {
+      slice: () => ({})
+    }
+  }));
+}
+
 describe("ObjectInspector - Proxy", () => {
   it("renders Proxy as expected", () => {
-    const enumProperties = jest.fn();
+    const enumProperties = getEnumPropertiesMock();
 
     const props = generateDefaults({
       createObjectClient: grip => ObjectClient(grip, {enumProperties}),
@@ -45,7 +53,7 @@ describe("ObjectInspector - Proxy", () => {
   });
 
   it("calls enumProperties when <target> and <handler> nodes are clicked", () => {
-    const enumProperties = jest.fn();
+    const enumProperties = getEnumPropertiesMock();
 
     const props = generateDefaults({
       createObjectClient: grip => ObjectClient(grip, {enumProperties}),

--- a/packages/devtools-reps/src/object-inspector/utils/client.js
+++ b/packages/devtools-reps/src/object-inspector/utils/client.js
@@ -20,7 +20,7 @@ async function enumIndexedProperties(
     const response = await iteratorSlice(iterator, start, end);
     return response;
   } catch (e) {
-    console.warn("Error in enumIndexedProperties", e);
+    console.error("Error in enumIndexedProperties", e);
     return {};
   }
 }
@@ -35,7 +35,7 @@ async function enumNonIndexedProperties(
     const response = await iteratorSlice(iterator, start, end);
     return response;
   } catch (e) {
-    console.warn("Error in enumNonIndexedProperties", e);
+    console.error("Error in enumNonIndexedProperties", e);
     return {};
   }
 }
@@ -50,7 +50,7 @@ async function enumEntries(
     const response = await iteratorSlice(iterator, start, end);
     return response;
   } catch (e) {
-    console.warn("Error in enumEntries", e);
+    console.error("Error in enumEntries", e);
     return {};
   }
 }
@@ -65,7 +65,7 @@ async function enumSymbols(
     const response = await iteratorSlice(iterator, start, end);
     return response;
   } catch (e) {
-    console.warn("Error in enumSymbols", e);
+    console.error("Error in enumSymbols", e);
     return {};
   }
 }
@@ -74,7 +74,7 @@ async function getPrototype(
   objectClient: ObjectClient
 ) : ?Promise<{prototype?: Object}> {
   if (typeof objectClient.getPrototype !== "function") {
-    console.warn("objectClient.getPrototype is not a function");
+    console.error("objectClient.getPrototype is not a function");
     return Promise.resolve({});
   }
   return objectClient.getPrototype();

--- a/packages/devtools-reps/src/object-inspector/utils/client.js
+++ b/packages/devtools-reps/src/object-inspector/utils/client.js
@@ -13,47 +13,70 @@ async function enumIndexedProperties(
   objectClient: ObjectClient,
   start: ?number,
   end: ?number
-) : Promise<{ownProperties: Object}> {
-  const {iterator} = await objectClient
-    .enumProperties({ignoreNonIndexedProperties: true});
-  const response = await iteratorSlice(iterator, start, end);
-  return response;
+) : Promise<{ownProperties?: Object}> {
+  try {
+    const {iterator} = await objectClient
+      .enumProperties({ignoreNonIndexedProperties: true});
+    const response = await iteratorSlice(iterator, start, end);
+    return response;
+  } catch (e) {
+    console.warn("Error in enumIndexedProperties", e);
+    return {};
+  }
 }
 
 async function enumNonIndexedProperties(
   objectClient: ObjectClient,
   start: ?number,
   end: ?number
-) : Promise<{ownProperties: Object}> {
-  const {iterator} = await objectClient.enumProperties({ignoreIndexedProperties: true});
-
-  const response = await iteratorSlice(iterator, start, end);
-  return response;
+) : Promise<{ownProperties?: Object}> {
+  try {
+    const {iterator} = await objectClient.enumProperties({ignoreIndexedProperties: true});
+    const response = await iteratorSlice(iterator, start, end);
+    return response;
+  } catch (e) {
+    console.warn("Error in enumNonIndexedProperties", e);
+    return {};
+  }
 }
 
 async function enumEntries(
   objectClient: ObjectClient,
   start: ?number,
   end: ?number
-) : Promise<{ownProperties: Object}> {
-  const {iterator} = await objectClient.enumEntries();
-  const response = await iteratorSlice(iterator, start, end);
-  return response;
+) : Promise<{ownProperties?: Object}> {
+  try {
+    const {iterator} = await objectClient.enumEntries();
+    const response = await iteratorSlice(iterator, start, end);
+    return response;
+  } catch (e) {
+    console.warn("Error in enumEntries", e);
+    return {};
+  }
 }
 
 async function enumSymbols(
   objectClient: ObjectClient,
   start: ?number,
   end: ?number
-) : Promise<{ownSymbols: Array<Object>}> {
-  const {iterator} = await objectClient.enumSymbols();
-  const response = await iteratorSlice(iterator, start, end);
-  return response;
+) : Promise<{ownSymbols?: Array<Object>}> {
+  try {
+    const {iterator} = await objectClient.enumSymbols();
+    const response = await iteratorSlice(iterator, start, end);
+    return response;
+  } catch (e) {
+    console.warn("Error in enumSymbols", e);
+    return {};
+  }
 }
 
-function getPrototype(
+async function getPrototype(
   objectClient: ObjectClient
-) : ?Promise<{prototype: Object}> {
+) : ?Promise<{prototype?: Object}> {
+  if (typeof objectClient.getPrototype !== "function") {
+    console.warn("objectClient.getPrototype is not a function");
+    return Promise.resolve({});
+  }
   return objectClient.getPrototype();
 }
 


### PR DESCRIPTION
Since we don't know what the ObjectClient we get looks like, it might happens that it doesn't have
the method we try to call (e.g. connecting to an older server, you will miss the enumSymbols function).
Wrapping everything in try/catch blocks mitigate the risk of crashing the ObjectInspector (in the beforementioned case, everything will be fine except we wouldn't get symbol properties, which seems acceptable).