### PR TITLE
Fix #917 - update listTabs API to remove deprecated callback argument

### DIFF
--- a/packages/devtools-connection/src/debugger/client.js
+++ b/packages/devtools-connection/src/debugger/client.js
@@ -424,8 +424,8 @@ DebuggerClient.prototype = {
    * This function exists only to preserve DebuggerClient's interface;
    * new code should say 'client.mainRoot.listTabs()'.
    */
-  listTabs: function(aOnResponse) {
-    return this.mainRoot.listTabs(aOnResponse);
+  listTabs: function() {
+    return this.mainRoot.listTabs();
   },
 
   /*


### PR DESCRIPTION
Just a signature update, removing an unused and deprecated argument. Note that listTabs now supports an options object as first argument. However this is only available on Nightly and given that launchpad can connect to several versions of Firefox I don't think we should explicitly advertise it here.

options would allow launchpad to retrieve favicon data, which could be a nice addition to the list of tabs.