### PR TITLE
Tweak ObjectInspector node block styling.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -24,12 +24,12 @@
 
 .tree.object-inspector .block .object-label,
 .tree.object-inspector .block .object-label * {
-  color: var(--grey-90, #0c0c0d);
-  font-weight: bold;
+  color: var(--theme-body-color);
 }
 
 .tree.object-inspector .block .object-label:before {
   content: "☲ ";
+  font-size: 1.1em;
 }
 
 .object-inspector .object-delimiter {


### PR DESCRIPTION
Changes suggested by @violasong 

Here's how it looks : 
![image](https://user-images.githubusercontent.com/578107/37088809-d33c219c-21fe-11e8-8e38-e090a3795675.png)
