### PR TITLE
Moves updateScopeBindings from debugger.html.

### DIFF
--- a/packages/devtools-map-bindings/src/tests/__snapshots__/updateScopeBindings.js.snap
+++ b/packages/devtools-map-bindings/src/tests/__snapshots__/updateScopeBindings.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`updateScopeBindings parses simple generated/minified source 1`] = `
+Object {
+  "actor": "actor",
+  "bindings": Object {
+    "arguments": Array [
+      Object {
+        "n": Object {
+          "value": 1,
+        },
+        "u": Object {
+          "value": 2,
+        },
+      },
+    ],
+    "variables": Object {},
+  },
+  "function": Object {
+    "actor": "function-actor",
+    "class": "Function",
+    "displayName": "sum",
+    "location": Object {
+      "column": 27,
+      "line": 1,
+      "sourceId": "sum.min",
+    },
+    "parameterNames": Array [
+      "n",
+      "u",
+    ],
+  },
+  "parent": undefined,
+  "sourceBindings": Object {
+    "first": "n",
+    "second": "u",
+  },
+  "type": "function",
+}
+`;

--- a/packages/devtools-map-bindings/src/tests/updateScopeBindings.js
+++ b/packages/devtools-map-bindings/src/tests/updateScopeBindings.js
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { updateScopeBindings } = require("../updateScopeBindings");
+const { getSource, getSourceMap, parseScopes } = require("./helpers");
+const { getLocationScopes } = require("../scopes");
+
+describe("updateScopeBindings", () => {
+  it("parses simple generated/minified source", async () => {
+    const source = getSource("sum.min");
+    const location = {
+      sourceId: source.id,
+      line: 1,
+      column: 27
+    };
+    const scopes = {
+      actor: 'actor',
+      bindings: {
+        arguments: [{
+          n: { value: 1 },
+          u: { value: 2 }
+        }],
+        variables: {}
+      },
+      function: {
+        actor: 'function-actor',
+        class: 'Function',
+        displayName: 'sum',
+        location: location,
+        parameterNames: ['n', 'u']
+      },
+      type: 'function'
+    };
+    const resultScopes = await updateScopeBindings(scopes, location, {
+      async getSourceMapsScopes(location: Location) {
+        const scopes = await parseScopes(location, source);
+        const map = getSourceMap(source);
+        const mappedScopes = getLocationScopes(map, scopes, location);
+        return mappedScopes;
+      }
+    });
+    expect(resultScopes).toMatchSnapshot();
+  });
+});

--- a/packages/devtools-map-bindings/src/updateScopeBindings.js
+++ b/packages/devtools-map-bindings/src/updateScopeBindings.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import type {
+  Location, SourceScope, Scope, MappedScopeBindings
+} from "debugger-html";
+
+export type ScopesDataSource = {
+  getSourceMapsScopes: (location: Location) => Promise<MappedScopeBindings[]|null>,
+};
+
+function extendScope(
+  scope: ?Scope,
+  generatedScopes: MappedScopeBindings[],
+  index: number
+): ?Scope {
+  if (!scope) {
+    return undefined;
+  }
+  if (index >= generatedScopes.length) {
+    return scope;
+  }
+  return (Object.assign({}, scope, {
+    parent: extendScope(scope.parent, generatedScopes, index + 1),
+    sourceBindings: generatedScopes[index].bindings
+  }) : any);
+}
+
+async function updateScopeBindings(
+  scope: ?Scope,
+  location: Location,
+  scopesDataSource: ScopesDataSource
+): Promise<?Scope> {
+  const generatedScopes = await scopesDataSource.getSourceMapsScopes(location);
+  if (!generatedScopes) {
+    return scope;
+  }
+  return extendScope(scope, generatedScopes, 0);
+}
+
+module.exports = {
+  updateScopeBindings,
+}


### PR DESCRIPTION
Associated Issue: blocks https://github.com/devtools-html/devtools-core/pull/780 and https://github.com/devtools-html/debugger.html/pull/4521

### Summary of Changes

* Moves updateScopeBindings to the devtools-core