### PR TITLE
limit jest to 2 workers on CI for devtools-reps tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
     - cd ./packages/devtools-utils; yarn test
     - cd ./packages/devtools-modules; yarn test
     - cd ./packages/devtools-components; yarn test
-    - cd ./packages/devtools-reps; yarn test
+    - cd ./packages/devtools-reps; yarn test -- --maxWorkers 2
 
 dependencies:
   pre:


### PR DESCRIPTION
jest is taking a lot of memory on CI which ends up by npm dying and tests failing.
Limiting the number of workers might help.