### PR TITLE
Switch rocket to svg

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.104-rc22",
+  "version": "0.0.105",
   "license": "MPL-2.0",
   "description":
     "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",

--- a/packages/devtools-launchpad/src/components/Sidebar.css
+++ b/packages/devtools-launchpad/src/components/Sidebar.css
@@ -74,12 +74,9 @@
   display: inline-block;
 }
 
-.landing-page .sidebar .title-wrapper .launchpad-container .rocket {
+.landing-page .sidebar .title-wrapper .launchpad-container .rocket svg {
   width: 18px;
   height: 18px;
-  background: url(/pad-assets/rocket.svg) no-repeat top left;
-  background-size: contain;
-  display: inline-block;
 }
 
 .landing-page

--- a/packages/devtools-launchpad/src/components/Sidebar.js
+++ b/packages/devtools-launchpad/src/components/Sidebar.js
@@ -6,7 +6,7 @@ const React = require("react");
 require("./Sidebar.css");
 const { DOM: dom } = React;
 const classnames = require("classnames");
-
+const Svg = require("../../assets/Svg.js");
 const Sidebar = React.createClass({
   displayName: "Sidebar",
 
@@ -24,7 +24,7 @@ const Sidebar = React.createClass({
       dom.h1({}, title),
       dom.div(
         { className: "launchpad-container" },
-        dom.div({ className: "rocket" }, ""),
+        Svg({ name: "rocket" }),
         dom.h2({ className: "launchpad-container-title" }, "Launchpad")
       )
     );


### PR DESCRIPTION
using the CSS url caused an MC linter to fail because it couldn't find the rocket svg asset.

I'd like to circle back to the launchpad and keep a lot of the assets from bundling w/ the debugger