### PR TITLE
Use aria-activedescendant properly.

### DIFF
--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -66,7 +66,7 @@ describe("Tree", () => {
     expect(mountTree()).toBeTruthy();
   });
 
-  it.only("is accessible", () => {
+  it("is accessible", () => {
     const wrapper = mountTree({
       expanded: new Set("ABCDEFGHIJKLMNO".split("")),
     });
@@ -143,18 +143,22 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-G");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-G");
 
     getTreeNodes(wrapper).first().simulate("click");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-A");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-A");
 
     getTreeNodes(wrapper).first().simulate("click");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-A");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-A");
 
     wrapper.simulate("blur");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().hasAttribute("aria-activedescendant")).toBe(false);
+    expect(wrapper.find(".focused").exists()).toBe(false);
   });
 
   it("renders as expected when navigating up with the keyboard", () => {
@@ -164,14 +168,17 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-L");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-L");
 
     simulateKeyDown(wrapper, "ArrowUp");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-K");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-K");
 
     simulateKeyDown(wrapper, "ArrowUp");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-E");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-E");
   });
 
   it("renders as expected when navigating up with the keyboard on a root", () => {
@@ -181,10 +188,12 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-A");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-A");
 
     simulateKeyDown(wrapper, "ArrowUp");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-A");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-A");
   });
 
   it("renders as expected when navigating down with the keyboard", () => {
@@ -194,14 +203,17 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-K");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-K");
 
     simulateKeyDown(wrapper, "ArrowDown");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-L");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-L");
 
     simulateKeyDown(wrapper, "ArrowDown");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-F");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-F");
   });
 
   it("renders as expected when navigating down with the keyboard on last node", () => {
@@ -211,10 +223,12 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-O");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-O");
 
     simulateKeyDown(wrapper, "ArrowDown");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-O");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-O");
   });
 
   it("renders as expected when navigating with right/left arrows", () => {
@@ -224,22 +238,27 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-L");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-L");
 
     simulateKeyDown(wrapper, "ArrowLeft");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-E");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-E");
 
     simulateKeyDown(wrapper, "ArrowLeft");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-E");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-E");
 
     simulateKeyDown(wrapper, "ArrowRight");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-E");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-E");
 
     simulateKeyDown(wrapper, "ArrowRight");
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-K");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-K");
   });
 
   it("ignores key strokes when pressing modifiers", () => {
@@ -249,6 +268,7 @@ describe("Tree", () => {
     });
     expect(formatTree(wrapper)).toMatchSnapshot();
     expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-L");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-L");
 
     let testKeys = [
       { key: "ArrowDown"},

--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -66,17 +66,19 @@ describe("Tree", () => {
     expect(mountTree()).toBeTruthy();
   });
 
-  it("is accessible", () => {
-    const wrapper = mountTree();
+  it.only("is accessible", () => {
+    const wrapper = mountTree({
+      expanded: new Set("ABCDEFGHIJKLMNO".split("")),
+    });
     expect(wrapper.getDOMNode().getAttribute("role")).toBe("tree");
     expect(wrapper.getDOMNode().getAttribute("tabIndex")).toBe("0");
 
     getTreeNodes(wrapper)
-      .everyWhere(node => {
-        return typeof node.prop("id") !== "undefined"
-          && node.prop("role") === "treeitem"
-          && typeof node.prop("aria-level") !== "undefined";
-      });
+      .everyWhere(node => expect(
+        node.prop("id").startsWith("key-")
+        && node.prop("role") === "treeitem"
+        && typeof node.prop("aria-level") !== "undefined"
+      ).toBe(true));
   });
 
   it("renders as expected", () => {

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -46,6 +46,7 @@ const TreeNode = createFactory(createClass({
   displayName: "TreeNode",
 
   propTypes: {
+    id: PropTypes.any.isRequired,
     index: PropTypes.number.isRequired,
     depth: PropTypes.number.isRequired,
     focused: PropTypes.bool.isRequired,
@@ -65,6 +66,7 @@ const TreeNode = createFactory(createClass({
   render() {
     const {
       depth,
+      id,
       item,
       focused,
       expanded,
@@ -121,6 +123,7 @@ const TreeNode = createFactory(createClass({
 
     return dom.div(
       {
+        id,
         className: "tree-node" + (focused ? " focused" : ""),
         style: {
           paddingInlineStart,
@@ -731,8 +734,10 @@ const Tree = createClass({
 
     const nodes = traversal.map((v, i) => {
       const { item, depth } = traversal[i];
+      const key = this.props.getKey(item, i);
       return TreeNode({
-        key: this.props.getKey(item, i),
+        key,
+        id: key,
         index: i,
         item,
         depth,


### PR DESCRIPTION
This patch adds a proper id attribute to the tree nodes
so that the `aria-activedescendant` attribute links to an
actual element.

It also fixes the use of `wrapper.everyWhere` which except to be returned an assertion.