### PR TITLE
Add explicit support for DeadObject in Grip rep.

### DIFF
--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -318,6 +318,10 @@ function supportsObject(object, noGrip = false) {
     return false;
   }
 
+  if (object.class === "DeadObject") {
+    return true;
+  }
+
   return (
     object.preview
     ? typeof object.preview.ownProperties !== "undefined"

--- a/packages/devtools-reps/src/reps/stubs/grip.js
+++ b/packages/devtools-reps/src/reps/stubs/grip.js
@@ -995,4 +995,13 @@ stubs.set("Generator", {
   }
 });
 
+stubs.set("DeadObject", {
+  "type": "object",
+  "actor": "server1.conn7.child2/obj41",
+  "class": "DeadObject",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false
+});
+
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -582,3 +582,24 @@ describe("Grip - Generator object", () => {
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
 });
+
+describe("Grip - DeadObject object", () => {
+  // Test object (executed in a privileged content, like about:preferences):
+  // `var s = Cu.Sandbox(null);Cu.nukeSandbox(s);s;`
+
+  const object = stubs.get("DeadObject");
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallowRenderRep(object, props);
+    const defaultOutput = "DeadObject {  }";
+
+    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("DeadObject");
+    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+  });
+});


### PR DESCRIPTION
It was already picked up, but because the GripRep is the default rep we fall
back to when no other Rep support the object.
Adding a test (and a stub) to make sure we handle those object as expected.