### PR TITLE
Have consistent pseudo-nodes in ObjectInspector.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
@@ -47,7 +47,7 @@ exports[`ObjectInspector - entries does not call enumEntries if entries are alre
 |  |  ▼ 10: \\"key-10\\" → \\"value-10\\"
 |  |  |    <key>: \\"key-10\\"
 |  |  |    <value>: \\"value-10\\"
-|  ▼ __proto__: {…}"
+|  ▼ <prototype>: {…}"
 `;
 
 exports[`ObjectInspector - entries renders Object with entries as expected 1`] = `
@@ -60,5 +60,5 @@ exports[`ObjectInspector - entries renders Object with entries as expected 1`] =
 |  |  ▼ 1: Symbol(b) → \\"value-b\\"
 |  |  |    <key>: Symbol(b)
 |  |  |    <value>: \\"value-b\\"
-|  ▼ __proto__: {…}"
+|  ▼ <prototype>: {…}"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
@@ -31,7 +31,7 @@ exports[`ObjectInspector - state has the expected expandedPaths state when click
 "▼ {…}
 |    a: 1
 |    Symbol(): \\"hello\\"
-|  ▶︎ __proto__: Object { … }
+|  ▶︎ <prototype>: Object { … }
 ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
 `;
 
@@ -51,7 +51,7 @@ exports[`ObjectInspector - state has the expected expandedPaths state when click
 "▼ {…}
 |    a: 1
 |    Symbol(): \\"hello\\"
-|  ▶︎ __proto__: Object { … }
+|  ▶︎ <prototype>: Object { … }
 ▼ Proxy
 |  ▶︎ <target>: Object { … }
 |  ▶︎ <handler>: Array(3) [ … ]"
@@ -64,14 +64,14 @@ exports[`ObjectInspector - state has the expected state when expanding a node 1`
 
 exports[`ObjectInspector - state has the expected state when expanding a node 2`] = `
 "▼ {…}
-|  ▶︎ __proto__: Object {  }
+|  ▶︎ <prototype>: Object {  }
 ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a node 3`] = `
 "▼ {…}
-|  ▼ __proto__: {}
-|  |  ▶︎ __proto__: Object {  }
+|  ▼ <prototype>: {}
+|  |  ▶︎ <prototype>: Object {  }
 ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
 `;
 
@@ -85,7 +85,7 @@ exports[`ObjectInspector - state has the expected state when expanding a proxy n
 ▼ Proxy
 |  ▶︎ <target>: Object { … }
 |  ▶︎ <handler>: Array(3) [ … ]
-|  ▶︎ __proto__: Object {  }"
+|  ▶︎ <prototype>: Object {  }"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a proxy node 3`] = `
@@ -93,6 +93,6 @@ exports[`ObjectInspector - state has the expected state when expanding a proxy n
 ▼ Proxy
 |  ▶︎ <target>: Object { … }
 |  ▶︎ <handler>: Array(3) [ … ]
-|  ▼ __proto__: {}
-|  |  ▶︎ __proto__: Object {  }"
+|  ▼ <prototype>: {}
+|  |  ▶︎ <prototype>: Object {  }"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
@@ -4,5 +4,5 @@ exports[`ObjectInspector - Proxy renders Proxy as expected 1`] = `
 "▼ Proxy
 |  ▶︎ <target>: Object { … }
 |  ▶︎ <handler>: Array(3) [ … ]
-|    __proto__: Object {  }"
+|    <prototype>: Object {  }"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/basic.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/basic.js
@@ -200,7 +200,7 @@ describe("ObjectInspector - renders", () => {
       NODE_TYPES.DEFAULT_PROPERTIES
     );
 
-    // The [default properties] node should have the "lessen" class only when collapsed.
+    // The <default properties> node should have the "lessen" class only when collapsed.
     let oi = mount(ObjectInspector(generateDefaults({
       roots: [defaultPropertiesNode],
     })));
@@ -224,7 +224,7 @@ describe("ObjectInspector - renders", () => {
       NODE_TYPES.PROTOTYPE
     );
 
-    // The __proto__ node should have the "lessen" class only when collapsed.
+    // The <prototype> node should have the "lessen" class only when collapsed.
     oi = mount(ObjectInspector(generateDefaults({
       roots: [prototypeNode],
     })));

--- a/packages/devtools-reps/src/object-inspector/tests/component/entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/entries.js
@@ -50,7 +50,7 @@ describe("ObjectInspector - entries", () => {
       },
       loadedProperties: new Map([
         ["root", mapStubs.get("properties")],
-        ["root/__proto__", true]
+        ["root/<prototype>", true]
       ])
     })));
 
@@ -77,7 +77,7 @@ describe("ObjectInspector - entries", () => {
       loadedProperties: new Map([
         ["root", mapStubs.get("properties")],
         [`root/${SAFE_PATH_PREFIX}entries`, mapStubs.get("11-entries")],
-        ["root/__proto__", true]
+        ["root/<prototype>", true]
       ])
     })));
 

--- a/packages/devtools-reps/src/object-inspector/tests/component/expand.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/expand.js
@@ -90,7 +90,7 @@ describe("ObjectInspector - state", () => {
 
     expect(store.getState().expandedPaths.has("root-1")).toBeTruthy();
     expect(store.getState().expandedPaths.has("root-2")).toBeTruthy();
-    expect(store.getState().expandedPaths.has("root-1/__proto__")).toBeTruthy();
+    expect(store.getState().expandedPaths.has("root-1/<prototype>")).toBeTruthy();
 
     // The property and symbols have primitive values, and can't be expanded.
     expect(store.getState().expandedPaths.size).toBe(3);
@@ -139,7 +139,8 @@ describe("ObjectInspector - state", () => {
     // Once all the loading promises are resolved, actors and loadedProperties
     // should have the expected values.
     expect(formatObjectInspector(wrapper)).toMatchSnapshot();
-    expect(store.getState().loadedProperties.has("root-1/__proto__")).toBeTruthy();
+
+    expect(store.getState().loadedProperties.has("root-1/<prototype>")).toBeTruthy();
     expect(store.getState().actors.has(protoStub.prototype.actor)).toBeTruthy();
   });
 
@@ -186,7 +187,7 @@ describe("ObjectInspector - state", () => {
     wrapper.update();
 
     expect(formatObjectInspector(wrapper)).toMatchSnapshot();
-    expect(store.getState().loadedProperties.has("root-2/__proto__")).toBeTruthy();
+    expect(store.getState().loadedProperties.has("root-2/<prototype>")).toBeTruthy();
     expect(store.getState().actors.has(protoStub.prototype.actor)).toBeTruthy();
   });
 

--- a/packages/devtools-reps/src/object-inspector/tests/test-utils.js
+++ b/packages/devtools-reps/src/object-inspector/tests/test-utils.js
@@ -19,7 +19,7 @@ const {WAIT_UNTIL_TYPE} = require("../../shared/redux/middleware/waitUntilServic
  *   |  |  ▼ 1 : Symbol(b) → "value-b"
  *   |  |  |    <key> : Symbol(b)
  *   |  |  |    <value> : "value-b"
- *   |  ▼ __proto__ : Object { … }
+ *   |  ▼ <prototype> : Object { … }
  *
  */
 function formatObjectInspector(wrapper: Object) {

--- a/packages/devtools-reps/src/object-inspector/tests/utils/get-children.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/get-children.js
@@ -104,7 +104,7 @@ describe("getChildren", () => {
       ["secureConnectionStart", 1500967716401],
       ["unloadEventEnd", 0],
       ["unloadEventStart", 0],
-      ["__proto__", stub.prototype]
+      ["<prototype>", stub.prototype]
     ];
     const childrenPaths = childrenEntries.map(([name]) => `rootpath/${name}`);
 

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -42,10 +42,10 @@ describe("makeNodesForProperties", () => {
     const nodes = makeNodesForProperties(objProperties, root);
 
     const names = nodes.map(n => n.name);
-    expect(names).toEqual(["0", "length", "__proto__"]);
+    expect(names).toEqual(["0", "length", "<prototype>"]);
 
     const paths = nodes.map(n => n.path);
-    expect(paths).toEqual(["root/0", "root/length", "root/__proto__"]);
+    expect(paths).toEqual(["root/0", "root/length", "root/<prototype>"]);
   });
 
   it("includes getters and setters", () => {
@@ -80,8 +80,8 @@ describe("makeNodesForProperties", () => {
     const names = nodes.map(n => n.name);
     const paths = nodes.map(n => n.path);
 
-    expect(names).toEqual(["bar", "baz", "foo", "__proto__"]);
-    expect(paths).toEqual(["root/bar", "root/baz", "root/foo", "root/__proto__"]);
+    expect(names).toEqual(["bar", "baz", "foo", "<prototype>"]);
+    expect(paths).toEqual(["root/bar", "root/baz", "root/foo", "root/<prototype>"]);
   });
 
   it("does not include unrelevant properties", () => {
@@ -123,14 +123,14 @@ describe("makeNodesForProperties", () => {
     const names = nodes.map(n => n.name);
     const paths = nodes.map(n => n.path);
 
-    expect(names).toEqual(["1", "2", "11", "_bar", "bar", "__proto__"]);
+    expect(names).toEqual(["1", "2", "11", "_bar", "bar", "<prototype>"]);
     expect(paths).toEqual([
       "root/1",
       "root/2",
       "root/11",
       "root/_bar",
       "root/bar",
-      "root/__proto__"
+      "root/<prototype>"
     ]);
   });
 
@@ -148,8 +148,8 @@ describe("makeNodesForProperties", () => {
     const names = nodes.map(n => n.name);
     const paths = nodes.map(n => n.path);
 
-    expect(names).toEqual(["bar", "__proto__"]);
-    expect(paths).toEqual(["root/bar", "root/__proto__"]);
+    expect(names).toEqual(["bar", "<prototype>"]);
+    expect(paths).toEqual(["root/bar", "root/<prototype>"]);
 
     expect(nodeIsPrototype(nodes[1])).toBe(true);
   });
@@ -172,7 +172,7 @@ describe("makeNodesForProperties", () => {
     const names = nodes.map(n => n.name);
     const paths = nodes.map(n => n.path);
 
-    expect(names).toEqual(["bar", "[default properties]"]);
+    expect(names).toEqual(["bar", "<default properties>"]);
     expect(paths).toEqual(["root/bar", "root/##-default"]);
 
     expect(nodeIsDefaultProperties(nodes[1])).toBe(true);
@@ -246,14 +246,14 @@ describe("makeNodesForProperties", () => {
       "332217",
       '"needs-quotes"',
       "unquoted",
-      "__proto__"
+      "<prototype>"
     ]);
     expect(paths).toEqual([
       "root/",
       "root/332217",
       "root/needs-quotes",
       "root/unquoted",
-      "root/__proto__"
+      "root/<prototype>"
     ]);
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
@@ -117,7 +117,7 @@ describe("shouldLoadItemIndexedProperties", () => {
     expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
   });
 
-  it("returns false for a [default properties] node", () => {
+  it("returns false for a <default properties> node", () => {
     const windowNode = createNode(null, "root", "/", {
       value: windowStubs.get("Window")
     });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
@@ -91,7 +91,7 @@ describe("shouldLoadItemNonIndexedProperties", () => {
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
-  it("returns false for a [default properties] node", () => {
+  it("returns false for a <default properties> node", () => {
     const windowNode = createNode(null, "root", "/", {
       value: windowStubs.get("Window")
     });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
@@ -91,7 +91,7 @@ describe("shouldLoadItemPrototype", () => {
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
-  it("returns false for a [default properties] node", () => {
+  it("returns false for a <default properties> node", () => {
     const windowNode = createNode(null, "root", "/", {
       value: windowStubs.get("Window")
     });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
@@ -91,7 +91,7 @@ describe("shouldLoadItemSymbols", () => {
     expect(shouldLoadItemSymbols(node)).toBeTruthy();
   });
 
-  it("returns false for a [default properties] node", () => {
+  it("returns false for a <default properties> node", () => {
     const windowNode = createNode(null, "root", "/", {
       value: windowStubs.get("Window")
     });

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -14,7 +14,7 @@ const MAX_NUMERICAL_PROPERTIES = 100;
 
 const NODE_TYPES = {
   BUCKET: Symbol("[n…n]"),
-  DEFAULT_PROPERTIES: Symbol("[default properties]"),
+  DEFAULT_PROPERTIES: Symbol("<default properties>"),
   ENTRIES: Symbol("<entries>"),
   GET: Symbol("<get>"),
   GRIP: Symbol("GRIP"),
@@ -26,7 +26,7 @@ const NODE_TYPES = {
   PROXY_HANDLER: Symbol("<handler>"),
   PROXY_TARGET: Symbol("<target>"),
   SET: Symbol("<set>"),
-  PROTOTYPE: Symbol("__proto__"),
+  PROTOTYPE: Symbol("<prototype>"),
   BLOCK: Symbol("☲"),
 };
 
@@ -484,7 +484,7 @@ function makeDefaultPropsBucket(
   if (defaultProperties.length > 0) {
     const defaultPropertiesNode = createNode(
       parent,
-      "[default properties]",
+      "<default properties>",
       `${parentPath}/${SAFE_PATH_PREFIX}default`,
       null,
       NODE_TYPES.DEFAULT_PROPERTIES
@@ -596,8 +596,8 @@ function makeNodeForPrototype(
   if (prototype && prototype.type !== "null") {
     return createNode(
       parent,
-      "__proto__",
-      `${parent.path}/__proto__`,
+      "<prototype>",
+      `${parent.path}/<prototype>`,
       { value: prototype },
       NODE_TYPES.PROTOTYPE
     );


### PR DESCRIPTION
`__proto__` is renamed to `<prototype>` and
`[default properties]` is renamed to `<default properties>` so
all our pseudo nodes share the same syntax, i.e. `<${name}>`.