### PR TITLE
Load indexed and non-indexed properties separately only for arrays.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -43,6 +43,7 @@ const {
   nodeIsPrototype,
   nodeIsSetter,
   nodeIsWindow,
+  shouldLoadAllItemProperties,
   shouldLoadItemEntries,
   shouldLoadItemIndexedProperties,
   shouldLoadItemNonIndexedProperties,
@@ -51,6 +52,7 @@ const {
 } = require("./utils/node");
 
 const {
+  enumAllProperties,
   enumEntries,
   enumIndexedProperties,
   enumNonIndexedProperties,
@@ -269,6 +271,10 @@ class ObjectInspector extends Component {
 
       if (shouldLoadItemNonIndexedProperties(item, loadedProperties)) {
         promises.push(enumNonIndexedProperties(getObjectClient(), start, end));
+      }
+
+      if (shouldLoadAllItemProperties(item, loadedProperties)) {
+        promises.push(enumAllProperties(getObjectClient(), start, end));
       }
 
       if (shouldLoadItemEntries(item, loadedProperties)) {

--- a/packages/devtools-reps/src/object-inspector/tests/component/properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/properties.js
@@ -67,8 +67,7 @@ describe("ObjectInspector - properties", () => {
     node.simulate("click");
 
     // The function is called twice,  to get  both non-indexed and indexed properties.
-    expect(enumProperties.mock.calls.length).toBe(2);
-    expect(enumProperties.mock.calls[0][0]).toEqual({ignoreNonIndexedProperties: true});
-    expect(enumProperties.mock.calls[1][0]).toEqual({ignoreIndexedProperties: true});
+    expect(enumProperties.mock.calls.length).toBe(1);
+    expect(enumProperties.mock.calls[0][0]).toEqual({});
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
@@ -66,15 +66,13 @@ describe("ObjectInspector - Proxy", () => {
     const handlerNode = nodes.at(2);
 
     targetNode.simulate("click");
-    // The function is called twice,  to get  both non-indexed and indexed properties.
-    expect(enumProperties.mock.calls.length).toBe(2);
-    expect(enumProperties.mock.calls[0][0]).toEqual({ignoreNonIndexedProperties: true});
-    expect(enumProperties.mock.calls[1][0]).toEqual({ignoreIndexedProperties: true});
+    expect(enumProperties.mock.calls.length).toBe(1);
+    expect(enumProperties.mock.calls[0][0]).toEqual({});
 
     handlerNode.simulate("click");
     // The function is called twice,  to get  both non-indexed and indexed properties.
-    expect(enumProperties.mock.calls.length).toBe(4);
-    expect(enumProperties.mock.calls[2][0]).toEqual({ignoreNonIndexedProperties: true});
-    expect(enumProperties.mock.calls[3][0]).toEqual({ignoreIndexedProperties: true});
+    expect(enumProperties.mock.calls.length).toBe(3);
+    expect(enumProperties.mock.calls[1][0]).toEqual({ignoreNonIndexedProperties: true});
+    expect(enumProperties.mock.calls[2][0]).toEqual({ignoreIndexedProperties: true});
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-all-item-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-all-item-properties.js
@@ -7,7 +7,7 @@ const {
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties,
-  shouldLoadItemIndexedProperties,
+  shouldLoadAllItemProperties,
 } = require("../../utils/node");
 
 const GripMapEntryRep = require("../../../reps/grip-map-entry");
@@ -17,12 +17,12 @@ const gripArrayStubs = require("../../../reps/stubs/grip-array");
 const gripStubs = require("../../../reps/stubs/grip");
 const windowStubs = require("../../../reps/stubs/window");
 
-describe("shouldLoadItemIndexedProperties", () => {
-  it("returns true for an array", () => {
+describe("shouldLoadAllItemProperties", () => {
+  it("returns false for an array", () => {
     const node = createNode(null, "root", "/", {
       value: gripArrayStubs.get("testMaxProps")
     });
-    expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
+    expect(shouldLoadAllItemProperties(node)).toBeFalsy();
   });
 
   it("returns false for an already loaded item", () => {
@@ -30,17 +30,17 @@ describe("shouldLoadItemIndexedProperties", () => {
       value: gripArrayStubs.get("testMaxProps")
     });
     const loadedProperties = new Map([[node.path, true]]);
-    expect(shouldLoadItemIndexedProperties(node, loadedProperties)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node, loadedProperties)).toBeFalsy();
   });
 
   it("returns false for an array node with buckets", () => {
     const node = createNode(null, "root", "/", {
       value: gripArrayStubs.get("Array(234)")
     });
-    expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node)).toBeFalsy();
   });
 
-  it("returns true for an array bucket node", () => {
+  it("returns false for an array bucket node", () => {
     const node = createNode(null, "root", "/", {
       value: gripArrayStubs.get("Array(234)")
     });
@@ -48,33 +48,7 @@ describe("shouldLoadItemIndexedProperties", () => {
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…99]");
-    expect(shouldLoadItemIndexedProperties(bucketNodes[0])).toBeTruthy();
-  });
-
-  it("returns false for an array bucket node with sub-buckets", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(23456)")
-    });
-    const bucketNodes = getChildren({item: node});
-
-    // Make sure we do have a bucket.
-    expect(bucketNodes[0].name).toBe("[0…999]");
-    expect(shouldLoadItemIndexedProperties(bucketNodes[0])).toBeFalsy();
-  });
-
-  it("returns true for an array sub-bucket node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(23456)")
-    });
-    const bucketNodes = getChildren({item: node});
-    // Make sure we do have a bucket.
-    expect(bucketNodes[0].name).toBe("[0…999]");
-
-    // Get the sub-buckets
-    const subBucketNodes = getChildren({item: bucketNodes[0]});
-    // Make sure we do have a bucket.
-    expect(subBucketNodes[0].name).toBe("[0…99]");
-    expect(shouldLoadItemIndexedProperties(subBucketNodes[0])).toBeTruthy();
+    expect(shouldLoadAllItemProperties(bucketNodes[0])).toBeFalsy();
   });
 
   it("returns false for an entries node", () => {
@@ -82,35 +56,35 @@ describe("shouldLoadItemIndexedProperties", () => {
       value: gripMapStubs.get("20-entries Map")
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
-    expect(shouldLoadItemIndexedProperties(entriesNode)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(entriesNode)).toBeFalsy();
   });
 
-  it("returns false for an Object", () => {
+  it("returns true for an Object", () => {
     const node = createNode(null, "root", "/", {
       value: gripStubs.get("testMaxProps")
     });
-    expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node)).toBeTruthy();
   });
 
-  it("returns false for a Map", () => {
+  it("returns true for a Map", () => {
     const node = createNode(null, "root", "/", {
       value: gripMapStubs.get("20-entries Map")
     });
-    expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node)).toBeTruthy();
   });
 
-  it("returns true for a Set", () => {
+  it("returns false for a Set", () => {
     const node = createNode(null, "root", "/", {
       value: gripArrayStubs.get("new Set([1,2,3,4])")
     });
-    expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
+    expect(shouldLoadAllItemProperties(node)).toBeFalsy();
   });
 
-  it("returns false for a Window", () => {
+  it("returns true for a Window", () => {
     const node = createNode(null, "root", "/", {
       value: windowStubs.get("Window")
     });
-    expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node)).toBeTruthy();
   });
 
   it("returns false for a [default properties] node", () => {
@@ -128,54 +102,54 @@ describe("shouldLoadItemIndexedProperties", () => {
     ]]);
     const [, defaultPropertiesNode] = getChildren({item: windowNode, loadedProperties});
     expect(nodeIsDefaultProperties(defaultPropertiesNode)).toBe(true);
-    expect(shouldLoadItemIndexedProperties(defaultPropertiesNode)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(defaultPropertiesNode)).toBeFalsy();
   });
 
   it("returns false for a MapEntry node", () => {
     const node = GripMapEntryRep.createGripMapEntry("key", "value");
-    expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node)).toBeFalsy();
   });
 
   it("returns false for a Proxy node", () => {
     const node = createNode(null, "root", "/", {
       value: gripStubs.get("testProxy")
     });
-    expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node)).toBeFalsy();
   });
 
-  it("returns false for a Proxy target node", () => {
+  it("returns true for a Proxy target node", () => {
     const proxyNode = createNode(null, "root", "/", {
       value: gripStubs.get("testProxy")
     });
     const [targetNode] = getChildren({item: proxyNode});
     // Make sure we have the target node.
     expect(targetNode.name).toBe("<target>");
-    expect(shouldLoadItemIndexedProperties(targetNode)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(targetNode)).toBeTruthy();
   });
 
   it("returns false for an accessor node", () => {
     const accessorNode = createNode(null, "root", "/", {
       value: accessorStubs.get("getter")
     });
-    expect(shouldLoadItemIndexedProperties(accessorNode)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(accessorNode)).toBeFalsy();
   });
 
-  it("returns false for an accessor <get> node", () => {
+  it("returns true for an accessor <get> node", () => {
     const accessorNode = createNode(null, "root", "/", accessorStubs.get("getter"));
     const [getNode] = getChildren({item: accessorNode});
     expect(getNode.name).toBe("<get>");
-    expect(shouldLoadItemIndexedProperties(getNode)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(getNode)).toBeTruthy();
   });
 
-  it("returns false for an accessor <set> node", () => {
+  it("returns true for an accessor <set> node", () => {
     const accessorNode = createNode(null, "root", "/", accessorStubs.get("setter"));
     const [setNode] = getChildren({item: accessorNode});
     expect(setNode.name).toBe("<set>");
-    expect(shouldLoadItemIndexedProperties(setNode)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(setNode)).toBeTruthy();
   });
 
   it("returns false for a primitive node", () => {
     const node = createNode(null, "root", "/", {value: 42});
-    expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
+    expect(shouldLoadAllItemProperties(node)).toBeFalsy();
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
@@ -59,18 +59,18 @@ describe("shouldLoadItemNonIndexedProperties", () => {
     expect(shouldLoadItemNonIndexedProperties(entriesNode)).toBeFalsy();
   });
 
-  it("returns true for an Object", () => {
+  it("returns false for an Object", () => {
     const node = createNode(null, "root", "/", {
       value: gripStubs.get("testMaxProps")
     });
-    expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
+    expect(shouldLoadItemNonIndexedProperties(node)).toBeFalsy();
   });
 
-  it("returns true for a Map", () => {
+  it("returns false for a Map", () => {
     const node = createNode(null, "root", "/", {
       value: gripMapStubs.get("20-entries Map")
     });
-    expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
+    expect(shouldLoadItemNonIndexedProperties(node)).toBeFalsy();
   });
 
   it("returns true for a Set", () => {
@@ -80,11 +80,11 @@ describe("shouldLoadItemNonIndexedProperties", () => {
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
-  it("returns true for a Window", () => {
+  it("returns false for a Window", () => {
     const node = createNode(null, "root", "/", {
       value: windowStubs.get("Window")
     });
-    expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
+    expect(shouldLoadItemNonIndexedProperties(node)).toBeFalsy();
   });
 
   it("returns false for a [default properties] node", () => {
@@ -117,14 +117,14 @@ describe("shouldLoadItemNonIndexedProperties", () => {
     expect(shouldLoadItemNonIndexedProperties(node)).toBeFalsy();
   });
 
-  it("returns true for a Proxy target node", () => {
+  it("returns false for a Proxy target node", () => {
     const proxyNode = createNode(null, "root", "/", {
       value: gripStubs.get("testProxy")
     });
     const [targetNode] = getChildren({item: proxyNode});
     // Make sure we have the target node.
     expect(targetNode.name).toBe("<target>");
-    expect(shouldLoadItemNonIndexedProperties(targetNode)).toBeTruthy();
+    expect(shouldLoadItemNonIndexedProperties(targetNode)).toBeFalsy();
   });
 
   it("returns false for an accessor node", () => {
@@ -134,18 +134,18 @@ describe("shouldLoadItemNonIndexedProperties", () => {
     expect(shouldLoadItemNonIndexedProperties(accessorNode)).toBeFalsy();
   });
 
-  it("returns true for an accessor <get> node", () => {
+  it("returns false for an accessor <get> node", () => {
     const accessorNode = createNode(null, "root", "/", accessorStubs.get("getter"));
     const [getNode] = getChildren({item: accessorNode});
     expect(getNode.name).toBe("<get>");
-    expect(shouldLoadItemNonIndexedProperties(getNode)).toBeTruthy();
+    expect(shouldLoadItemNonIndexedProperties(getNode)).toBeFalsy();
   });
 
-  it("returns true for an accessor <set> node", () => {
+  it("returns false for an accessor <set> node", () => {
     const accessorNode = createNode(null, "root", "/", accessorStubs.get("setter"));
     const [setNode] = getChildren({item: accessorNode});
     expect(setNode.name).toBe("<set>");
-    expect(shouldLoadItemNonIndexedProperties(setNode)).toBeTruthy();
+    expect(shouldLoadItemNonIndexedProperties(setNode)).toBeFalsy();
   });
 
   it("returns false for a primitive node", () => {

--- a/packages/devtools-reps/src/object-inspector/utils/client.js
+++ b/packages/devtools-reps/src/object-inspector/utils/client.js
@@ -9,6 +9,21 @@ import type {
   PropertiesIterator,
 } from "../types";
 
+async function enumAllProperties(
+  objectClient: ObjectClient,
+  start: ?number,
+  end: ?number
+) : Promise<{ownProperties?: Object}> {
+  try {
+    const {iterator} = await objectClient.enumProperties({});
+    const response = await iteratorSlice(iterator, start, end);
+    return response;
+  } catch (e) {
+    console.error("Error in enumAllProperties", e);
+    return {};
+  }
+}
+
 async function enumIndexedProperties(
   objectClient: ObjectClient,
   start: ?number,
@@ -93,6 +108,7 @@ function iteratorSlice(
 }
 
 module.exports = {
+  enumAllProperties,
   enumEntries,
   enumIndexedProperties,
   enumNonIndexedProperties,

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -776,7 +776,8 @@ function shouldLoadItemIndexedProperties(
     && !nodeNeedsNumericalBuckets(item)
     && !nodeIsEntries(getClosestNonBucketNode(item))
     // The data is loaded when expanding the window node.
-    && !nodeIsDefaultProperties(item);
+    && !nodeIsDefaultProperties(item)
+    && nodeIsArrayLike(gripItem);
 }
 
 function shouldLoadItemNonIndexedProperties(
@@ -793,7 +794,26 @@ function shouldLoadItemNonIndexedProperties(
     && !nodeIsEntries(getClosestNonBucketNode(item))
     && !nodeIsBucket(item)
     // The data is loaded when expanding the window node.
-    && !nodeIsDefaultProperties(item);
+    && !nodeIsDefaultProperties(item)
+    && nodeIsArrayLike(gripItem);
+}
+
+function shouldLoadAllItemProperties(
+  item: Node,
+  loadedProperties: LoadedProperties = new Map()
+) : boolean {
+  const gripItem = getClosestGripNode(item);
+  const value = getValue(gripItem);
+
+  return value
+    && nodeHasProperties(gripItem)
+    && !loadedProperties.has(item.path)
+    && !nodeIsProxy(item)
+    && !nodeIsEntries(getClosestNonBucketNode(item))
+    && !nodeIsBucket(item)
+    // The data is loaded when expanding the window node.
+    && !nodeIsDefaultProperties(item)
+    && !nodeIsArrayLike(gripItem);
 }
 
 function shouldLoadItemEntries(
@@ -878,6 +898,7 @@ module.exports = {
   nodeNeedsNumericalBuckets,
   nodeSupportsNumericalBucketing,
   setNodeChildren,
+  shouldLoadAllItemProperties,
   shouldLoadItemEntries,
   shouldLoadItemIndexedProperties,
   shouldLoadItemNonIndexedProperties,


### PR DESCRIPTION
Fixes #707

This patch makes the ObjectClient use enumProperties options for ArrayLike objects since it may cause a bug in object with a length property.

Hopefully a better fix will happen in  https://bugzilla.mozilla.org/show_bug.cgi?id=1403065  so we'll be able to revert this change.