### PR TITLE
Expand node when arrow is clicked

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -25,3 +25,7 @@
 .object-inspector .object-delimiter {
   color: var(--theme-comment);
 }
+
+.tree.object-inspector .arrow svg {
+  pointer-events: none;
+}

--- a/packages/devtools-reps/src/object-inspector/utils/selection.js
+++ b/packages/devtools-reps/src/object-inspector/utils/selection.js
@@ -2,9 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const {ELEMENT_NODE} = require("../../shared/dom-node-constants");
+
 function documentHasSelection() : boolean {
   const selection = getSelection();
-  return selection && selection.type === "Range";
+  if (!selection) {
+    return false;
+  }
+
+  const {
+    anchorNode,
+    focusNode,
+  } = selection;
+
+  // When clicking the arrow, which is an inline svg element, the selection do have a type
+  // of "Range". We need to have an explicit case when the anchor and the focus node are
+  // the same and they have an arrow ancestor.
+  if (
+    focusNode &&
+    focusNode === anchorNode &&
+    focusNode.nodeType == ELEMENT_NODE &&
+    focusNode.closest(".arrow")
+  ) {
+    return false;
+  }
+
+  return selection.type === "Range";
 }
 
 module.exports = {


### PR DESCRIPTION
The issue was caused because of the documentHasSelection helper
we introduced recently.
When an inline svg document is clicked, the getSelection does return
a Range type.
Here we set an explicit if for the arrow click to fix the issue.