### PR TITLE
Changed fetchSourceMap to reject instead of resolve when sourceMapURL is not found

### DIFF
--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -64,7 +64,7 @@ function fetchSourceMap(generatedSource: Source) {
   }
 
   if (!generatedSource.sourceMapURL) {
-    return Promise.resolve(null);
+    return Promise.reject();
   }
 
   // Fire off the request, set it in the cache, and return it.


### PR DESCRIPTION
This is a result of the discussion here: https://github.com/devtools-html/debugger.html/pull/1937#issuecomment-330414299.

The end goal is to better allow failures when loading of source maps to clear the sourceMapURL in order to enable pretty printing: Relied on by: https://github.com/devtools-html/debugger.html/pull/5296.

Associated Issue: https://github.com/devtools-html/debugger.html/issues/1661


### Summary of Changes

* Changed fetchSourceMap to reject instead of resolve when sourceMapURL is not found