### PR TITLE
Guard nodeHasAllEntriesInPreview

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-has-all-entries-in-preview.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-has-all-entries-in-preview.js
@@ -28,13 +28,13 @@ describe("nodeHasEntries", () => {
     ).toBe(true);
   });
 
-  it("returns false for a Map with nore than 10 items", () => {
+  it("returns false for a Map with more than 10 items", () => {
     expect(nodeHasAllEntriesInPreview(
       createRootNode(gripMapStubs.get("testMoreThanMaxEntries"))
     )).toBe(false);
   });
 
-  it("returns false for a WeakSet with nore than 10 items", () => {
+  it("returns false for a WeakSet with more than 10 items", () => {
     expect(nodeHasAllEntriesInPreview(
       createRootNode(
         gripArrayStubs.get("new WeakSet(document.querySelectorAll('div, button'))")

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-has-all-entries-in-preview.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-has-all-entries-in-preview.js
@@ -12,29 +12,53 @@ const {
 
 const createRootNode = value => createNode(null, "root", "/", {value});
 describe("nodeHasEntries", () => {
-  it("returns true when expected", () => {
+  it("returns true for a Map with every entries in the preview", () => {
     expect(nodeHasAllEntriesInPreview(
       createRootNode(gripMapStubs.get("testSymbolKeyedMap")))
     ).toBe(true);
-
+  });
+  it("returns true for a WeakMap with every entries in the preview", () => {
     expect(nodeHasAllEntriesInPreview(
       createRootNode(gripMapStubs.get("testWeakMap"))
     )).toBe(true);
-
+  });
+  it("returns true for a Set with every entries in the preview", () => {
     expect(nodeHasAllEntriesInPreview(
       createRootNode(gripArrayStubs.get("new Set([1,2,3,4])")))
     ).toBe(true);
   });
 
-  it("returns false when expected", () => {
+  it("returns false for a Map with nore than 10 items", () => {
     expect(nodeHasAllEntriesInPreview(
       createRootNode(gripMapStubs.get("testMoreThanMaxEntries"))
     )).toBe(false);
+  });
 
+  it("returns false for a WeakSet with nore than 10 items", () => {
     expect(nodeHasAllEntriesInPreview(
       createRootNode(
         gripArrayStubs.get("new WeakSet(document.querySelectorAll('div, button'))")
       )
     )).toBe(false);
+  });
+
+  it("returns false for a null value", () => {
+    expect(nodeHasAllEntriesInPreview(createRootNode(null))).toBe(false);
+  });
+
+  it("returns false for an undefined value", () => {
+    expect(nodeHasAllEntriesInPreview(createRootNode(null))).toBe(false);
+  });
+
+  it("returns false for an empty object", () => {
+    expect(nodeHasAllEntriesInPreview(createRootNode({}))).toBe(false);
+  });
+
+  it("returns false for an object with a preview without items", () => {
+    expect(nodeHasAllEntriesInPreview(createRootNode({
+      preview: {
+        size: 1
+      }
+    }))).toBe(false);
   });
 });

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -219,6 +219,10 @@ function nodeHasAllEntriesInPreview(item : Node) : boolean {
     size,
   } = preview;
 
+  if (!entries && !items) {
+    return false;
+  }
+
   return entries
     ? entries.length === size
     : items.length === length;


### PR DESCRIPTION
Fixes #681.

Some Map grip can have a preview object which contains only a size property.
In such case, the ObjectInspector was throwing in `nodeHasAllEntriesInPreview`,
since it expected to have at least an entries or items property.
We now return early on the function if the preview object does not have an
entries nor an item property.