### PR TITLE
Do not use CSS custom property in Tree.

### DIFF
--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -368,7 +368,7 @@ describe("Tree", () => {
     expect(formatTree(wrapper)).toMatchSnapshot();
 
     getTreeNodes(wrapper).forEach(n => {
-      if ("ABECDMN".split("").includes(n.text())) {
+      if ("ABECDMN".split("").includes(getSanitizedNodeText(n))) {
         expect(n.find(".arrow.expanded").exists()).toBe(true);
       } else {
         expect(n.find(".arrow").exists()).toBe(false);
@@ -446,12 +446,16 @@ function formatTree(wrapper) {
       let arrowStr = "  ";
       if (arrow.exists()) {
         arrowStr = arrow.hasClass("expanded") ? "▼ " : "▶︎ ";
-      } else {
-        arrowStr = "  ";
       }
-      return `${indentStr}${arrowStr}${node.text()}`;
+
+      return `${indentStr}${arrowStr}${getSanitizedNodeText(node)}`;
     })
     .join("\n");
+}
+
+function getSanitizedNodeText(node) {
+  // Stripping off the invisible space used in the indent.
+  return node.text().replace(/^\u200B+/, "");
 }
 
 // Encoding of the following tree/forest:

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -3,16 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .tree {
-  --arrow-width: 10px;
-  --arrow-single-margin: 5px;
-  --arrow-total-width: calc(var(--arrow-width) + var(--arrow-single-margin));
-  --arrow-fill-color: var(--theme-splitter-color, #9B9B9B);
-  --tree-indent-width: 1em;
-  --tree-indent-border-color: #A2D1FF;
-  --tree-indent-border-width: 1px;
-  --tree-node-hover-background-color: #F0F9FE;
-  --tree-node-focus-color: white;
-  --tree-node-focus-background-color: var(--theme-selection-background, #0a84ff);
   overflow: auto;
 }
 
@@ -36,25 +26,35 @@
   display: block;
 }
 
+.tree-indent {
+  display: inline-block;
+  width: 12px;
+  margin-inline-start: 5px;
+  border-inline-start: 1px solid #A2D1FF;
+}
+
 .tree .tree-node[data-expandable="true"] {
   cursor: default;
 }
 
 .tree .tree-node:not(.focused):hover {
-  background-color: var(--tree-node-hover-background-color);
+  background-color: #F0F9FE;
 }
 
 .tree .tree-node.focused {
-  color: var(--tree-node-focus-color);
-  background-color: var(--tree-node-focus-background-color);
-  --arrow-fill-color: currentColor;
+  color: white;
+  background-color: var(--theme-selection-background, #0a84ff);
+}
+
+.tree-node.focused .arrow svg {
+  fill: currentColor;
 }
 
 .arrow svg {
-  fill: var(--arrow-fill-color);
+  fill: var(--theme-splitter-color, #9B9B9B);
   transition: transform 0.125s ease;
-  width: var(--arrow-width);
-  margin-inline-end: var(--arrow-single-margin);
+  width: 10px;
+  margin-inline-end: 5px;
   transform: rotate(-90deg);
 }
 

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -44,6 +44,8 @@ class ArrowExpander extends Component {
   }
 }
 
+const treeIndent = dom.span({className: "tree-indent"}, "\u200B");
+
 class TreeNode extends Component {
   static get propTypes() {
     return {
@@ -83,38 +85,6 @@ class TreeNode extends Component {
       })
       : null;
 
-    const treeIndentWidthVar = "var(--tree-indent-width)";
-    const treeBorderColorVar = "var(--tree-indent-border-color, black)";
-    const treeBorderWidthVar = "var(--tree-indent-border-width, 1px)";
-
-    const paddingInlineStart = `calc(
-      (${treeIndentWidthVar} * ${depth})
-      ${(isExpandable ? "" : "+ var(--arrow-total-width)")}
-    )`;
-
-    // This is the computed border that will mimic a border on tree nodes.
-    // This allow us to have as many "borders" as we need without adding
-    // specific elements for that purpose only.
-    // it's a gradient with "hard stops" which will give us as much plain
-    // lines as we need given the depth of the node.
-    // The gradient uses CSS custom properties so everything is customizable
-    // by consumers if needed.
-    const backgroundBorder = depth === 0
-      ? null
-      : "linear-gradient(90deg, " +
-          Array.from({length: depth}).map((_, i) => {
-            const indentWidth = `(${i} * ${treeIndentWidthVar})`;
-            const alignIndent = `(var(--arrow-width) / 2)`;
-            const start = `calc(${indentWidth} + ${alignIndent})`;
-            const end = `calc(${indentWidth} + ${alignIndent} + ${treeBorderWidthVar})`;
-
-            return `transparent ${start},
-              ${treeBorderColorVar} ${start},
-              ${treeBorderColorVar} ${end},
-              transparent ${end}`;
-          }).join(",") +
-        ")";
-
     let ariaExpanded;
     if (this.props.isExpandable) {
       ariaExpanded = false;
@@ -123,21 +93,20 @@ class TreeNode extends Component {
       ariaExpanded = true;
     }
 
+    const indents = Array.from({length: depth}).fill(treeIndent);
+    let items = indents.concat(renderItem(item, depth, focused, arrow, expanded));
+
     return dom.div(
       {
         id,
         className: "tree-node" + (focused ? " focused" : ""),
-        style: {
-          paddingInlineStart,
-          backgroundImage: backgroundBorder,
-        },
         onClick: this.props.onClick,
         role: "treeitem",
         "aria-level": depth,
         "aria-expanded": ariaExpanded,
-        "data-expandable": this.props.isExpandable,
+        "data-expandable": this.props.isExpandable
       },
-      renderItem(item, depth, focused, arrow, expanded)
+      ...items
     );
   }
 }
@@ -189,19 +158,7 @@ function oncePerAnimationFrame(fn) {
  * restrict you to only one certain kind of tree.
  *
  * The tree comes with basic styling for the indent, the arrow, as well as hovered
- * and focused styles.
- * All of this can be customize on the customer end, by overriding the following
- * CSS custom properties :
- *   --arrow-width: the width of the arrow.
- *   --arrow-single-margin: the end margin between the arrow and the item that follows.
- *   --arrow-fill-color: the fill-color of the arrow.
- *   --tree-indent-width: the width of a 1-level-deep item.
- *   --tree-indent-border-color: the color of the indent border.
- *   --tree-indent-border-width: the width of the indent border.
- *   --tree-node-hover-background-color: the background color of a hovered node.
- *   --tree-node-focus-color: the color of a focused node.
- *   --tree-node-focus-background-color: the background color of a focused node.
- *
+ * and focused styles which can be override in CSS.
  *
  * ### Example Usage
  *

--- a/packages/devtools-components/stories/tree.js
+++ b/packages/devtools-components/stories/tree.js
@@ -4,7 +4,6 @@
 
 import React from "react";
 const { Component, createFactory, createElement } = React;
-import dom from "react-dom-factories";
 
 import Components from "../index";
 const Tree = createFactory(Components.Tree);
@@ -84,6 +83,15 @@ storiesOf("Tree", module)
       focused: "item 250",
       getRoots: () => nodes,
     }, {});
+  })
+  .add("1000 items tree", () => {
+    const nodes = Array.from({length: 1000}).map((_, i) => `item-${i + 1}`);
+    return renderTree({
+      getRoots: () => ["ROOT"],
+      expanded: new Set()
+    }, {
+      children: {"ROOT": nodes}
+    });
   })
   .add("30,000 items tree", () => {
     const nodes = Array.from({length: 1000}).map((_, i) => `item-${i + 1}`);
@@ -185,13 +193,9 @@ function createTreeElement(props, context, tree) {
     getChildren: x => tree.children && tree.children[x]
       ? tree.children[x]
       : [],
-    renderItem: (x, depth, focused, arrow, expanded) => dom.div({},
-      arrow,
-      x,
-    ),
+    renderItem: (x, depth, focused, arrow, expanded) => [arrow, x],
     getRoots: () => ["A"],
     getKey: x => "key-" + x,
-    itemHeight: 1,
     onFocus: x => {
       context.setState(previousState => {
         return {focused: x};


### PR DESCRIPTION
Because it takes a lot of time to compute on large tree.
It wasn't only the massive "background as a border", but the indent as well.
Without those 2 scrolling is quite fast.

Using multiple elements for the indent and border works quite well.
Here is 2 profiles, with and without the patch, scrolling through a tree of a thousand node with one expanded root.

In order to get consistent results, I triggered the scrolling with this code : 
```js
var index = 0;
function scrollNext() {
  index = index + 40;
  nodes[index].scrollIntoView();
  if (index < nodes.length - 1) {
    requestAnimationFrame(scrollNext);
  }
}
scrollNext();
```

where `nodes` contains all the nodes of the tree.

Profile without patch:  https://perf-html.io/public/24499d1b8bcd2e67f5071a867b0c3823f2e6c289/calltree/?hiddenThreads=&range=1.4863_2.8093&thread=5&threadOrder=0-2-3-4-5-1&v=2

Profile with patch :  https://perf-html.io/public/6a238fd4b31c250e730970dfe4d488edeef87a31/calltree/?hiddenThreads=&range=1.0600_1.8985&thread=5&threadOrder=0-2-3-4-5-1&v=2

Not perfect, but definitely better.