### PR TITLE
Add Zlib into valid licenses.

### DIFF
--- a/packages/devtools-license-check/bin/devtools-license-check
+++ b/packages/devtools-license-check/bin/devtools-license-check
@@ -61,6 +61,8 @@ const VALID_LICENSES = [
   'Unlicense',
   'Public Domain',
   'Public domain',
+
+  'Zlib',
 ];
 
 function isValidLicense(license) {


### PR DESCRIPTION
Zlib is used by the packo packages, which is a dependency of babel-eslint,
of which we need the latest version on the debugger.
The [Zlib license](https://spdx.org/licenses/Zlib.html) seems pretty safe to
add in the list of valid licenses here.