### PR TITLE
Fix launching chrome on windows

### DIFF
--- a/packages/devtools-launchpad/src/server/launch.js
+++ b/packages/devtools-launchpad/src/server/launch.js
@@ -6,7 +6,6 @@ const ps = require("child_process");
 const path = require("path");
 const { isFirefoxRunning } = require("./utils/firefox");
 const firefoxDriver = require("../../bin/firefox-driver");
-const isWindows = /^win/.test(process.platform);
 const {
   getValue
 } = require("devtools-config");
@@ -24,13 +23,6 @@ function handleLaunchRequest(req, res) {
         tcpPort: getValue("firefox.tcpPort")
       };
       if (!isRunning) {
-        process.on('unhandledRejection', (err)=> {
-          if (err.message.indexOf('Could not locate Firefox on the current system')>-1) {
-            console.error('selenium-webdriver could not locate Firefox, please launch it manually.');
-          } else {
-            throw err;
-          }
-        });
         firefoxDriver.start(location, options);
         res.end("launched firefox");
       } else {
@@ -41,11 +33,7 @@ function handleLaunchRequest(req, res) {
 
   if (browser == "Chrome") {
     const chromeDriver= path.resolve(__dirname, "../../bin/chrome-driver.js");
-    if (isWindows) {
-      ps.spawn('node', [chromeDriver, "--location", location]);
-    } else {
-      ps.spawn(chromeDriver, ["--location", location]);
-    }
+    ps.spawn('node', [chromeDriver, "--location", location]);
     res.end("launched chrome");
   }
 }


### PR DESCRIPTION
Associated Issue: #749

### Summary of Changes

* launch chrome with `node` as first arguments, since windows don't know about shebag notation
* catch error if selenium driver throw ff not found

### Misc
* Not bump version since, doesn't have credentials to do so
* No test

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

Still looking where the existing test :cold_sweat: 
