### PR TITLE
Don't show pointer cursor on Tree node if it is not expandable.

### DIFF
--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -302,6 +302,15 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
   });
+
+  it("adds the expected data-expandable attribute", () => {
+    const wrapper = mountTree({
+      isExpandable: item => item === "A"
+    });
+    const nodes = getTreeNodes(wrapper);
+    expect(nodes.at(0).prop("data-expandable")).toBe(true);
+    expect(nodes.at(1).prop("data-expandable")).toBe(false);
+  });
 });
 
 function getTreeNodes(wrapper) {

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -36,7 +36,7 @@
   display: block;
 }
 
-.tree .tree-node {
+.tree .tree-node[data-expandable="true"] {
   cursor: pointer;
 }
 

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -130,6 +130,7 @@ const TreeNode = createFactory(createClass({
         role: "treeitem",
         "aria-level": depth,
         "aria-expanded": ariaExpanded,
+        "data-expandable": this.props.isExpandable,
       },
       renderItem(item, depth, focused, arrow, expanded)
     );


### PR DESCRIPTION
Fixes #691.

Adds a data-expandable attribute to the tree node that we
then target to show a pointer cursor only on expandable nodes.