### PR TITLE
Move eslint to devDependencies

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -60,11 +60,6 @@
     "devtools-modules": "^0.0.31",
     "devtools-sprintf-js": "^1.0.3",
     "devtools-utils": "^0.0.5",
-    "eslint": "^3.12.0",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-flowtype": "^2.20.0",
-    "eslint-plugin-mozilla": "0.4.3",
-    "eslint-plugin-react": "^6.7.1",
     "express": "^4.13.4",
     "extract-text-webpack-plugin": "^3.0.0",
     "fs-extra": "^2.0.0",
@@ -101,6 +96,11 @@
   },
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
+    "eslint": "^3.12.0",
+    "eslint-plugin-babel": "^3.3.0",
+    "eslint-plugin-flowtype": "^2.20.0",
+    "eslint-plugin-mozilla": "0.4.3",
+    "eslint-plugin-react": "^6.7.1",
     "ipaddr": "^0.0.9",
     "jest": "^19.0.2",
     "yarn": "^0.20.3"


### PR DESCRIPTION
Move eslint and some related packages to devDependencies.  This avoids
an error from the license checker.
