### PR TITLE
Remove xmlns attribute in svgs.

### DIFF
--- a/packages/devtools-components/src/images/arrow.svg
+++ b/packages/devtools-components/src/images/arrow.svg
@@ -1,6 +1,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="0 0 16 16">
   <path d="M8 13.4c-.5 0-.9-.2-1.2-.6L.4 5.2C0 4.7-.1 4.3.2 3.7S1 3 1.6 3h12.8c.6 0 1.2.1 1.4.7.3.6.2 1.1-.2 1.6l-6.4 7.6c-.3.4-.7.5-1.2.5z"/>
 </svg>

--- a/packages/devtools-reps/src/shared/images/jump-definition.svg
+++ b/packages/devtools-reps/src/shared/images/jump-definition.svg
@@ -1,7 +1,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="0 0 16 16">
     <g stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
         <g id="arrow" transform="translate(1.000000, 3.000000)">
             <path d="M4.5,0.5 L6.5,2.5"></path>

--- a/packages/devtools-reps/src/shared/images/open-inspector.svg
+++ b/packages/devtools-reps/src/shared/images/open-inspector.svg
@@ -1,6 +1,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="0 0 16 16">
   <path d="M8,3L12,3L12,7L14,7L14,8L12,8L12,12L8,12L8,14L7,14L7,12L3,12L3,8L1,8L1,7L3,7L3,3L7,3L7,1L8,1L8,3ZM10,10L10,5L5,5L5,10L10,10Z"/>
 </svg>


### PR DESCRIPTION
Fixes #950.

The attribute is removed by React anyway, and it prints a warning message in
the console