### PR TITLE
add clike and rust modes to source editor

### DIFF
--- a/packages/devtools-source-editor/src/source-editor.js
+++ b/packages/devtools-source-editor/src/source-editor.js
@@ -25,6 +25,8 @@ require("codemirror/addon/fold/indent-fold");
 require("codemirror/addon/fold/foldgutter");
 require("codemirror/addon/selection/active-line");
 require("codemirror/addon/edit/matchbrackets");
+require("codemirror/mode/clike/clike");
+require("codemirror/mode/rust/rust");
 
 require("./source-editor.css");
 


### PR DESCRIPTION
#Associated Issue: no issues, required to add syntax highlighting for non js languages to better accommodate growing WASM support

### Summary of Changes

* Added clike and rust modes to codemirror based source editor

### Test Plan

No test plan as no changes to the features are implemented

### Screenshots/Videos (OPTIONAL)
n/a