### PR TITLE
Add a button to jump to a function definition.

### DIFF
--- a/packages/devtools-reps/src/launchpad/components/Result.js
+++ b/packages/devtools-reps/src/launchpad/components/Result.js
@@ -81,6 +81,8 @@ class Result extends Component {
         releaseActor,
         mode: MODE[modeKey],
         onInspectIconClick: nodeFront => console.log("inspectIcon click", nodeFront),
+        onViewSourceInDebugger: location =>
+          console.log("onViewSourceInDebugger", {location}),
       })
     );
   }

--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -13,6 +13,7 @@ const {
   wrapRender,
 } = require("./rep-utils");
 const { MODE } = require("./constants");
+const Svg = require("../shared/images/Svg");
 
 const dom = require("react-dom-factories");
 const { span } = dom;
@@ -23,10 +24,28 @@ const { span } = dom;
 FunctionRep.propTypes = {
   object: PropTypes.object.isRequired,
   parameterNames: PropTypes.array,
+  onViewSourceInDebugger: PropTypes.func,
 };
 
 function FunctionRep(props) {
-  let grip = props.object;
+  let {
+    object: grip,
+    onViewSourceInDebugger,
+  } = props;
+
+  let jumpToDefinitionButton;
+  if (onViewSourceInDebugger && grip.location && grip.location.url) {
+    jumpToDefinitionButton = Svg("jump-definition", {
+      element: "a",
+      draggable: false,
+      title: "Jump to definition",
+      onClick: e => {
+        // Stop the event propagation so we don't trigger ObjectInspector expand/collapse.
+        e.stopPropagation();
+        onViewSourceInDebugger(grip.location);
+      }
+    });
+  }
 
   return (
     span({
@@ -40,7 +59,8 @@ function FunctionRep(props) {
       getFunctionName(grip, props),
       "(",
       ...renderParams(props),
-      ")"
+      ")",
+      jumpToDefinitionButton,
     )
   );
 }

--- a/packages/devtools-reps/src/reps/reps.css
+++ b/packages/devtools-reps/src/reps/reps.css
@@ -213,6 +213,22 @@
 }
 
 /******************************************************************************/
+/* Jump to definition button */
+
+.jump-definition svg {
+  stroke: var(--comment-node-color);
+  height: 16px;
+  width: 16px;
+  margin-left: .25em;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.jump-definition svg:hover {
+  stroke: var(--theme-highlight-blue);
+}
+
+/******************************************************************************/
 /* "more…" ellipsis */
 .more-ellipsis {
   color: var(--comment-node-color);

--- a/packages/devtools-reps/src/reps/tests/function.js
+++ b/packages/devtools-reps/src/reps/tests/function.js
@@ -2,6 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* global jest */
 const { shallow } = require("enzyme");
 const { REPS } = require("../rep");
 const { MODE } = require("../constants");
@@ -231,5 +232,55 @@ describe("Function - Anonymous generator function", () => {
       mode: MODE.TINY,
       parameterNames: ["a", "b", "c"]
     }).text()).toBe("* (a, b, c)");
+  });
+});
+
+describe("Function - Jump to definition", () => {
+  it("renders an icon when onViewSourceInDebugger props is provided", () => {
+    const onViewSourceInDebugger = jest.fn();
+    const object = stubs.get("Named");
+    const renderedComponent = renderRep(object, {
+      onViewSourceInDebugger
+    });
+
+    const node = renderedComponent.find(".jump-definition");
+    node.simulate("click", {
+      type: "click",
+      stopPropagation: () => {},
+    });
+
+    expect(node.exists()).toBeTruthy();
+    expect(onViewSourceInDebugger.mock.calls.length).toEqual(1);
+    expect(onViewSourceInDebugger.mock.calls[0][0]).toEqual(object.location);
+  });
+
+  it("does not render an icon when onViewSourceInDebugger props is not provided", () => {
+    const object = stubs.get("Named");
+    const renderedComponent = renderRep(object);
+
+    const node = renderedComponent.find(".jump-definition");
+    expect(node.exists()).toBeFalsy();
+  });
+
+  it("does not render an icon when the object has no location", () => {
+    const object = Object.assign({}, stubs.get("Named"));
+    delete object.location;
+    const renderedComponent = renderRep(object, {
+      onViewSourceInDebugger: () => {}
+    });
+
+    const node = renderedComponent.find(".jump-definition");
+    expect(node.exists()).toBeFalsy();
+  });
+
+  it("does not render an icon when the object has no url location", () => {
+    const object = Object.assign({}, stubs.get("Named"));
+    object.location.url = null;
+    const renderedComponent = renderRep(object, {
+      onViewSourceInDebugger: () => {}
+    });
+
+    const node = renderedComponent.find(".jump-definition");
+    expect(node.exists()).toBeFalsy();
   });
 });

--- a/packages/devtools-reps/src/shared/images/Svg.js
+++ b/packages/devtools-reps/src/shared/images/Svg.js
@@ -8,6 +8,7 @@ import InlineSVG from "svg-inline-react";
 
 const svg = {
   "open-inspector": require("./open-inspector.svg"),
+  "jump-definition": require("./jump-definition.svg"),
 };
 
 Svg.propTypes = {

--- a/packages/devtools-reps/src/shared/images/jump-definition.svg
+++ b/packages/devtools-reps/src/shared/images/jump-definition.svg
@@ -1,0 +1,17 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <g stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="arrow" transform="translate(1.000000, 3.000000)">
+            <path d="M4.5,0.5 L6.5,2.5"></path>
+            <path d="M4.5,2.5 L6.5,4.5" transform="translate(5.500000, 3.500000) scale(1, -1) translate(-5.500000, -3.500000) "></path>
+            <path d="M6.00090144,2.5 C4.67806937,2.5 3.67938478,2.5 3.00484766,2.5 C1.99304199,2.5 1.01049805,3.5168457 0.993840144,4.52403846 C0.988750751,4.54723808 0.988750751,5.87097168 0.993840144,8.49523926" id="Path-2" stroke-linejoin="round"></path>
+        </g>
+        <g id="content-lines" transform="translate(9.000000, 2.000000)">
+            <path d="M1.5,3.5 L5.5,3.5"></path>
+            <path d="M0.5,1.5 L5.5,1.5"></path>
+            <path d="M0.5,5.5 L5.5,5.5"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Fixes #640.

The Function rep would accept an onViewSourceInDebugger prop, and the
icon would be shown when we do have this props as well as a location with
a non-null url (so we don't show it on prototypes for example).
Clicking on the button would call the prop with the location object.
A test is added to make sure we handle the different possible cases.

### Test Plan
Open the Reps test app and evaluate a function

### Screenshots
<img width="387" alt="screen shot 2017-11-22 at 14 04 28" src="https://user-images.githubusercontent.com/578107/33129731-410d5904-cf91-11e7-832f-6b670813527c.png">

