### PR TITLE
Override console.error in create-object-client.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/component/create-object-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/create-object-client.js
@@ -86,11 +86,18 @@ describe("createObjectClient", () => {
     const stub = gripRepStubs.get("testMoreThanMaxProps");
     const root = createNode(null, "root", "/", {value: stub});
 
+    // Override console.error so we don't spam test results.
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
     const createObjectClient = x => ({});
     mount(ObjectInspector({
       autoExpandDepth: 1,
       roots: [root],
       createObjectClient,
     }));
+
+    // rollback console.error.
+    console.error = originalConsoleError;
   });
 });


### PR DESCRIPTION
In this test, we check that the ObjectInspector does not throw if
the create object client has not the method we expect.
If the objectClient is faulty, we do use console.error to warn the
developer though, and those console calls are spamming the terminal
during the test, which can make you think that some tests are failing.
Here we override console.error so we have a saner output.