### PR TITLE
Opens launchpad on reload of previously closed external tab

### DIFF
--- a/packages/devtools-launchpad/src/index.js
+++ b/packages/devtools-launchpad/src/index.js
@@ -180,10 +180,15 @@ async function getTabs(actions) {
 async function bootstrap(React, ReactDOM) {
   const connTarget = getTargetFromQuery();
   if (connTarget) {
-    const { tab, tabConnection } = await startDebugging(connTarget);
+    const debuggedTarget = await startDebugging(connTarget);
 
-    await updateConfig();
-    return { tab, connTarget, tabConnection };
+    if (debuggedTarget) {
+      const { tab, tabConnection } = debuggedTarget;
+      await updateConfig();
+      return { tab, connTarget, tabConnection };
+    } else {
+      console.info("Tab closed due to missing debugged target window.")
+    }
   }
 
   const { store, actions, LaunchpadApp } = await initApp();


### PR DESCRIPTION
Associated Issue: #846

### Summary of Changes

- added check if debugged target exists
- if not we default to launchpad

### Test Plan

- tested on running debugger

### Screenshots/Videos 
![reload](https://user-images.githubusercontent.com/23530054/33956634-7651c94c-e03f-11e7-8619-3648ce28c444.gif)
