### PR TITLE
Fix indentation of non-expandable nodes

### DIFF
--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -44,7 +44,7 @@
 
 /* Align with expandables siblings (where we have the arrow) */
 .tree-node[data-expandable="false"] .tree-indent:last-of-type {
-  margin-inline-end: 15px;
+  margin-inline-end: 4px;
 }
 
 /* For non expandable root nodes, we don't have .tree-indent elements, so we declare


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/5250

The indentation of non-expandable nodes was too large.

### Summary of Changes

```diff
 .tree-node[data-expandable="false"] .tree-indent:last-of-type {
-  margin-inline-end: 15px;
+  margin-inline-end: 4px;
 }
```