### PR TITLE
[WIP] Move the logic to load properties of a node to util file.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -22,6 +22,8 @@ const {
   MODE,
 } = require("../reps/constants");
 
+const Utils = require("./utils");
+
 const {
   getChildren,
   getClosestGripNode,
@@ -39,8 +41,11 @@ const {
   nodeIsPrototype,
   nodeIsSetter,
   nodeIsWindow,
+} = Utils.node;
+
+const {
   loadItemProperties,
-} = require("./utils/node");
+} = Utils.loadProperties;
 
 import type {
   CachedNodes,

--- a/packages/devtools-reps/src/object-inspector/tests/component/state.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/state.js
@@ -111,7 +111,7 @@ describe("ObjectInspector - state", () => {
     // Once all the loading promises are resolved, the loading
     // state property should be cleaned up, and actors and loadedProperties
     // should have the expected values.
-    await Promise.all(state.loading.get("root-1"));
+    await state.loading.get("root-1");
 
     state = wrapper.state();
     expect(state.loading.has("root-1")).toBeFalsy();
@@ -131,7 +131,7 @@ describe("ObjectInspector - state", () => {
     // Once all the loading promises are resolved, the loading
     // state property should be cleaned up, and actors and loadedProperties
     // should have the expected values.
-    await Promise.all(state.loading.get("root-1/__proto__"));
+    await state.loading.get("root-1/__proto__");
     expect(formatObjectInspector(wrapper)).toMatchSnapshot();
     state = wrapper.state();
 
@@ -168,7 +168,7 @@ describe("ObjectInspector - state", () => {
     // Once all the loading promises are resolved, the loading
     // state property should be cleaned up, and actors and loadedProperties
     // should have the expected values.
-    await Promise.all(state.loading.get("root-2"));
+    await state.loading.get("root-2");
     expect(formatObjectInspector(wrapper)).toMatchSnapshot();
 
     state = wrapper.state();
@@ -187,7 +187,7 @@ describe("ObjectInspector - state", () => {
     // Once all the loading promises are resolved, the loading
     // state property should be cleaned up, and actors and loadedProperties
     // should have the expected values.
-    await Promise.all(state.loading.get("root-2/__proto__"));
+    await state.loading.get("root-2/__proto__");
     expect(formatObjectInspector(wrapper)).toMatchSnapshot();
     state = wrapper.state();
 

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-entries.js
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const Utils = require("../../utils");
 const {
   createNode,
   getChildren,
   makeNodesForEntries,
+} = Utils.node;
+
+const {
   shouldLoadItemEntries,
-} = require("../../utils/node");
+} = Utils.loadProperties;
 
 const gripMapStubs = require("../../../reps/stubs/grip-map");
 const gripArrayStubs = require("../../../reps/stubs/grip-array");

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const Utils = require("../../utils");
 const {
   createNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties,
+} = Utils.node;
+
+const {
   shouldLoadItemIndexedProperties,
-} = require("../../utils/node");
+} = Utils.loadProperties;
 
 const GripMapEntryRep = require("../../../reps/grip-map-entry");
 const accessorStubs = require("../../../reps/stubs/accessor");

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const Utils = require("../../utils");
 const {
   createNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties,
+} = Utils.node;
+
+const {
   shouldLoadItemNonIndexedProperties,
-} = require("../../utils/node");
+} = Utils.loadProperties;
 
 const GripMapEntryRep = require("../../../reps/grip-map-entry");
 const accessorStubs = require("../../../reps/stubs/accessor");

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const Utils = require("../../utils");
 const {
   createNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties,
+} = Utils.node;
+
+const {
   shouldLoadItemPrototype,
-} = require("../../utils/node");
+} = Utils.loadProperties;
 
 const GripMapEntryRep = require("../../../reps/grip-map-entry");
 const accessorStubs = require("../../../reps/stubs/accessor");

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const Utils = require("../../utils");
 const {
   createNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties,
+} = Utils.node;
+
+const {
   shouldLoadItemSymbols,
-} = require("../../utils/node");
+} = Utils.loadProperties;
 
 const GripMapEntryRep = require("../../../reps/grip-map-entry");
 const accessorStubs = require("../../../reps/stubs/accessor");

--- a/packages/devtools-reps/src/object-inspector/utils/index.js
+++ b/packages/devtools-reps/src/object-inspector/utils/index.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const client = require("./client");
+const loadProperties = require("./load-properties");
+const node = require("./node");
+
+module.exports = {
+  client,
+  loadProperties,
+  node,
+};

--- a/packages/devtools-reps/src/object-inspector/utils/load-properties.js
+++ b/packages/devtools-reps/src/object-inspector/utils/load-properties.js
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const {
+  enumEntries,
+  enumIndexedProperties,
+  enumNonIndexedProperties,
+  getPrototype,
+  enumSymbols,
+} = require("./client");
+
+const {
+  getClosestGripNode,
+  getClosestNonBucketNode,
+  getValue,
+  nodeHasAccessors,
+  nodeHasAllEntriesInPreview,
+  nodeHasProperties,
+  nodeIsBucket,
+  nodeIsDefaultProperties,
+  nodeIsEntries,
+  nodeIsMapEntry,
+  nodeIsPrimitive,
+  nodeIsProxy,
+  nodeNeedsNumericalBuckets,
+} = require("./node");
+
+import type {
+  GripProperties,
+  LoadedProperties,
+  Node,
+  NodeContents,
+  ObjectClient,
+  RdpGrip,
+} from "../types";
+
+function loadItemProperties(
+  item: Node,
+  createObjectClient: (RdpGrip | NodeContents) => ObjectClient,
+  loadedProperties: LoadedProperties
+) : Promise<GripProperties> | null {
+  const [start, end] = item.meta
+    ? [item.meta.startIndex, item.meta.endIndex]
+    : [];
+
+  let objectClient;
+  const getObjectClient = () => {
+    if (objectClient) {
+      return objectClient;
+    }
+
+    const gripItem = getClosestGripNode(item);
+    const value = getValue(gripItem);
+    return createObjectClient(value);
+  };
+
+  let loadingPromises = [];
+  if (shouldLoadItemIndexedProperties(item, loadedProperties)) {
+    loadingPromises.push(enumIndexedProperties(getObjectClient(), start, end));
+  }
+
+  if (shouldLoadItemNonIndexedProperties(item, loadedProperties)) {
+    loadingPromises.push(enumNonIndexedProperties(getObjectClient(), start, end));
+  }
+
+  if (shouldLoadItemEntries(item, loadedProperties)) {
+    loadingPromises.push(enumEntries(getObjectClient(), start, end));
+  }
+
+  if (shouldLoadItemPrototype(item, loadedProperties)) {
+    loadingPromises.push(getPrototype(getObjectClient()));
+  }
+
+  if (shouldLoadItemSymbols(item, loadedProperties)) {
+    loadingPromises.push(enumSymbols(getObjectClient(), start, end));
+  }
+
+  if (loadingPromises.length === 0) {
+    return null;
+  }
+
+  return Promise.all(loadingPromises)
+    .then(responses => responses.reduce((accumulator, res) => {
+      // Let's loop through the responses to build a single response object.
+      Object.entries(res).forEach(([k, v]) => {
+        if (accumulator.hasOwnProperty(k)) {
+          if (Array.isArray(accumulator[k])) {
+            accumulator[k].push(...v);
+          } else if (typeof accumulator[k] === "object") {
+            accumulator[k] = Object.assign({}, accumulator[k], v);
+          }
+        } else {
+          accumulator[k] = v;
+        }
+      });
+      return accumulator;
+    }, {}));
+}
+
+function shouldLoadItemIndexedProperties(
+  item: Node,
+  loadedProperties: LoadedProperties = new Map()
+) : boolean {
+  const gripItem = getClosestGripNode(item);
+  const value = getValue(gripItem);
+
+  return value
+    && nodeHasProperties(gripItem)
+    && !loadedProperties.has(item.path)
+    && !nodeIsProxy(item)
+    && !nodeNeedsNumericalBuckets(item)
+    && !nodeIsEntries(getClosestNonBucketNode(item))
+    // The data is loaded when expanding the window node.
+    && !nodeIsDefaultProperties(item);
+}
+
+function shouldLoadItemNonIndexedProperties(
+  item: Node,
+  loadedProperties: LoadedProperties = new Map()
+) : boolean {
+  const gripItem = getClosestGripNode(item);
+  const value = getValue(gripItem);
+
+  return value
+    && nodeHasProperties(gripItem)
+    && !loadedProperties.has(item.path)
+    && !nodeIsProxy(item)
+    && !nodeIsEntries(getClosestNonBucketNode(item))
+    && !nodeIsBucket(item)
+    // The data is loaded when expanding the window node.
+    && !nodeIsDefaultProperties(item);
+}
+
+function shouldLoadItemEntries(
+  item: Node,
+  loadedProperties: LoadedProperties = new Map()
+) : boolean {
+  const gripItem = getClosestGripNode(item);
+  const value = getValue(gripItem);
+
+  return value
+    && nodeIsEntries(getClosestNonBucketNode(item))
+    && !nodeHasAllEntriesInPreview(gripItem)
+    && !loadedProperties.has(item.path)
+    && !nodeNeedsNumericalBuckets(item);
+}
+
+function shouldLoadItemPrototype(
+  item: Node,
+  loadedProperties: LoadedProperties = new Map()
+) : boolean {
+  const value = getValue(item);
+
+  return value
+    && !loadedProperties.has(item.path)
+    && !nodeIsBucket(item)
+    && !nodeIsMapEntry(item)
+    && !nodeIsEntries(item)
+    && !nodeIsDefaultProperties(item)
+    && !nodeHasAccessors(item)
+    && !nodeIsPrimitive(item);
+}
+
+function shouldLoadItemSymbols(
+  item: Node,
+  loadedProperties: LoadedProperties = new Map()
+) : boolean {
+  const value = getValue(item);
+
+  return value
+    && !loadedProperties.has(item.path)
+    && !nodeIsBucket(item)
+    && !nodeIsMapEntry(item)
+    && !nodeIsEntries(item)
+    && !nodeIsDefaultProperties(item)
+    && !nodeHasAccessors(item)
+    && !nodeIsPrimitive(item)
+    && !nodeIsProxy(item);
+}
+
+module.exports = {
+  loadItemProperties,
+  shouldLoadItemEntries,
+  shouldLoadItemIndexedProperties,
+  shouldLoadItemNonIndexedProperties,
+  shouldLoadItemPrototype,
+  shouldLoadItemSymbols,
+};

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -29,12 +29,21 @@ const NODE_TYPES = {
   PROTOTYPE: Symbol("__proto__"),
 };
 
+const {
+  enumEntries,
+  enumIndexedProperties,
+  enumNonIndexedProperties,
+  getPrototype,
+  enumSymbols,
+} = require("./client");
+
 import type {
   CachedNodes,
   GripProperties,
   LoadedProperties,
   Node,
   NodeContents,
+  ObjectClient,
   RdpGrip,
 } from "../types";
 
@@ -762,6 +771,69 @@ function getClosestNonBucketNode(item: Node) : Node | null {
   return getClosestNonBucketNode(parent);
 }
 
+function loadItemProperties(
+  item: Node,
+  createObjectClient: (RdpGrip | NodeContents) => ObjectClient,
+  loadedProperties: LoadedProperties
+) : Promise<Object> | null {
+  const [start, end] = item.meta
+    ? [item.meta.startIndex, item.meta.endIndex]
+    : [];
+
+  let objectClient;
+  const getObjectClient = () => {
+    if (objectClient) {
+      return objectClient;
+    }
+
+    const gripItem = getClosestGripNode(item);
+    const value = getValue(gripItem);
+    return createObjectClient(value);
+  };
+
+  let loadingPromises = [];
+  if (shouldLoadItemIndexedProperties(item, loadedProperties)) {
+    loadingPromises.push(enumIndexedProperties(getObjectClient(), start, end));
+  }
+
+  if (shouldLoadItemNonIndexedProperties(item, loadedProperties)) {
+    loadingPromises.push(enumNonIndexedProperties(getObjectClient(), start, end));
+  }
+
+  if (shouldLoadItemEntries(item, loadedProperties)) {
+    loadingPromises.push(enumEntries(getObjectClient(), start, end));
+  }
+
+  if (shouldLoadItemPrototype(item, loadedProperties)) {
+    loadingPromises.push(getPrototype(getObjectClient()));
+  }
+
+  if (shouldLoadItemSymbols(item, loadedProperties)) {
+    loadingPromises.push(enumSymbols(getObjectClient(), start, end));
+  }
+
+  if (loadingPromises.length === 0) {
+    return null;
+  }
+
+  return Promise.all(loadingPromises)
+    .then(responses => responses.reduce((accumulator, res) => {
+      // Let's loop through the responses to build a single response object.
+      Object.entries(res).forEach(([k, v]) => {
+        if (accumulator.hasOwnProperty(k)) {
+          if (Array.isArray(accumulator[k])) {
+            accumulator[k].push(...v);
+          } else if (typeof accumulator[k] === "object") {
+            accumulator[k] = Object.assign({}, accumulator[k], v);
+          }
+        } else {
+          accumulator[k] = v;
+        }
+      });
+      return accumulator;
+    }, {}));
+}
+
 function shouldLoadItemIndexedProperties(
   item: Node,
   loadedProperties: LoadedProperties = new Map()
@@ -878,6 +950,7 @@ module.exports = {
   nodeNeedsNumericalBuckets,
   nodeSupportsNumericalBucketing,
   setNodeChildren,
+  loadItemProperties,
   shouldLoadItemEntries,
   shouldLoadItemIndexedProperties,
   shouldLoadItemNonIndexedProperties,

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -29,21 +29,12 @@ const NODE_TYPES = {
   PROTOTYPE: Symbol("__proto__"),
 };
 
-const {
-  enumEntries,
-  enumIndexedProperties,
-  enumNonIndexedProperties,
-  getPrototype,
-  enumSymbols,
-} = require("./client");
-
 import type {
   CachedNodes,
   GripProperties,
   LoadedProperties,
   Node,
   NodeContents,
-  ObjectClient,
   RdpGrip,
 } from "../types";
 
@@ -771,150 +762,6 @@ function getClosestNonBucketNode(item: Node) : Node | null {
   return getClosestNonBucketNode(parent);
 }
 
-function loadItemProperties(
-  item: Node,
-  createObjectClient: (RdpGrip | NodeContents) => ObjectClient,
-  loadedProperties: LoadedProperties
-) : Promise<Object> | null {
-  const [start, end] = item.meta
-    ? [item.meta.startIndex, item.meta.endIndex]
-    : [];
-
-  let objectClient;
-  const getObjectClient = () => {
-    if (objectClient) {
-      return objectClient;
-    }
-
-    const gripItem = getClosestGripNode(item);
-    const value = getValue(gripItem);
-    return createObjectClient(value);
-  };
-
-  let loadingPromises = [];
-  if (shouldLoadItemIndexedProperties(item, loadedProperties)) {
-    loadingPromises.push(enumIndexedProperties(getObjectClient(), start, end));
-  }
-
-  if (shouldLoadItemNonIndexedProperties(item, loadedProperties)) {
-    loadingPromises.push(enumNonIndexedProperties(getObjectClient(), start, end));
-  }
-
-  if (shouldLoadItemEntries(item, loadedProperties)) {
-    loadingPromises.push(enumEntries(getObjectClient(), start, end));
-  }
-
-  if (shouldLoadItemPrototype(item, loadedProperties)) {
-    loadingPromises.push(getPrototype(getObjectClient()));
-  }
-
-  if (shouldLoadItemSymbols(item, loadedProperties)) {
-    loadingPromises.push(enumSymbols(getObjectClient(), start, end));
-  }
-
-  if (loadingPromises.length === 0) {
-    return null;
-  }
-
-  return Promise.all(loadingPromises)
-    .then(responses => responses.reduce((accumulator, res) => {
-      // Let's loop through the responses to build a single response object.
-      Object.entries(res).forEach(([k, v]) => {
-        if (accumulator.hasOwnProperty(k)) {
-          if (Array.isArray(accumulator[k])) {
-            accumulator[k].push(...v);
-          } else if (typeof accumulator[k] === "object") {
-            accumulator[k] = Object.assign({}, accumulator[k], v);
-          }
-        } else {
-          accumulator[k] = v;
-        }
-      });
-      return accumulator;
-    }, {}));
-}
-
-function shouldLoadItemIndexedProperties(
-  item: Node,
-  loadedProperties: LoadedProperties = new Map()
-) : boolean {
-  const gripItem = getClosestGripNode(item);
-  const value = getValue(gripItem);
-
-  return value
-    && nodeHasProperties(gripItem)
-    && !loadedProperties.has(item.path)
-    && !nodeIsProxy(item)
-    && !nodeNeedsNumericalBuckets(item)
-    && !nodeIsEntries(getClosestNonBucketNode(item))
-    // The data is loaded when expanding the window node.
-    && !nodeIsDefaultProperties(item);
-}
-
-function shouldLoadItemNonIndexedProperties(
-  item: Node,
-  loadedProperties: LoadedProperties = new Map()
-) : boolean {
-  const gripItem = getClosestGripNode(item);
-  const value = getValue(gripItem);
-
-  return value
-    && nodeHasProperties(gripItem)
-    && !loadedProperties.has(item.path)
-    && !nodeIsProxy(item)
-    && !nodeIsEntries(getClosestNonBucketNode(item))
-    && !nodeIsBucket(item)
-    // The data is loaded when expanding the window node.
-    && !nodeIsDefaultProperties(item);
-}
-
-function shouldLoadItemEntries(
-  item: Node,
-  loadedProperties: LoadedProperties = new Map()
-) : boolean {
-  const gripItem = getClosestGripNode(item);
-  const value = getValue(gripItem);
-
-  return value
-    && nodeIsEntries(getClosestNonBucketNode(item))
-    && !nodeHasAllEntriesInPreview(gripItem)
-    && !loadedProperties.has(item.path)
-    && !nodeNeedsNumericalBuckets(item);
-}
-
-function shouldLoadItemPrototype(
-  item: Node,
-  loadedProperties: LoadedProperties = new Map()
-) : boolean {
-  const value = getValue(item);
-
-  return value
-    && !loadedProperties.has(item.path)
-    && !nodeIsBucket(item)
-    && !nodeIsMapEntry(item)
-    && !nodeIsEntries(item)
-    && !nodeIsDefaultProperties(item)
-    && !nodeHasAccessors(item)
-    && !nodeIsPrimitive(item);
-}
-
-function shouldLoadItemSymbols(
-  item: Node,
-  loadedProperties: LoadedProperties = new Map()
-) : boolean {
-  const value = getValue(item);
-
-  return value
-    && !loadedProperties.has(item.path)
-    && !nodeIsBucket(item)
-    && !nodeIsMapEntry(item)
-    && !nodeIsEntries(item)
-    && !nodeIsDefaultProperties(item)
-    && !nodeHasAccessors(item)
-    && !nodeIsPrimitive(item)
-    && !nodeIsProxy(item);
-}
-
 module.exports = {
   createNode,
   getChildren,
@@ -950,12 +797,6 @@ module.exports = {
   nodeNeedsNumericalBuckets,
   nodeSupportsNumericalBucketing,
   setNodeChildren,
-  loadItemProperties,
-  shouldLoadItemEntries,
-  shouldLoadItemIndexedProperties,
-  shouldLoadItemNonIndexedProperties,
-  shouldLoadItemPrototype,
-  shouldLoadItemSymbols,
   sortProperties,
   NODE_TYPES,
   // Export for testing purpose.


### PR DESCRIPTION
This will allow a consumer (e.g. the debugger) to preload properties of a given root
and use them as it wishes (e.g., for the debugger, use all the direct properties as
root for the ObjectInspector of the Popup preview).