### PR TITLE
Fix console message explaining how to turn on logging.

### DIFF
--- a/packages/devtools-launchpad/bin/firefox-proxy
+++ b/packages/devtools-launchpad/bin/firefox-proxy
@@ -14,7 +14,7 @@ function proxy(host, webSocketPort, tcpPort, logging) {
   console.log(`Listening for WS on localhost:${webSocketPort}, all traffic is proxied to ${host}:${tcpPort}`);
   if (!logging) {
     console.log("Protocol messages can be logged by enabling " +
-    "logging.firefoxProtocol in your local.json config");
+    "logging.firefoxProxy in debugger.html/configs/local.json");
   }
   let wsServer = new ws.Server({ port: webSocketPort });
   wsServer.on("connection", function onConnection(wsConnection) {

--- a/packages/devtools-launchpad/bin/firefox-proxy
+++ b/packages/devtools-launchpad/bin/firefox-proxy
@@ -13,8 +13,9 @@ const net = require("net");
 function proxy(host, webSocketPort, tcpPort, logging) {
   console.log(`Listening for WS on localhost:${webSocketPort}, all traffic is proxied to ${host}:${tcpPort}`);
   if (!logging) {
-    console.log("Protocol messages can be logged by enabling " +
-    "logging.firefoxProxy in /configs/local.json");
+     const style = "background-color:#F9F9FA; color:#E135B2;"
+     console.log("Protocol messages can be logged by enabling %clogging.firefoxProxy%c " +
+       "in %c/configs/local.json", style, "", style);
   }
   let wsServer = new ws.Server({ port: webSocketPort });
   wsServer.on("connection", function onConnection(wsConnection) {

--- a/packages/devtools-launchpad/bin/firefox-proxy
+++ b/packages/devtools-launchpad/bin/firefox-proxy
@@ -14,7 +14,7 @@ function proxy(host, webSocketPort, tcpPort, logging) {
   console.log(`Listening for WS on localhost:${webSocketPort}, all traffic is proxied to ${host}:${tcpPort}`);
   if (!logging) {
     console.log("Protocol messages can be logged by enabling " +
-    "logging.firefoxProxy in debugger.html/configs/local.json");
+    "logging.firefoxProxy in /configs/local.json");
   }
   let wsServer = new ws.Server({ port: webSocketPort });
   wsServer.on("connection", function onConnection(wsConnection) {


### PR DESCRIPTION
The console message shows the wrong property name.