### PR TITLE
Don't escape the Unicode replacement character

### DIFF
--- a/packages/devtools-reps/src/reps/rep-utils.js
+++ b/packages/devtools-reps/src/reps/rep-utils.js
@@ -49,8 +49,8 @@ const escapeRegexp = new RegExp(
   "\x7f-\x9f" +
   // BOM
   "\ufeff" +
-  // Replacement characters and non-characters.
-  "\ufffc-\uffff" +
+  // Specials, except for the replacement character.
+  "\ufff0-\ufffc\ufffe\uffff" +
   // Surrogates.
   "\ud800-\udfff" +
   // Mathematical invisibles.

--- a/packages/devtools-reps/src/reps/tests/string.js
+++ b/packages/devtools-reps/src/reps/tests/string.js
@@ -43,11 +43,11 @@ const testCases = [{
 }, {
   name: "testQuoting",
   props: {
-    object: "\t\n\r\"'\\\x1f\x9f\ufeff\ufffe\ud8000\u2063\ufffc\u2028\ueeee",
+    object: "\t\n\r\"'\\\x1f\x9f\ufeff\ufffe\ud8000\u2063\ufffc\u2028\ueeee\ufffd",
     useQuotes: true
   },
   // eslint-disable-next-line max-len
-  result: "\"\\t\\n\\r\\\"'\\\\\\u001f\\u009f\\ufeff\\ufffe\\ud8000\\u2063\\ufffc\\u2028\\ueeee\""
+  result: "\"\\t\\n\\r\\\"'\\\\\\u001f\\u009f\\ufeff\\ufffe\\ud8000\\u2063\\ufffc\\u2028\\ueeee\ufffd\""
 }, {
   name: "testUnpairedSurrogate",
   props: {


### PR DESCRIPTION
It makes sense to pass through the Unicode replacement character,
because users understand it.  However, the other specials (including
unassigned ones) should be quoted.
Fixes #644
