### PR TITLE
Soften utils

### DIFF
--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-utils",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "DevTools Utils",
   "main": "index.js",
   "scripts": {

--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -46,9 +46,9 @@ WorkerDispatcher.prototype = {
           }
 
           if (!this.worker) {
-            reject("Oops, The worker has shutdown!");
             return;
           }
+
           this.worker.removeEventListener("message", listener);
           if (result.error) {
             reject(result.error);


### PR DESCRIPTION
We made the worker util reject tasks that were completed after the worker had shutdown a couple months ago. This rationale was so that tests that involved async behavior would strictly have to wait for the activity to complete before shutting down.

This was a mistake because our actions are going to be complex. It is therefore an implementation detail what work will follow an action and a test that is just looking at one action should not have to know it.

> NOTE this is just for our tests. the workers never shutdown during the lifetime of the app.