### PR TITLE
decode base64 inline json

### DIFF
--- a/packages/devtools-utils/src/network-request.js
+++ b/packages/devtools-utils/src/network-request.js
@@ -4,21 +4,27 @@
 
 // @flow
 
+const InlineBase64JSON = "data:application/json;";
+
 // opts is ignored because this is only used in local development and
 // replaces a more powerful network request from Firefox that can be
 // configured.
 function networkRequest(url: string, opts: any) {
+  if (url.startsWith(InlineBase64JSON)) {
+    const content = atob(url.slice(url.indexOf("base64") + 7));
+    return Promise.resolve({ content });
+  }
+
   return Promise.race([
     fetch(`/get?url=${url}`).then(res => {
       if (res.status >= 200 && res.status < 300) {
-        return res.text()
-          .then(text => ({ content: text }));
+        return res.text().then(text => ({ content: text }));
       }
       return Promise.reject(new Error(`failed to request ${url}`));
     }),
     new Promise((resolve, reject) => {
       setTimeout(() => reject(new Error("Connect timeout error")), 6000);
-    }),
+    })
   ]);
 }
 


### PR DESCRIPTION
### Summary of Changes

* The launchpad server does not support inline base64 URLs as well as the panel. 
* adding atob support here is an edge case that could be a bit faster.


here is a patch for adding it to the [launchpad ](https://github.com/devtools-html/devtools-core/compare/master...jasonLaster:network-req?expand=1). unfortunately, here node does not send the mappings down well in every case...