### PR TITLE
Prepare devtools-map-bindings to process original scopes source maps

### DIFF
--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -221,7 +221,10 @@ declare module "debugger-html" {
 
   declare type SyntheticScope = {
     type: string,
-    bindingsNames: string[]
+    bindingsNames: string[],
+    sourceBindings?: {
+      [originalName: string]: string
+    }
   };
 
   /**

--- a/packages/devtools-map-bindings/package.json
+++ b/packages/devtools-map-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-map-bindings",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description":
     "DevTools utilities in support of original source scopes and names",
   "repository": "github:devtools-html/devtools-core",

--- a/packages/devtools-map-bindings/src/remapOriginalScopes.js
+++ b/packages/devtools-map-bindings/src/remapOriginalScopes.js
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import type {
+  Scope, SyntheticScope
+} from "debugger-html";
+
+import type { OriginalScope } from "./types";
+
+function matchOriginalAndRuntimeScopes(originalScopes, runtimeScopes) {
+  // Same as in remapScope: split on function boundary
+  const { chunks } = originalScopes.reduce(
+    ({ isLast, chunks: chunks_ }, s, index) => {
+      let chunk;
+      if (isLast) {
+        chunk = {
+          scopes: [],
+          index
+        };
+        chunks_.push(chunk);
+      } else {
+        chunk = chunks_[chunks_.length - 1];
+      }
+      chunk.scopes.push(s);
+      const isFunction = s.type === "function";
+      return { isLast: isFunction, chunks: chunks_ };
+    },
+    { isLast: true, chunks: [] }
+  );
+
+  return chunks.reduce(
+    ({ result, runtimeScopesTail, index }, chunk) => {
+      const chunkGeneratedNames = chunk.scopes.reduce((acc, s) => {
+        return acc.concat(s.generatedNames);
+      }, []);
+
+      // Find runtime scopes range that includes all names.
+      const bestRuntimeScopeIndex = chunkGeneratedNames.reduce((max, name) => {
+        const foundScopeIndex = runtimeScopesTail.findIndex(s =>
+          s.generatedNames.includes(name)
+        );
+        return Math.max(max, foundScopeIndex);
+      }, 0);
+      // Snap to function border.
+      // while (
+      //   bestRuntimeScopeIndex + 1 < runtimeScopesTail.length &&
+      //   runtimeScopesTail[bestRuntimeScopeIndex].type !== "function"
+      // ) {
+      //   bestRuntimeScopeIndex++;
+      // }
+      result.push({
+        originalStart: chunk.index,
+        originalEnd: chunk.index + chunk.scopes.length,
+        start: index,
+        end: index + bestRuntimeScopeIndex + 1
+      });
+      return {
+        result,
+        runtimeScopesTail: runtimeScopesTail.slice(bestRuntimeScopeIndex + 1),
+        index: index + bestRuntimeScopeIndex + 1
+      };
+    },
+    { result: [], runtimeScopesTail: runtimeScopes, index: 0 }
+  ).result;
+}
+
+function remapOriginalScopes(
+  scope: ?Scope,
+  originalScopes: OriginalScope[]
+): ?Scope {
+  const runtimeScopesVars = [];
+  const resultStack = [];
+  for (let s = scope; s; s = s.parent) {
+    const generatedNames = s.bindings
+      ? s.bindings.arguments.reduce((acc, arg) => {
+          return acc.concat(Object.keys(arg));
+        }, Object.keys(s.bindings.variables))
+      : [];
+    runtimeScopesVars.push({
+      type: s.type,
+      generatedNames
+    });
+    resultStack.push(s);
+  }
+  const originalScopesVars = originalScopes.map(fs => {
+    const generatedNames = Object.keys(fs.bindings).map(orignalName => {
+      return fs.bindings[orignalName].expr;
+    });
+    return {
+      type: fs.type,
+      generatedNames
+    };
+  });
+  const remapedScopes = matchOriginalAndRuntimeScopes(
+    originalScopesVars,
+    runtimeScopesVars
+  );
+  if (!remapedScopes) {
+    return scope;
+  }
+  let result: ?Scope = null;
+  for (let i = remapedScopes.length - 1; i >= 0; i--) {
+    const { originalStart, originalEnd, start, end } = remapedScopes[i];
+    // Skip if we have gaps
+    while (end < resultStack.length) {
+      result = (Object.assign({}, resultStack.pop(), {
+        parent: result
+      }) : any);
+    }
+    const groupLength = end - start;
+    let groupIndex = groupLength - 1;
+    const scopes: SyntheticScope[] = [];
+    for (let j = originalStart; j < originalEnd; j++) {
+      const { type, bindings } = originalScopes[j];
+      const bindingsNames = Object.keys(bindings);
+      const sourceBindings = bindingsNames.reduce((acc, name) => {
+        acc[name] = bindings[name].expr;
+        return acc;
+      }, Object.create(null));
+      scopes.push({
+        type,
+        bindingsNames,
+        sourceBindings
+      });
+    }
+    while (groupIndex >= 0) {
+      result = (Object.assign({}, resultStack.pop(), {
+        parent: result,
+        syntheticScopes: {
+          scopes,
+          groupIndex,
+          groupLength
+        }
+      }) : any);
+      groupIndex--;
+    }
+  }
+  return result;
+}
+
+module.exports = {
+  remapOriginalScopes,
+};

--- a/packages/devtools-map-bindings/src/tests/__snapshots__/remapOriginalScopes.js.snap
+++ b/packages/devtools-map-bindings/src/tests/__snapshots__/remapOriginalScopes.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`remapsOrignalScopes simple 1`] = `
+Object {
+  "0": Object {
+    "bindings": Object {
+      "e": Array [],
+      "n": Array [],
+      "o": Array [],
+      "r": Array [],
+      "t": Array [],
+      "u": Array [],
+    },
+    "type": "function",
+  },
+  "1": Object {
+    "bindings": Object {},
+    "type": "script",
+  },
+  "parent": null,
+  "syntheticScopes": Object {
+    "groupIndex": 0,
+    "groupLength": 1,
+    "scopes": Array [
+      Object {
+        "bindingsNames": Array [
+          "na",
+          "nb",
+        ],
+        "sourceBindings": Object {
+          "na": "o",
+          "nb": "u",
+        },
+        "type": "block",
+      },
+      Object {
+        "bindingsNames": Array [
+          "ma",
+          "mb",
+        ],
+        "sourceBindings": Object {
+          "ma": "r",
+          "mb": "t",
+        },
+        "type": "block",
+      },
+      Object {
+        "bindingsNames": Array [
+          "a",
+          "b",
+        ],
+        "sourceBindings": Object {
+          "a": "n",
+          "b": "e",
+        },
+        "type": "function",
+      },
+    ],
+  },
+}
+`;

--- a/packages/devtools-map-bindings/src/tests/remapOriginalScopes.js
+++ b/packages/devtools-map-bindings/src/tests/remapOriginalScopes.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { remapOriginalScopes } = require("../remapOriginalScopes");
+
+describe("remapsOrignalScopes", () => {
+  it("simple", () => {
+    const scopes = [
+      {
+        type: "function",
+        bindings: { n: [], e: [], o: [], u: [], r: [], t: [] }
+      },
+      {
+        type: "script",
+        bindings: {}
+      }
+    ];
+    const originalScopes = [
+      {
+        type: "block",
+        bindings: {
+          na: { expr: "o", type: "var" },
+          nb: { expr: "u", type: "var" }
+        }
+      },
+      {
+        type: "block",
+        bindings: {
+          ma: { expr: "r", type: "var" },
+          mb: { expr: "t", type: "var" }
+        }
+      },
+      {
+        type: "function",
+        displayName: "compare()",
+        bindings: {
+          a: { expr: "n", type: "arg" },
+          b: { expr: "e", type: "arg" }
+        }
+      }
+    ];
+
+    expect(remapOriginalScopes(scopes, originalScopes)).toMatchSnapshot();
+  });
+});

--- a/packages/devtools-map-bindings/src/tests/updateScopeBindings.js
+++ b/packages/devtools-map-bindings/src/tests/updateScopeBindings.js
@@ -52,6 +52,9 @@ describe("updateScopeBindings", () => {
         async getOriginalSourceScopes(location: Location) {
           const scopes = await parseScopes(location, originalSource);
           return scopes;
+        },
+        async getSourceMapsOriginalScopes(location) {
+          return null;
         }
       }
     );

--- a/packages/devtools-map-bindings/src/types.js
+++ b/packages/devtools-map-bindings/src/types.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import type {
+  Location, SourceScope, MappedScopeBindings
+} from "debugger-html";
+
+export type OriginalScope = {
+  type: string,
+  displayName?: string,
+  bindings: {
+    [originalName: string]: {
+      expr: string,
+      type: string
+    }
+  }
+};
+
+export type ScopesDataSource = {
+  getSourceMapsScopes: (location: Location) => Promise<MappedScopeBindings[]|null>,
+  getSourceMapsOriginalScopes: (location: Location) => Promise<?(OriginalScope[])>,
+  getOriginalSourceScopes: (location: Location) => Promise<?(SourceScope[])>,
+};

--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -20,6 +20,7 @@ const getGeneratedLocation = dispatcher.task("getGeneratedLocation");
 const getOriginalLocation = dispatcher.task("getOriginalLocation");
 const getLocationScopes = dispatcher.task("getLocationScopes");
 const getOriginalSourceText = dispatcher.task("getOriginalSourceText");
+const getOriginalScopes = dispatcher.task("getOriginalScopes");
 const applySourceMap = dispatcher.task("applySourceMap");
 const clearSourceMaps = dispatcher.task("clearSourceMaps");
 const hasMappedSource = dispatcher.task("hasMappedSource");
@@ -35,6 +36,7 @@ module.exports = {
   getOriginalLocation,
   getLocationScopes,
   getOriginalSourceText,
+  getOriginalScopes,
   applySourceMap,
   clearSourceMaps,
   startSourceMapWorker: dispatcher.start.bind(dispatcher),

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -39,6 +39,8 @@ import type {
   MappedScopeBindings
 } from "debugger-html";
 
+import type { OriginalScope } from "devtools-map-bindings/src/types";
+
 async function getOriginalURLs(generatedSource: Source) {
   const map = await fetchSourceMap(generatedSource);
   return map && map.sources;
@@ -154,6 +156,11 @@ async function hasMappedSource(location: Location): Promise<boolean> {
   return loc.sourceId !== location.sourceId;
 }
 
+async function getOriginalScopes(location: Location): Promise<?(OriginalScope[])> {
+  // TODO if present, read scope data from the experimental source maps format.
+  return null;
+}
+
 function applySourceMap(
   generatedId: string,
   url: string,
@@ -174,6 +181,7 @@ module.exports = {
   getOriginalLocation,
   getOriginalSourceText,
   getLocationScopes,
+  getOriginalScopes,
   applySourceMap,
   clearSourceMaps,
   hasMappedSource

--- a/packages/devtools-source-map/src/worker.js
+++ b/packages/devtools-source-map/src/worker.js
@@ -8,6 +8,7 @@ const {
   getOriginalLocation,
   getOriginalSourceText,
   getLocationScopes,
+  getOriginalScopes,
   hasMappedSource,
   applySourceMap
 } = require("./source-map");
@@ -24,6 +25,7 @@ self.onmessage = workerHandler({
   getOriginalLocation,
   getLocationScopes,
   getOriginalSourceText,
+  getOriginalScopes,
   hasMappedSource,
   applySourceMap,
   clearSourceMaps


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/pull/4613

### Summary of Changes

* Adds remapOriginalScopes to consume scope data and generate synthetic scopes
* Adds stubbed getOriginalScopes

