### PR TITLE
Add new representations for uninitialized/unmapped/unscoped.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -40,6 +40,9 @@ const {
   nodeIsPrimitive,
   nodeIsPrototype,
   nodeIsSetter,
+  nodeIsUninitializedBinding,
+  nodeIsUnmappedBinding,
+  nodeIsUnscopedBinding,
   nodeIsWindow,
 } = Utils.node;
 
@@ -311,7 +314,13 @@ class ObjectInspector extends Component {
       itemValue.hasOwnProperty &&
       itemValue.hasOwnProperty("unavailable");
 
-    if (nodeIsOptimizedOut(item)) {
+    if (nodeIsUninitializedBinding(item)) {
+      objectValue = dom.span({ className: "unavailable" }, "(uninitialized)");
+    } else if (nodeIsUnmappedBinding(item)) {
+      objectValue = dom.span({ className: "unavailable" }, "(unmapped)");
+    } else if (nodeIsUnscopedBinding(item)) {
+      objectValue = dom.span({ className: "unavailable" }, "(unscoped)");
+    } else if (nodeIsOptimizedOut(item)) {
       objectValue = dom.span({ className: "unavailable" }, "(optimized away)");
     } else if (nodeIsMissingArguments(item) || unavailable) {
       objectValue = dom.span({ className: "unavailable" }, "(unavailable)");

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/properties.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/properties.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ObjectInspector - properties renders uninitialized bindings 1`] = `
+"<ObjectInspector autoExpandDepth={0} createObjectClient={[Function]} roots={{...}}>
+  <Tree className=\\"object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode id=\\"root/someFoo\\" index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div id=\\"root/someFoo\\" className=\\"tree-node\\" onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]} data-expandable={false}>
+          <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
+            <span className=\\"object-label\\" onClick={{...}}>
+              someFoo
+            </span>
+            <span className=\\"object-delimiter\\">
+              : 
+            </span>
+            <span className=\\"unavailable\\">
+              (uninitialized)
+            </span>
+          </div>
+        </div>
+      </TreeNode>
+    </div>
+  </Tree>
+</ObjectInspector>"
+`;
+
+exports[`ObjectInspector - properties renders unmapped bindings 1`] = `
+"<ObjectInspector autoExpandDepth={0} createObjectClient={[Function]} roots={{...}}>
+  <Tree className=\\"object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode id=\\"root/someFoo\\" index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div id=\\"root/someFoo\\" className=\\"tree-node\\" onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]} data-expandable={false}>
+          <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
+            <span className=\\"object-label\\" onClick={{...}}>
+              someFoo
+            </span>
+            <span className=\\"object-delimiter\\">
+              : 
+            </span>
+            <span className=\\"unavailable\\">
+              (unmapped)
+            </span>
+          </div>
+        </div>
+      </TreeNode>
+    </div>
+  </Tree>
+</ObjectInspector>"
+`;
+
+exports[`ObjectInspector - properties renders unscoped bindings 1`] = `
+"<ObjectInspector autoExpandDepth={0} createObjectClient={[Function]} roots={{...}}>
+  <Tree className=\\"object-inspector\\" autoExpandAll={true} autoExpandDepth={0} disabledFocus={[undefined]} itemHeight={20} isExpanded={[Function]} isExpandable={[Function]} focused={{...}} getRoots={[Function]} getParent={[Function]} getChildren={[Function]} getKey={[Function]} onExpand={[Function]} onCollapse={[Function]} onFocus={[Function]} renderItem={[Function]}>
+    <div className=\\"tree object-inspector\\" role=\\"tree\\" tabIndex=\\"0\\" onKeyDown={[Function]} onKeyPress={[Function]} onKeyUp={[Function]} onFocus={[Function]} onBlur={[Function]} onClick={[Function]} aria-label={[undefined]} aria-labelledby={[undefined]} aria-activedescendant={{...}} style={{...}}>
+      <TreeNode id=\\"root/someFoo\\" index={0} item={{...}} depth={0} renderItem={[Function]} focused={false} expanded={false} isExpandable={false} onExpand={[Function]} onCollapse={[Function]} onClick={[Function]}>
+        <div id=\\"root/someFoo\\" className=\\"tree-node\\" onClick={[Function]} role=\\"treeitem\\" aria-level={0} aria-expanded={[undefined]} data-expandable={false}>
+          <div className=\\"node object-node\\" onClick={[Function]} onDoubleClick={{...}}>
+            <span className=\\"object-label\\" onClick={{...}}>
+              someFoo
+            </span>
+            <span className=\\"object-delimiter\\">
+              : 
+            </span>
+            <span className=\\"unavailable\\">
+              (unscoped)
+            </span>
+          </div>
+        </div>
+      </TreeNode>
+    </div>
+  </Tree>
+</ObjectInspector>"
+`;

--- a/packages/devtools-reps/src/object-inspector/tests/component/properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/properties.js
@@ -71,4 +71,52 @@ describe("ObjectInspector - properties", () => {
     expect(enumProperties.mock.calls[0][0]).toEqual({ignoreNonIndexedProperties: true});
     expect(enumProperties.mock.calls[1][0]).toEqual({ignoreIndexedProperties: true});
   });
+
+  it("renders uninitialized bindings", () => {
+    const wrapper = mount(ObjectInspector(generateDefaults({
+      roots: [{
+        name: "someFoo",
+        path: "root/someFoo",
+        contents: {
+          value: {
+            uninitialized: true,
+          },
+        }
+      }]
+    })));
+
+    expect(wrapper.debug()).toMatchSnapshot();
+  });
+
+  it("renders unmapped bindings", () => {
+    const wrapper = mount(ObjectInspector(generateDefaults({
+      roots: [{
+        name: "someFoo",
+        path: "root/someFoo",
+        contents: {
+          value: {
+            unmapped: true,
+          },
+        }
+      }]
+    })));
+
+    expect(wrapper.debug()).toMatchSnapshot();
+  });
+
+  it("renders unscoped bindings", () => {
+    const wrapper = mount(ObjectInspector(generateDefaults({
+      roots: [{
+        name: "someFoo",
+        path: "root/someFoo",
+        contents: {
+          value: {
+            unscoped: true,
+          },
+        }
+      }]
+    })));
+
+    expect(wrapper.debug()).toMatchSnapshot();
+  });
 });

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -105,6 +105,27 @@ function nodeIsOptimizedOut(item: Node) : boolean {
   return !nodeHasChildren(item) && value && value.optimizedOut;
 }
 
+function nodeIsUninitializedBinding(item: Node) : boolean {
+  const value = getValue(item);
+  return value && value.uninitialized;
+}
+
+// Used to check if an item represents a binding that exists in a sourcemap's
+// original file content, but does not match up with a binding found in the
+// generated code.
+function nodeIsUnmappedBinding(item: Node) : boolean {
+  const value = getValue(item);
+  return value && value.unmapped;
+}
+
+// Used to check if an item represents a binding that exists in the debugger's
+// parser result, but does not match up with a binding returned by the
+// debugger server.
+function nodeIsUnscopedBinding(item: Node) : boolean {
+  const value = getValue(item);
+  return value && value.unscoped;
+}
+
 function nodeIsMissingArguments(item: Node) : boolean {
   const value = getValue(item);
   return !nodeHasChildren(item) && value && value.missingArguments;
@@ -793,6 +814,9 @@ module.exports = {
   nodeIsPrototype,
   nodeIsProxy,
   nodeIsSetter,
+  nodeIsUninitializedBinding,
+  nodeIsUnmappedBinding,
+  nodeIsUnscopedBinding,
   nodeIsWindow,
   nodeNeedsNumericalBuckets,
   nodeSupportsNumericalBucketing,


### PR DESCRIPTION
Related Issues: #5252, #5215

### Summary of Changes

* Adds `nodeIsUninitializedBinding` which I'm surprised wasn't already there. Uninitialized bindings were just showing as `null`, so this makes them show as `(uninitialized)`
* Adds two more states related to mapping original source file bindings to the actual executing bindings
