### PR TITLE
Expose all ObjectInspector utils.

### DIFF
--- a/packages/devtools-reps/src/index.js
+++ b/packages/devtools-reps/src/index.js
@@ -5,7 +5,7 @@
 const { MODE } = require("./reps/constants");
 const { REPS, getRep } = require("./reps/rep");
 const ObjectInspector = require("./object-inspector/");
-const ObjectInspectorUtils = require("./object-inspector/utils/node");
+const ObjectInspectorUtils = require("./object-inspector/utils/");
 
 const {
   parseURLEncodedText,


### PR DESCRIPTION
This is needed for the debugger to be able to fetch properties on its own.