### PR TITLE
force a state change when changing the initial measurements

### DIFF
--- a/packages/devtools-splitter/src/SplitBox.js
+++ b/packages/devtools-splitter/src/SplitBox.js
@@ -81,6 +81,14 @@ class SplitBox extends Component {
     if (this.props.vert !== nextProps.vert) {
       this.setState({ vert: nextProps.vert });
     }
+    if (this.props.initialSize !== nextProps.initialSize
+      || this.props.initialWidth !== nextProps.initialWidth 
+      || this.props.initialHeight !== nextProps.initialHeight) {
+      this.setState({ 
+        width: parseInt(nextProps.initialWidth || nextProps.initialSize, 10),
+        height: parseInt(nextProps.initialHeight || nextProps.initialSize, 10),
+      });
+    }
   }
 
   // Dragging Events


### PR DESCRIPTION
In conjunction with this PR to debugger: https://github.com/devtools-html/debugger.html/pull/5383

### Summary of Changes

* force a state change when changing the initial measurements

This is to ensure that when we render another SplitBox in the same location, it actually get initialized as desired.
Another solution could be to use react's `key` property, perhaps passed into props, so that react can tell that it is a different element.