### PR TITLE
Compute sourceRoot when only relative URLs are seen

### DIFF
--- a/packages/devtools-source-map/src/tests/fixtures/noroot2.js
+++ b/packages/devtools-source-map/src/tests/fixtures/noroot2.js
@@ -1,0 +1,2 @@
+/* Doesn't really matter what is in here.  */
+// # sourceMappingURL=noroot2.js.map

--- a/packages/devtools-source-map/src/tests/fixtures/noroot2.js.map
+++ b/packages/devtools-source-map/src/tests/fixtures/noroot2.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "sources": [
+    "heart.js"
+  ],
+  "names": [],
+  "mappings": ";AAAA;AACA;;AAEA;AACA;;AAEA;AACA;AACA;;AAEA;AACA;AACA,uBAAe;AACf;AACA;AACA;;AAEA;AACA;;AAEA;AACA;;AAEA;AACA;AACA;;;AAGA;AACA;;AAEA;AACA;;AAEA;AACA;;AAEA;AACA;;;;;;;ACtCA;AACA,QAAO,SAAS;AAChB;;AAEA;AACA;;AAEA;AACA;AACA;;AAEA;AACA;AACA;AACA;AACA;;;;;;;ACfA;AACA;AACA;;;;;;;ACFA;AACA;AACA;;AAEA,mBAAkB;;;;;;;ACJlB;AACA;AACA",
+  "file": "noroot.js",
+  "sourceContents": ["this is the full text"]
+}

--- a/packages/devtools-source-map/src/tests/source-map.js
+++ b/packages/devtools-source-map/src/tests/source-map.js
@@ -50,6 +50,11 @@ describe("source maps", () => {
       const urls = await setupBundleFixture("noroot");
       expect(urls).toEqual(["http://example.com/heart.js"]);
     });
+
+    test("Non-existing sourceRoot resolution with relative URLs", async () => {
+      const urls = await setupBundleFixture("noroot2");
+      expect(urls).toEqual(["http://example.com/heart.js"]);
+    });
   });
 
   describe("hasMappedSource", async () => {

--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -11,6 +11,8 @@ const { SourceMapConsumer } = require("source-map");
 
 const path = require("./path");
 
+const URL_ISH = new RegExp("^[a-z]+:/");
+
 import type {
   Location,
   Source,
@@ -28,10 +30,17 @@ function _setSourceMapRoot(
   absSourceMapURL: string,
   source: Source
 ) {
-  // No need to do this fiddling if we won't be fetching any sources over the
-  // wire.
+  // No need to do this fiddling if we won't be fetching any sources
+  // over the wire.  However, we do still want to if any of the source
+  // URLs are relative.  What's difficult is that we want to pretend
+  // that some non-URLs, like "webpack:/whatever", are actually URLs.
   if (sourceMap.hasContentsOfAllSources()) {
-    return;
+    const allURLsAreAbsolute = sourceMap.sources.every(sourceName => {
+      return URL_ISH.test(sourceName);
+    });
+    if (allURLsAreAbsolute) {
+      return;
+    }
   }
 
   // If it's already a URL, just leave it alone.


### PR DESCRIPTION
Currently _setSourceMapRoot bails if the source map contains all the
sources.  However, this is not valid according to the source map spec;
and the debugger doesn't work properly with the returned URLs.  On the
other hand, some source maps have non-URLs like "webpack:/bootstrap",
which we do want to treat as absolute.  So, this patch works around
the problem by examining the URLs in a mildly lax way.
Fixes #356

Associated Issue: #<issue number>

### Summary of Changes

* change 1
* change 2

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

### Screenshots/Videos (OPTIONAL)