### PR TITLE
 Better function name in Error stacktrace. 

### DIFF
--- a/packages/devtools-reps/src/reps/error.js
+++ b/packages/devtools-reps/src/reps/error.js
@@ -10,6 +10,7 @@ const {
   isGrip,
   wrapRender,
 } = require("./rep-utils");
+const { cleanFunctionName } = require("./function");
 const { MODE } = require("./constants");
 
 const dom = require("react-dom-factories");
@@ -91,11 +92,7 @@ function getStacktraceElements(preview) {
       const result = line.match(/^(.*)@(.*)$/);
       let functionName;
       let location;
-      if (!result || result.length !== 3) {
-        // This line did not match up nicely with the "function@location" pattern for
-        // some reason.
-        functionName = line;
-      } else {
+      if (result && result.length === 3) {
         functionName = result[1];
 
         // If the resource was loaded by base-loader.js, the location looks like:
@@ -104,16 +101,18 @@ function getStacktraceElements(preview) {
         location = result[2].split(" -> ").pop();
       }
 
-      stack.push(
-        span({
-          key: "fn" + index,
-          className: "objectBox-stackTrace-fn"
-        }, functionName),
-        span({
-          key: "location" + index,
-          className: "objectBox-stackTrace-location"
-        }, ` (${location})`)
-      );
+      if (!functionName) {
+        functionName = "<anonymous>";
+      }
+
+      stack.push(span({
+        key: "fn" + index,
+        className: "objectBox-stackTrace-fn"
+      }, cleanFunctionName(functionName)),
+      span({
+        key: "location" + index,
+        className: "objectBox-stackTrace-location"
+      }, ` (${location})`));
     });
 
   return span({

--- a/packages/devtools-reps/src/reps/error.js
+++ b/packages/devtools-reps/src/reps/error.js
@@ -89,9 +89,13 @@ function getStacktraceElements(preview) {
         return;
       }
 
-      const result = line.match(/^(.*)@(.*)$/);
       let functionName;
       let location;
+
+      // Given the input: "functionName@scriptLocation:2:100"
+      // Result:
+      // ["functionName@scriptLocation:2:100", "functionName", "scriptLocation:2:100"]
+      const result = line.match(/^(.*)@(.*)$/);
       if (result && result.length === 3) {
         functionName = result[1];
 

--- a/packages/devtools-reps/src/reps/tests/__snapshots__/error.js.snap
+++ b/packages/devtools-reps/src/reps/tests/__snapshots__/error.js.snap
@@ -15,7 +15,9 @@ exports[`Error - Eval error renders with expected text for an EvalError 1`] = `
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -41,7 +43,9 @@ exports[`Error - Internal error renders with expected text for an InternalError 
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -91,7 +95,9 @@ exports[`Error - Multi line stack error renders with expected text for Error obj
     <span
       className="objectBox-stackTrace-fn"
       key="fn2"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location2"
@@ -117,7 +123,9 @@ exports[`Error - Range error renders with expected text for RangeError 1`] = `
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -143,7 +151,9 @@ exports[`Error - Reference error renders with expected text for ReferenceError 1
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -169,7 +179,9 @@ exports[`Error - Simple error renders with expected text for simple error 1`] = 
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -195,7 +207,9 @@ exports[`Error - Syntax error renders with expected text for SyntaxError 1`] = `
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -221,7 +235,9 @@ exports[`Error - Type error renders with expected text for TypeError 1`] = `
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -247,7 +263,9 @@ exports[`Error - URI error renders with expected text for URIError 1`] = `
     <span
       className="objectBox-stackTrace-fn"
       key="fn0"
-    />
+    >
+      &lt;anonymous&gt;
+    </span>
     <span
       className="objectBox-stackTrace-location"
       key="location0"
@@ -295,7 +313,7 @@ exports[`Error - base-loader.js renders as expected without mode 1`] = `
       className="objectBox-stackTrace-fn"
       key="fn1"
     >
-      send/&lt;
+      send
     </span>
     <span
       className="objectBox-stackTrace-location"
@@ -307,7 +325,7 @@ exports[`Error - base-loader.js renders as expected without mode 1`] = `
       className="objectBox-stackTrace-fn"
       key="fn2"
     >
-      exports.makeInfallible/&lt;
+      makeInfallible
     </span>
     <span
       className="objectBox-stackTrace-location"
@@ -319,7 +337,7 @@ exports[`Error - base-loader.js renders as expected without mode 1`] = `
       className="objectBox-stackTrace-fn"
       key="fn3"
     >
-      exports.makeInfallible/&lt;
+      makeInfallible
     </span>
     <span
       className="objectBox-stackTrace-location"


### PR DESCRIPTION
Fixes #959.

Built on top of https://github.com/devtools-html/devtools-core/pull/973, only https://github.com/devtools-html/devtools-core/commit/4c4accc965f9a9f233ce2837b956aaed10600d0f is relevant here.

- Display `<anonymous>` for unnamed functions.
- Call cleanFunctionName on it.