### PR TITLE
Introduce getStackTrace method for webconsole client (sync with m-c)

### DIFF
--- a/packages/devtools-connection/src/webconsole/client.js
+++ b/packages/devtools-connection/src/webconsole/client.js
@@ -525,6 +525,24 @@ WebConsoleClient.prototype = {
   },
 
   /**
+   * Retrieve the stack-trace information for the given NetworkEventActor.
+   *
+   * @param string actor
+   *        The NetworkEventActor ID.
+   * @param function onResponse
+   *        The function invoked when the stack-trace is received.
+   * @return request
+   *         Request object that implements both Promise and EventEmitter interfaces
+   */
+  getStackTrace: function (actor, onResponse) {
+    let packet = {
+      to: actor,
+      type: "getStackTrace",
+    };
+    return this._client.request(packet, onResponse);
+  },
+
+  /**
    * Send a HTTP request with the given data.
    *
    * @param string aData


### PR DESCRIPTION
This PR add `getStackTrace` method for fetching stack-trace info from the back-end.  This method exists in m-c for some time, but wasn't synced with devtools-connection package.

Honza