### PR TITLE
Prevent expanding an object when a string is selected.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -368,6 +368,10 @@ class ObjectInspector extends Component {
         }),
         onClick: e => {
           e.stopPropagation();
+          const selection = getSelection();
+          if (selection && selection.toString()) {
+            return;
+          }
           if (isPrimitive === false) {
             this.setExpanded(item, !expanded);
           }


### PR DESCRIPTION
Fix #885

This patch is going to fix an unnecessary object expanding when a string is selected.