### PR TITLE
Update devtools-reps to devtools-components 0.0.5

### DIFF
--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "devtools-components": "^0.0.4",
+    "devtools-components": "^0.0.5",
     "lodash": "^4.17.2",
     "react": "=15.3.2",
     "react-dom": "=15.3.2",

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
@@ -3,9 +3,9 @@
 exports[`ObjectInspector - classnames has the expected class 1`] = `
 "<ObjectInspector autoExpandDepth={0} roots={{...}} createObjectClient={[Function]}>
   <Tree className=\\"object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
-    <div className=\\"tree object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
-      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
-        <div className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]}>
+    <div className=\\"tree object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode id=\\"root\\" index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div id=\\"root\\" className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]} data-expandable={false}>
           <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
             <span className=\\"object-label\\" onClick={{...}}>
               root
@@ -27,9 +27,9 @@ exports[`ObjectInspector - classnames has the expected class 1`] = `
 exports[`ObjectInspector - classnames has the inline class when inline prop is true 1`] = `
 "<ObjectInspector autoExpandDepth={0} roots={{...}} createObjectClient={[Function]} inline={true}>
   <Tree className=\\"inline object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
-    <div className=\\"tree inline object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
-      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
-        <div className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]}>
+    <div className=\\"tree inline object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode id=\\"root\\" index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div id=\\"root\\" className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]} data-expandable={false}>
           <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
             <span className=\\"object-label\\" onClick={{...}}>
               root
@@ -51,9 +51,9 @@ exports[`ObjectInspector - classnames has the inline class when inline prop is t
 exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop is true 1`] = `
 "<ObjectInspector autoExpandDepth={0} roots={{...}} createObjectClient={[Function]} disableWrap={true}>
   <Tree className=\\"nowrap object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
-    <div className=\\"tree nowrap object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onScroll={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
-      <TreeNode index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
-        <div className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]}>
+    <div className=\\"tree nowrap object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode id=\\"root\\" index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div id=\\"root\\" className=\\"tree-node\\" style={{...}} onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]} data-expandable={false}>
           <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
             <span className=\\"object-label\\" onClick={{...}}>
               root

--- a/packages/devtools-reps/yarn.lock
+++ b/packages/devtools-reps/yarn.lock
@@ -1604,9 +1604,9 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-devtools-components@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/devtools-components/-/devtools-components-0.0.4.tgz#68ae84d5a5fb73b05b842380eed48d77a997576c"
+devtools-components@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/devtools-components/-/devtools-components-0.0.5.tgz#1b0c1718a9c0b6e3415f05377f0e5093aef82d9f"
   dependencies:
     svg-inline-loader "^0.8.0"
     svg-inline-react "^1.0.2"


### PR DESCRIPTION
This gives us a performance regression fix that would be more than welcomed in the console.

Snapshots were updated to match the new tree structure