### PR TITLE
make eslint a dep

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "license": "MPL-2.0",
   "description":
     "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
@@ -62,6 +62,11 @@
     "devtools-modules": "^0.0.31",
     "devtools-sprintf-js": "^1.0.3",
     "devtools-utils": "^0.0.5",
+    "eslint": "^3.12.0",
+    "eslint-plugin-babel": "^3.3.0",
+    "eslint-plugin-flowtype": "^2.20.0",
+    "eslint-plugin-mozilla": "0.4.3",
+    "eslint-plugin-react": "^6.7.1",
     "express": "^4.13.4",
     "extract-text-webpack-plugin": "^3.0.0",
     "fs-extra": "^2.0.0",
@@ -98,11 +103,6 @@
   },
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
-    "eslint": "^3.12.0",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-flowtype": "^2.20.0",
-    "eslint-plugin-mozilla": "0.4.3",
-    "eslint-plugin-react": "^6.7.1",
     "ipaddr": "^0.0.9",
     "jest": "^19.0.2",
     "react-addons-perf": "^15.4.2",


### PR DESCRIPTION
eslint should be a true dependency so we can use it in debugger land

see: https://github.com/devtools-html/debugger.html/issues/4178