### PR TITLE
Remove resizeBreakpointGutter

### DIFF
--- a/packages/devtools-source-editor/src/utils.js
+++ b/packages/devtools-source-editor/src/utils.js
@@ -37,24 +37,10 @@ function getTokenLocation(codeMirror: any, tokenEl: HTMLElement) {
   };
 }
 
-/**
- * Forces the breakpoint gutter to be the same size as the line
- * numbers gutter. Editor CSS will absolutely position the gutter
- * beneath the line numbers. This makes it easy to be flexible with
- * how we overlay breakpoints.
- */
-function resizeBreakpointGutter(editor) {
-  const gutters = editor.display.gutters;
-  const lineNumbers = gutters.querySelector(".CodeMirror-linenumbers");
-  const breakpoints = gutters.querySelector(".breakpoints");
-  breakpoints.style.width = `${lineNumbers.clientWidth}px`;
-}
-
 module.exports = {
   removeLineClass,
   clearLineClass,
   getTextForLine,
   getCursorLine,
-  getTokenLocation,
-  resizeBreakpointGutter
+  getTokenLocation
 };


### PR DESCRIPTION
Removes an unused function, that is now defined in debugger.html