### PR TITLE
Fix lint scripts error

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "flow": "flow",
     "license-check": "lerna run license-check",
-    "lint": "yarn run lint-css; a=$?; yarn run lint-js; b=$?; test $a -eq 0 -a $b -eq 0",
+    "lint": "yarn lint-css; a=$?; yarn lint-js; b=$?; test $a -eq 0 -a $b -eq 0",
     "lint-css": "stylelint packages/devtools-launchpad/**/*.css",
     "lint-js": "eslint packages/devtools-launchpad/src; eslint packages/devtools-reps/src; eslint packages/devtools-components/src",
     "nom": "rm -rf node_modules/ packages/*/node_modules/ && yarn install",
-    "prepush": "yarn run lint && yarn run flow",
+    "prepush": "yarn lint && yarn flow",
     "postinstall": "lerna bootstrap",
     "test": "lerna run test"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "flow": "flow",
     "license-check": "lerna run license-check",
-    "lint": "yarn run lint-css -s; a=$?; yarn run lint-js -s; b=$?; test $a -eq 0 -a $b -eq 0",
+    "lint": "yarn run lint-css; a=$?; yarn run lint-js; b=$?; test $a -eq 0 -a $b -eq 0",
     "lint-css": "stylelint packages/devtools-launchpad/**/*.css",
     "lint-js": "eslint packages/devtools-launchpad/src; eslint packages/devtools-reps/src; eslint packages/devtools-components/src",
     "nom": "rm -rf node_modules/ packages/*/node_modules/ && yarn install",


### PR DESCRIPTION
Fixes #857, by ommiting `-s` options. I'm not sure if they meant to add some
sort of functionality or they were accidental, but removing them fixed the errors
for me.