### PR TITLE
[WIP] Bump devtools-reps to 0.20.0

### DIFF
--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-reps",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Devtools Reps",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
See [Bug 1436670](https://bugzilla.mozilla.org/show_bug.cgi?id=1436670).
[TRY run](https://treeherder.mozilla.org/#/jobs?repo=try&revision=69a07dcf5a90d892ca084777f3b05f70db61ebd7)