### PR TITLE
Move the url opened when clicking the launch firefox button to config

### DIFF
--- a/packages/devtools-launchpad/configs/development.json
+++ b/packages/devtools-launchpad/configs/development.json
@@ -5,6 +5,7 @@
   "favicon": "assets/launchpad-favicon.png",
   "theme": "light",
   "dir": "ltr",
+  "defaultURL": "https://devtools-html.github.io/debugger-examples/",
   "logging": {
     "client": false,
     "firefoxProxy": false,

--- a/packages/devtools-launchpad/src/server/launch.js
+++ b/packages/devtools-launchpad/src/server/launch.js
@@ -12,7 +12,7 @@ const {
 
 function handleLaunchRequest(req, res) {
   const browser = req.body.browser;
-  const location = "https://devtools-html.github.io/debugger-examples/";
+  const location = getValue("defaultURL");
 
   process.env.PATH += `:${__dirname}`;
   if (browser == "Firefox") {


### PR DESCRIPTION
It was hardcoded in launch.js and was well suited for the debugger,
but other tools might want to see other default pages.