### PR TITLE
Add an omitLinkHref prop to the String rep.

### DIFF
--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -31,6 +31,7 @@ StringRep.propTypes = {
   cropLimit: React.PropTypes.number,
   openLink: React.PropTypes.func,
   className: React.PropTypes.string,
+  omitLinkHref: React.PropTypes.bool,
 };
 
 function StringRep(props) {
@@ -43,6 +44,7 @@ function StringRep(props) {
     useQuotes = true,
     escapeWhitespace = true,
     openLink,
+    omitLinkHref = true,
   } = props;
 
   const classNames = ["objectBox", "objectBox-string"];
@@ -84,7 +86,9 @@ function StringRep(props) {
       items.push(a({
         className: "url",
         title: token,
-        href: token,
+        href: omitLinkHref === true
+          ? null
+          : token,
         draggable: false,
         onClick: openLink
           ? e => {

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -9,7 +9,8 @@ const { Rep } = REPS;
 
 const renderRep = (string, props) => mount(
   Rep(Object.assign({
-    object: string
+    object: string,
+    omitLinkHref: false,
   }, props))
 );
 
@@ -254,5 +255,21 @@ describe("test String with URL", () => {
 
     link.simulate("click");
     expect(openLink).toBeCalledWith(url);
+  });
+
+  it("does not create an href attribute if omitLinkHref is true", () => {
+    const url = "http://example.com";
+    const element = renderRep(url, {omitLinkHref: true, useQuotes: false});
+    expect(element.text()).toEqual(url);
+    const link = element.find("a");
+    expect(link.prop("href")).toBe(null);
+  });
+
+  it("does not create an href attribute if omitLinkHref is undefined", () => {
+    const url = "http://example.com";
+    const element = mount(Rep({ object: url, useQuotes: false }));
+    expect(element.text()).toEqual(url);
+    const link = element.find("a");
+    expect(link.prop("href")).toBe(null);
   });
 });


### PR DESCRIPTION
This boolean prop prevents the creation of the href attribute on
generated links in the String rep. It is true by default so
consumer can use the String rep safely. We still want to be
able to generate the href attribute (for the JSON panel for example),
this is why we offer the choice to still create it.

Tests are added to make sure we don't regress.