### PR TITLE
Fix keyboard navigation on the Tree component.

### DIFF
--- a/packages/devtools-components/src/tests/__snapshots__/tree.js.snap
+++ b/packages/devtools-components/src/tests/__snapshots__/tree.js.snap
@@ -588,6 +588,36 @@ exports[`Tree renders as expected when navigating up with the keyboard on a root
 |  |    O"
 `;
 
+exports[`Tree renders as expected when navigating with arrows on unexpandable roots 1`] = `
+"  [A]
+  M"
+`;
+
+exports[`Tree renders as expected when navigating with arrows on unexpandable roots 2`] = `
+"  A
+  [M]"
+`;
+
+exports[`Tree renders as expected when navigating with arrows on unexpandable roots 3`] = `
+"  [A]
+  M"
+`;
+
+exports[`Tree renders as expected when navigating with left arrows on roots 1`] = `
+"▶︎ A
+▶︎ [M]"
+`;
+
+exports[`Tree renders as expected when navigating with left arrows on roots 2`] = `
+"▶︎ [A]
+▶︎ M"
+`;
+
+exports[`Tree renders as expected when navigating with left arrows on roots 3`] = `
+"▶︎ [A]
+▶︎ M"
+`;
+
 exports[`Tree renders as expected when navigating with right/left arrows 1`] = `
 "▼ A
 |  ▼ B


### PR DESCRIPTION
This patch re-establish the keyboard navigation on the
Tree. It handles the scroll position of the closest
scrollable parent so when a node is focused it is not
off-canvas.
This also fixes smaller keyboard navigation bugs and add
tests to make sure everything works as expected.

![sep-25-2017 15-30-47](https://user-images.githubusercontent.com/578107/30810820-8da8d684-a206-11e7-9eae-6398adcf96d7.gif)
![sep-25-2017 15-30-29](https://user-images.githubusercontent.com/578107/30810822-8e057538-a206-11e7-82ae-ee022f8ccbd0.gif)
![sep-25-2017 15-29-56](https://user-images.githubusercontent.com/578107/30810821-8db1ca3c-a206-11e7-85c9-ea9fba6dbde0.gif)
