### PR TITLE
Add arrow spacing in right pane for Chrome

### DIFF
--- a/packages/devtools-components/postcss.config.js
+++ b/packages/devtools-components/postcss.config.js
@@ -3,4 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Dumb export so launchpad does not throw.
-module.exports = () => ({});
+module.exports = () => {
+  return {
+    plugins: [require("autoprefixer")]
+  };
+};

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -75,6 +75,7 @@
   transition: transform 0.125s ease;
   width: 10px;
   margin-inline-end: 5px;
+  -webkit-margin-end: 5px;
   transform: rotate(-90deg);
 }
 

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -15,10 +15,6 @@
 }
 
 .tree.noselect {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 
@@ -75,7 +71,6 @@
   transition: transform 0.125s ease;
   width: 10px;
   margin-inline-end: 5px;
-  -webkit-margin-end: 5px;
   transform: rotate(-90deg);
 }
 


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/5457

### Summary of Changes

* Chrome doesn't support `margin-line-end` so `-webkit-margin-end: 5px;` was added to `.arrow svg`

### Test Plan

- Start debugger.html
- Open in Chrome
- Open a new tab in Firefox
- Attach debugger.html to Firefox
- View sidebar arrow with correct spacing

### Screenshot

![screen shot 2018-02-17 at 15 41 19](https://user-images.githubusercontent.com/24863179/36342634-202810c4-13f9-11e8-9182-42ffb7b728ba.png)
