### PR TITLE
Allow symbol grips to have an actor

### DIFF
--- a/packages/devtools-reps/src/reps/rep-utils.js
+++ b/packages/devtools-reps/src/reps/rep-utils.js
@@ -341,18 +341,13 @@ function getGripPreviewItems(grip) {
  * @return {boolean}
  */
 function getGripType(object, noGrip) {
-  let type = typeof object;
-  if (type == "object" && object instanceof String) {
-    type = "string";
-  } else if (object && type == "object" && object.type && noGrip !== true) {
-    type = object.type;
+  if (noGrip || Object(object) !== object) {
+    return typeof object;
   }
-
-  if (isGrip(object)) {
-    type = object.class;
+  if (object.type === "object") {
+    return object.class;
   }
-
-  return type;
+  return object.type;
 }
 
 /**


### PR DESCRIPTION
Associated Issue: #842

### Summary of Changes

 - Does not assume that grips with an actor will be object grips with a class
 - Does not access `type` nor `actor` properties if `noGrip === true`
 - Removes a seemingly unnecessary case about String objects, there shouldn't be such kind of grip. And if this was necessary in the `noGrip === true` case, then I guess that Boolean, Number and Symbol objects should also be handled.

You can update stubs or whatever else once symbol actors are really added.

### Test Plan

I modified added an actor to symbol grips and applied this patch to `devtools/client/shared/components/reps/reps.js`. Symbol values were properly displayed in the console.