### PR TITLE
Add an actor id data attribute on symbol rep

### DIFF
--- a/packages/devtools-reps/src/reps/stubs/symbol.js
+++ b/packages/devtools-reps/src/reps/stubs/symbol.js
@@ -5,11 +5,13 @@
 const stubs = new Map();
 stubs.set("Symbol", {
   type: "symbol",
+  actor: "server1.conn1.child1/symbol1",
   name: "foo"
 });
 
 stubs.set("SymbolWithoutIdentifier", {
-  type: "symbol"
+  type: "symbol",
+  actor: "server1.conn1.child1/symbol2",
 });
 
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/symbol.js
+++ b/packages/devtools-reps/src/reps/symbol.js
@@ -27,7 +27,10 @@ function SymbolRep(props) {
   } = props;
   let {name} = object;
 
-  return span({className}, `Symbol(${name || ""})`);
+  return span({
+    className,
+    "data-link-actor-id": object.actor,
+  }, `Symbol(${name || ""})`);
 }
 
 function supportsObject(object, noGrip = false) {

--- a/packages/devtools-reps/src/reps/tests/symbol.js
+++ b/packages/devtools-reps/src/reps/tests/symbol.js
@@ -6,6 +6,7 @@ const { shallow } = require("enzyme");
 const { REPS } = require("../rep");
 const { Rep } = REPS;
 const stubs = require("../stubs/symbol");
+const { expectActorAttribute } = require("./test-helpers");
 
 describe("test Symbol", () => {
   const stub = stubs.get("Symbol");
@@ -16,6 +17,7 @@ describe("test Symbol", () => {
     }));
 
     expect(renderedComponent.text()).toEqual("Symbol(foo)");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 });
 
@@ -28,5 +30,6 @@ describe("test Symbol without identifier", () => {
     }));
 
     expect(renderedComponent.text()).toEqual("Symbol()");
+    expectActorAttribute(renderedComponent, stub.actor);
   });
 });


### PR DESCRIPTION
This then can be used to retrieve the actor the node is representing.
For example, in the console we can use it in the context menu entry
to store an object as a global variable.

Associated Issue: #878

### Summary of Changes

 - Add an actor id data attribute on symbol rep

### Test Plan

I added an actor to symbol grips and applied #874 and this patch to devtools/client/shared/components/reps/reps.js. The symbols could be stored as global variables.

I also tried it without symbol actors (which is the current behavior) and then `object.actor` is undefined and react just ignores it. So it's harmless if this lands before [bug 1424722](https://bugzilla.mozilla.org/show_bug.cgi?id=1424722).