### PR TITLE
Remove Object.assign calls in favor of the spread operator

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 7.7.2
+    version: 8.9.4
   environment:
     DOWNLOADS_PATH: "$HOME/downloads"
     YARN_PATH: "$HOME/.yarn"

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -267,9 +267,10 @@ class ObjectInspector extends Component {
       return {
         label: this.renderGrip(
           item,
-          Object.assign({}, this.props, {
+          {
+            ...this.props,
             functionName: label
-          })
+          }
         )
       };
     }
@@ -280,7 +281,7 @@ class ObjectInspector extends Component {
       || nodeIsMapEntry(item)
       || isPrimitive
     ) {
-      let repsProp = Object.assign({}, this.props);
+      let repsProp = {...this.props};
       if (depth > 0) {
         repsProp.mode = this.props.mode === MODE.LONG
           ? MODE.SHORT
@@ -416,11 +417,12 @@ class ObjectInspector extends Component {
     props: Props
   ) {
     const object = getValue(item);
-    return Rep(Object.assign({}, props, {
+    return Rep({
+      ...props,
       object,
       mode: props.mode || MODE.TINY,
       defaultRep: Grip,
-    }));
+    });
   }
 
   render() {

--- a/packages/devtools-reps/src/object-inspector/reducer.js
+++ b/packages/devtools-reps/src/object-inspector/reducer.js
@@ -17,7 +17,7 @@ function reducer(
     data,
   } = action;
 
-  const cloneState = overrides => Object.assign({}, state, overrides);
+  const cloneState = overrides => ({ ...state, ...overrides});
 
   if (type === "NODE_EXPAND") {
     return cloneState({
@@ -56,7 +56,7 @@ function mergeResponses(responses: Array<Object>) : Object {
 
   for (const response of responses) {
     if (response.hasOwnProperty("ownProperties")) {
-      data.ownProperties = Object.assign({}, data.ownProperties, response.ownProperties);
+      data.ownProperties = {...data.ownProperties, ...response.ownProperties};
     }
 
     if (response.ownSymbols && response.ownSymbols.length > 0) {

--- a/packages/devtools-reps/src/object-inspector/store.js
+++ b/packages/devtools-reps/src/object-inspector/store.js
@@ -14,12 +14,13 @@ import type {
 } from "./types";
 
 function createInitialState(overrides : Object) : State {
-  return Object.assign({
+  return {
     actors: new Set(),
     expandedPaths: new Set(),
     focusedItem: null,
     loadedProperties: new Map(),
-  }, overrides);
+    ...overrides,
+  };
 }
 
 module.exports = (props : Props) => {

--- a/packages/devtools-reps/src/object-inspector/tests/__mocks__/object-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/__mocks__/object-client.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 function ObjectClient(grip, overrides) {
-  return Object.assign({
+  return {
     grip,
     enumEntries: function () {
       return Promise.resolve({
@@ -38,8 +38,9 @@ function ObjectClient(grip, overrides) {
           return Promise.resolve(res);
         }
       };
-    }
-  }, overrides);
+    },
+    ...overrides,
+  };
 }
 
 module.exports = ObjectClient;

--- a/packages/devtools-reps/src/object-inspector/tests/component/basic.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/basic.js
@@ -18,10 +18,11 @@ const ObjectClient = require("../__mocks__/object-client");
 const gripRepStubs = require(`${repsPath}/stubs/grip`);
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
-    createObjectClient: grip => ObjectClient(grip)
-  }, overrides);
+    createObjectClient: grip => ObjectClient(grip),
+    ...overrides,
+  };
 }
 
 describe("ObjectInspector - renders", () => {
@@ -164,12 +165,12 @@ describe("ObjectInspector - renders", () => {
           "root",
           {
             ownProperties: Object.keys(stub.preview.ownProperties)
-              .reduce((res, key) =>
-                Object.assign({
-                  [key]: {
-                    value: stub
-                  },
-                }, res), {})
+              .reduce((res, key) => ({
+                [key]: {
+                  value: stub
+                },
+                ...res,
+              }), {})
           }
         ]])
     })));

--- a/packages/devtools-reps/src/object-inspector/tests/component/classnames.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/classnames.js
@@ -9,15 +9,16 @@ const ObjectInspector = createFactory(require("../../index"));
 const ObjectClient = require("../__mocks__/object-client");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
     roots: [{
       path: "root",
       name: "root",
       contents: {value: 42}
     }],
-    createObjectClient: grip => ObjectClient(grip)
-  }, overrides);
+    createObjectClient: grip => ObjectClient(grip),
+    ...overrides,
+  };
 }
 
 function mountObjectInspector(props) {

--- a/packages/devtools-reps/src/object-inspector/tests/component/entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/entries.js
@@ -16,10 +16,11 @@ const ObjectClient = require("../__mocks__/object-client");
 const { SAFE_PATH_PREFIX } = require("../../utils/node");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
-    createObjectClient: grip => ObjectClient(grip)
-  }, overrides);
+    createObjectClient: grip => ObjectClient(grip),
+    ...overrides
+  };
 }
 
 function getEnumEntriesMock() {

--- a/packages/devtools-reps/src/object-inspector/tests/component/events.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/events.js
@@ -13,10 +13,11 @@ const gripRepStubs = require("../../../reps/stubs/grip");
 const ObjectClient = require("../__mocks__/object-client");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
-    createObjectClient: grip => ObjectClient(grip)
-  }, overrides);
+    createObjectClient: grip => ObjectClient(grip),
+    ...overrides,
+  };
 }
 
 describe("ObjectInspector - properties", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/component/expand.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/expand.js
@@ -21,7 +21,7 @@ const {
 } = require("../../utils/node");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
     roots: [{
       path: "root-1",
@@ -36,7 +36,8 @@ function generateDefaults(overrides) {
     }],
     createObjectClient: grip => ObjectClient(grip),
     mode: MODE.LONG,
-  }, overrides);
+    ...overrides,
+  };
 }
 
 describe("ObjectInspector - state", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/component/function.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/function.js
@@ -12,10 +12,11 @@ const functionStubs = require("../../../reps/stubs/function");
 const ObjectClient = require("../__mocks__/object-client");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 1,
-    createObjectClient: grip => ObjectClient(grip)
-  }, overrides);
+    createObjectClient: grip => ObjectClient(grip),
+    ...overrides,
+  };
 }
 
 describe("ObjectInspector - functions", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
@@ -13,11 +13,12 @@ const accessorStubs = require("../../../reps/stubs/accessor");
 const ObjectClient = require("../__mocks__/object-client");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 1,
     createObjectClient: grip => ObjectClient(grip),
     mode: MODE.LONG,
-  }, overrides);
+    ...overrides,
+  };
 }
 
 describe("ObjectInspector - getters & setters", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/component/properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/properties.js
@@ -17,10 +17,11 @@ const {
 } = require("../test-utils");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
     createObjectClient: grip => ObjectClient(grip),
-  }, overrides);
+    ...overrides,
+  };
 }
 
 function getEnumPropertiesMock() {

--- a/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
@@ -14,7 +14,7 @@ const { formatObjectInspector } = require("../test-utils");
 
 const ObjectClient = require("../__mocks__/object-client");
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     roots: [{
       path: "root",
       contents: {value: stub}
@@ -26,8 +26,9 @@ function generateDefaults(overrides) {
     // enumProperties for the root's properties.
     loadedProperties: new Map([
       ["root", {prototype: {}}]
-    ])
-  }, overrides);
+    ]),
+    ...overrides,
+  };
 }
 
 function getEnumPropertiesMock() {

--- a/packages/devtools-reps/src/object-inspector/tests/component/release-actors.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/release-actors.js
@@ -14,7 +14,7 @@ const ObjectClient = require("../__mocks__/object-client");
 const stub = gripRepStubs.get("testMoreThanMaxProps");
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
     roots: [{
       path: "root",
@@ -22,8 +22,9 @@ function generateDefaults(overrides) {
         value: stub
       }
     }],
-    createObjectClient: grip => ObjectClient(grip)
-  }, overrides);
+    createObjectClient: grip => ObjectClient(grip),
+    ...overrides,
+  };
 }
 
 describe("release actors", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/component/window.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/window.js
@@ -20,11 +20,12 @@ const windowNode = createNode(
 );
 
 function generateDefaults(overrides) {
-  return Object.assign({
+  return {
     autoExpandDepth: 0,
     roots: [windowNode],
-    createObjectClient: grip => ObjectClient(grip)
-  }, overrides);
+    createObjectClient: grip => ObjectClient(grip),
+    ...overrides,
+  };
 }
 
 describe("ObjectInspector - dimTopLevelWindow", () => {

--- a/packages/devtools-reps/src/object-inspector/tests/utils/get-closest-grip-node.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/get-closest-grip-node.js
@@ -46,7 +46,7 @@ describe("getClosestGripNode", () => {
     const root = createNode(null, "root", "/", {value: grip});
     let [bucket] = makeNumericalBuckets(root);
     for (let i = 0; i < 10; i++) {
-      bucket = (makeNumericalBuckets(Object.assign({}, bucket)))[0];
+      bucket = (makeNumericalBuckets({...bucket}))[0];
     }
     expect(getClosestGripNode(bucket)).toBe(root);
   });

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -535,7 +535,7 @@ function makeNodesForProperties(
   const parentPath = parent.path;
   const parentValue = getValue(parent);
 
-  let allProperties = Object.assign({}, ownProperties, safeGetterValues);
+  let allProperties = {...ownProperties, ...safeGetterValues};
 
   // Ignore properties that are neither non-concrete nor getters/setters.
   const propertiesNames = sortProperties(Object.keys(allProperties)).filter(name => {

--- a/packages/devtools-reps/src/reps/array.js
+++ b/packages/devtools-reps/src/reps/array.js
@@ -78,13 +78,17 @@ function arrayIterator(props, array, max) {
     let item;
 
     try {
-      item = ItemRep(Object.assign({}, props, config, {
+      item = ItemRep({
+        ...props,
+        ...config,
         object: array[i],
-      }));
+      });
     } catch (exc) {
-      item = ItemRep(Object.assign({}, props, config, {
+      item = ItemRep({
+        ...props,
+        ...config,
         object: exc,
-      }));
+      });
     }
     items.push(item);
   }
@@ -118,10 +122,11 @@ function ItemRep(props) {
   } = props;
   return (
     span({},
-      Rep(Object.assign({}, props, {
+      Rep({
+        ...props,
         object: object,
         mode: mode
-      })),
+      }),
       delim
     )
   );

--- a/packages/devtools-reps/src/reps/event.js
+++ b/packages/devtools-reps/src/reps/event.js
@@ -27,16 +27,18 @@ Event.propTypes = {
 };
 
 function Event(props) {
-  // Use `Object.assign` to keep `props` without changes because:
-  // 1. JSON.stringify/JSON.parse is slow.
-  // 2. Immutable.js is planned for the future.
-  let gripProps = Object.assign({}, props, {
-    title: getTitle(props)
-  });
-  gripProps.object = Object.assign({}, props.object);
-  gripProps.object.preview = Object.assign({}, props.object.preview);
+  let gripProps = {
+    ...props,
+    title: getTitle(props),
+    object: {
+      ...props.object,
+      preview: {
+        ...props.object.preview,
+        ownProperties: {},
+      },
+    }
+  };
 
-  gripProps.object.preview.ownProperties = {};
   if (gripProps.object.preview.target) {
     Object.assign(gripProps.object.preview.ownProperties, {
       target: gripProps.object.preview.target

--- a/packages/devtools-reps/src/reps/grip-array.js
+++ b/packages/devtools-reps/src/reps/grip-array.js
@@ -203,12 +203,13 @@ function arrayIterator(props, grip, max) {
     }
 
     if (res.length < max) {
-      res.push(Rep(Object.assign({}, props, {
+      res.push(Rep({
+        ...props,
         object,
         mode: MODE.TINY,
         // Do not propagate title to array items reps
         title: undefined,
-      })));
+      }));
     }
 
     return res;

--- a/packages/devtools-reps/src/reps/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/grip-map-entry.js
@@ -36,13 +36,14 @@ function GripMapEntry(props) {
 
   return span({
     className: "objectBox objectBox-map-entry"
-  }, PropRep(Object.assign({}, props, {
+  }, PropRep({
+    ...props,
     name: key,
     object: value,
     equal: " \u2192 ",
     title: null,
     suppressQuotes: false,
-  })));
+  }));
 }
 
 function supportsObject(grip, noGrip = false) {

--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -179,7 +179,8 @@ function propIterator(props, object, max) {
     const length = max - indexes.length;
 
     const symbolsProps = ownSymbols.slice(0, length).map(symbolItem => {
-      return PropRep(Object.assign({}, props, {
+      return PropRep({
+        ...props,
         mode: MODE.TINY,
         name: symbolItem,
         object: symbolItem.descriptor.value,
@@ -187,7 +188,7 @@ function propIterator(props, object, max) {
         defaultRep: Grip,
         title: null,
         suppressQuotes,
-      }));
+      });
     });
 
     propsArray.push(...symbolsProps);
@@ -232,7 +233,8 @@ function getProps(componentProps, properties, indexes, suppressQuotes) {
     let name = propertiesKeys[i];
     let value = getPropValue(properties[name]);
 
-    return PropRep(Object.assign({}, componentProps, {
+    return PropRep({
+      ...componentProps,
       mode: MODE.TINY,
       name,
       object: value,
@@ -240,7 +242,7 @@ function getProps(componentProps, properties, indexes, suppressQuotes) {
       defaultRep: Grip,
       title: null,
       suppressQuotes,
-    }));
+    });
   });
 }
 

--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -153,7 +153,7 @@ function propIterator(props, object, max) {
   let propertiesLength = getPropertiesLength(object);
 
   if (object.preview && object.preview.safeGetterValues) {
-    properties = Object.assign({}, properties, object.preview.safeGetterValues);
+    properties = {...properties, ...object.preview.safeGetterValues};
   }
 
   let indexes = getPropIndexes(properties, max, isInterestingProp);

--- a/packages/devtools-reps/src/reps/object.js
+++ b/packages/devtools-reps/src/reps/object.js
@@ -96,13 +96,14 @@ function propIterator(props, object, max) {
   const propertiesNames = Object.keys(object);
 
   const pushPropRep = (name, value) => {
-    elements.push(PropRep(Object.assign({}, props, {
+    elements.push(PropRep({
+      ...props,
       key: name,
       mode: MODE.TINY,
       name,
       object: value,
       equal: ": ",
-    })));
+    }));
     propertiesNumber++;
 
     if (propertiesNumber < propertiesNames.length) {

--- a/packages/devtools-reps/src/reps/promise.js
+++ b/packages/devtools-reps/src/reps/promise.js
@@ -84,13 +84,14 @@ function getProps(props, promiseState) {
 
   return keys.reduce((res, key, i) => {
     let object = promiseState[key];
-    res = res.concat(PropRep(Object.assign({}, props, {
+    res = res.concat(PropRep({
+      ...props,
       mode: MODE.TINY,
       name: `<${key}>`,
       object,
       equal: ": ",
       suppressQuotes: true,
-    })));
+    }));
 
     // Interleave commas between elements
     if (i !== keys.length - 1) {

--- a/packages/devtools-reps/src/reps/prop-rep.js
+++ b/packages/devtools-reps/src/reps/prop-rep.js
@@ -63,12 +63,13 @@ function PropRep(props) {
     }
     key = span({"className": "nodeName"}, name);
   } else {
-    key = Rep(Object.assign({}, props, {
+    key = Rep({
+      ...props,
       className: "nodeName",
       object: name,
       mode: mode || MODE.TINY,
       defaultRep: Grip,
-    }));
+    });
   }
 
   return [
@@ -76,7 +77,7 @@ function PropRep(props) {
     span({
       "className": "objectEqual"
     }, equal),
-    Rep(Object.assign({}, props)),
+    Rep({...props}),
   ];
 }
 

--- a/packages/devtools-reps/src/reps/stubs/grip.js
+++ b/packages/devtools-reps/src/reps/stubs/grip.js
@@ -71,7 +71,8 @@ stubs.set("testMoreThanMaxProps", {
   "preview": {
     "kind": "Object",
     "ownProperties": Array.from({length: longModeMaxLength})
-      .reduce((res, item, index) => Object.assign(res, {
+      .reduce((res, item, index) => ({
+        ...res,
         ["p" + index]: {
           "configurable": true,
           "enumerable": true,

--- a/packages/devtools-reps/src/reps/stubs/grip.js
+++ b/packages/devtools-reps/src/reps/stubs/grip.js
@@ -1004,4 +1004,43 @@ stubs.set("DeadObject", {
   "sealed": false
 });
 
+// Packet for :
+// var obj = Object.create(null); obj.__proto__ = []; obj;
+stubs.set("ObjectWith__proto__Property", {
+  "type": "object",
+  "actor": "server1.conn1.child1/obj31",
+  "class": "Object",
+  "extensible": true,
+  "frozen": false,
+  "sealed": false,
+  "ownPropertyLength": 1,
+  "preview": {
+    "kind": "Object",
+    "ownProperties": {
+      ["__proto__"]: {
+        "configurable": true,
+        "enumerable": true,
+        "writable": true,
+        "value": {
+          "type": "object",
+          "actor": "server1.conn1.child1/obj32",
+          "class": "Array",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 1,
+          "preview": {
+            "kind": "ArrayLike",
+            "length": 0
+          }
+        }
+      }
+    },
+    "ownSymbols": [],
+    "ownPropertiesLength": 1,
+    "ownSymbolsLength": 0,
+    "safeGetterValues": {}
+  }
+});
+
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/tests/array.js
+++ b/packages/devtools-reps/src/reps/tests/array.js
@@ -21,7 +21,7 @@ describe("Array", () => {
 
   it("renders empty array as expected", () => {
     const object = [];
-    const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
+    const renderRep = props => shallow(Rep({ object, ...props }));
 
     const defaultOutput = "[]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
@@ -32,7 +32,7 @@ describe("Array", () => {
 
   it("renders basic array as expected", () => {
     const object = [1, "foo", {}];
-    const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
+    const renderRep = props => shallow(Rep({ object, ...props }));
 
     const defaultOutput = `[ 1, "foo", {} ]`;
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
@@ -43,7 +43,7 @@ describe("Array", () => {
 
   it("renders array with more than SHORT mode maximum props as expected", () => {
     const object = Array(maxLengthMap.get(MODE.SHORT) + 1).fill("foo");
-    const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
+    const renderRep = props => shallow(Rep({ object, ...props }));
 
     const defaultShortOutput =
       `[ ${Array(maxLengthMap.get(MODE.SHORT)).fill("\"foo\"").join(", ")}, … ]`;
@@ -57,7 +57,7 @@ describe("Array", () => {
 
   it("renders array with more than LONG mode maximum props as expected", () => {
     const object = Array(maxLengthMap.get(MODE.LONG) + 1).fill("foo");
-    const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
+    const renderRep = props => shallow(Rep({ object, ...props }));
 
     const defaultShortOutput =
       `[ ${Array(maxLengthMap.get(MODE.SHORT)).fill("\"foo\"").join(", ")}, … ]`;
@@ -71,7 +71,7 @@ describe("Array", () => {
   it("renders recursive array as expected", () => {
     const object = [1];
     object.push(object);
-    const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
+    const renderRep = props => shallow(Rep({ object, ...props }));
 
     const defaultOutput = "[ 1, […] ]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
@@ -87,7 +87,7 @@ describe("Array", () => {
       p3: "s3",
       p4: "s4"
     }];
-    const renderRep = props => shallow(Rep(Object.assign({ object }, props)));
+    const renderRep = props => shallow(Rep({ object, ...props }));
 
     const defaultOutput = "[ {…} ]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);

--- a/packages/devtools-reps/src/reps/tests/comment-node.js
+++ b/packages/devtools-reps/src/reps/tests/comment-node.js
@@ -34,7 +34,7 @@ describe("CommentNode", () => {
 
   it("renders as expected", () => {
     const object = stubs.get("Comment");
-    const renderRep = props => shallow(CommentNode.rep(Object.assign({object}, props)));
+    const renderRep = props => shallow(CommentNode.rep({object, ...props}));
 
     let component = renderRep({mode: undefined});
     expect(component.text())

--- a/packages/devtools-reps/src/reps/tests/event.js
+++ b/packages/devtools-reps/src/reps/tests/event.js
@@ -40,7 +40,7 @@ describe("Event - keyboard event", () => {
   });
 
   it("renders with expected text", () => {
-    const renderRep = props => shallow(Event.rep(Object.assign({object}, props)));
+    const renderRep = props => shallow(Event.rep({object, ...props}));
     expect(renderRep().text()).toEqual(
       "keyup { target: body, key: \"Control\", charCode: 0, … }");
     expect(renderRep({mode: MODE.LONG}).text()).toEqual(
@@ -56,7 +56,7 @@ describe("Event - keyboard event with modifiers", () => {
   });
 
   it("renders with expected text", () => {
-    const renderRep = props => shallow(Event.rep(Object.assign({object}, props)));
+    const renderRep = props => shallow(Event.rep({object, ...props}));
     expect(renderRep({mode: MODE.LONG}).text()).toEqual(
       "keyup Meta-Shift { target: body, key: \"M\", charCode: 0, keyCode: 77 }");
   });
@@ -70,7 +70,7 @@ describe("Event - message event", () => {
   });
 
   it("renders with expected text", () => {
-    const renderRep = props => shallow(Event.rep(Object.assign({object}, props)));
+    const renderRep = props => shallow(Event.rep({object, ...props}));
     expect(renderRep().text()).toEqual(
       "message { target: Window, isTrusted: false, data: \"test data\", … }");
     expect(renderRep({mode: MODE.LONG}).text()).toEqual(
@@ -82,7 +82,7 @@ describe("Event - message event", () => {
 
 describe("Event - mouse event", () => {
   const object = stubs.get("testMouseEvent");
-  const renderRep = props => shallow(Event.rep(Object.assign({object}, props)));
+  const renderRep = props => shallow(Event.rep({object, ...props}));
 
   const grips = getSelectableInInspectorGrips(object);
   expect(grips.length).toBe(1, "the stub has one node grip");

--- a/packages/devtools-reps/src/reps/tests/function.js
+++ b/packages/devtools-reps/src/reps/tests/function.js
@@ -13,7 +13,7 @@ const {
   expectActorAttribute
 } = require("./test-helpers");
 const renderRep = (object, props) => {
-  return shallow(Func.rep(Object.assign({object}, props)));
+  return shallow(Func.rep({object, ...props}));
 };
 
 describe("Function - Named", () => {
@@ -264,8 +264,11 @@ describe("Function - Jump to definition", () => {
   });
 
   it("does not render an icon when the object has no location", () => {
-    const object = Object.assign({}, stubs.get("getRandom"));
-    delete object.location;
+    const object = {
+      ...stubs.get("getRandom"),
+      location: null,
+    };
+
     const renderedComponent = renderRep(object, {
       onViewSourceInDebugger: () => {}
     });
@@ -275,7 +278,9 @@ describe("Function - Jump to definition", () => {
   });
 
   it("does not render an icon when the object has no url location", () => {
-    const object = Object.assign({}, stubs.get("getRandom"));
+    const object = {
+      ...stubs.get("getRandom"),
+    };
     object.location.url = null;
     const renderedComponent = renderRep(object, {
       onViewSourceInDebugger: () => {}
@@ -286,7 +291,7 @@ describe("Function - Jump to definition", () => {
   });
 
   it("does not render an icon when function was declared in console input", () => {
-    const object = Object.assign({}, stubs.get("EvaledInDebuggerFunction"));
+    const object = stubs.get("EvaledInDebuggerFunction");
     const renderedComponent = renderRep(object, {
       onViewSourceInDebugger: () => {}
     });

--- a/packages/devtools-reps/src/reps/tests/grip-array.js
+++ b/packages/devtools-reps/src/reps/tests/grip-array.js
@@ -18,9 +18,10 @@ const {
 const { maxLengthMap } = GripArray;
 
 function shallowRenderRep(object, props = {}) {
-  return shallow(GripArray.rep(Object.assign({
+  return shallow(GripArray.rep({
     object,
-  }, props)));
+    ...props,
+  }));
 }
 
 describe("GripArray - basic", () => {

--- a/packages/devtools-reps/src/reps/tests/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map-entry.js
@@ -20,10 +20,11 @@ const nodeStubs = require("../stubs/element-node");
 const gripArrayStubs = require("../stubs/grip-array");
 
 const renderRep = (object, mode, props) => {
-  return shallow(GripMapEntry.rep(Object.assign({
-      object,
-      mode,
-  }, props)));
+  return shallow(GripMapEntry.rep({
+    object,
+    mode,
+    ...props,
+  }));
 };
 
 describe("GripMapEntry - simple", () => {

--- a/packages/devtools-reps/src/reps/tests/grip-map.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map.js
@@ -19,9 +19,10 @@ const {
 const {maxLengthMap} = GripMap;
 
 function shallowRenderRep(object, props = {}) {
-  return shallow(GripMap.rep(Object.assign({
+  return shallow(GripMap.rep({
     object,
-  }, props)));
+    ...props,
+  }));
 }
 
 describe("GripMap - empty map", () => {

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -7,6 +7,7 @@
 const { shallow } = require("enzyme");
 const {
   getRep,
+  Rep,
 } = require("../rep");
 const Grip = require("../grip");
 const { MODE } = require("../constants");
@@ -21,9 +22,10 @@ const {
 const {maxLengthMap} = Grip;
 
 function shallowRenderRep(object, props = {}) {
-  return shallow(Grip.rep(Object.assign({
+  return shallow(Grip.rep({
     object,
-  }, props)));
+    ...props
+  }));
 }
 
 describe("Grip - empty object", () => {
@@ -599,6 +601,24 @@ describe("Grip - DeadObject object", () => {
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("DeadObject");
+    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+  });
+});
+
+describe("Grip - Object with __proto__ property", () => {
+  const object = stubs.get("ObjectWith__proto__Property");
+
+  it("correctly selects Grip Rep", () => {
+    expect(getRep(object)).toBe(Grip.rep);
+  });
+
+  it("renders as expected", () => {
+    const renderRep = (props) => shallow(Rep({object, ...props}));
+    const defaultOutput = "Object { __proto__: [] }";
+
+    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });

--- a/packages/devtools-reps/src/reps/tests/object.js
+++ b/packages/devtools-reps/src/reps/tests/object.js
@@ -11,7 +11,7 @@ const { Obj } = REPS;
 const { MODE } = require("../constants");
 
 const renderComponent = (object, props) => {
-  return shallow(Obj.rep(Object.assign({ object }, props)));
+  return shallow(Obj.rep({ object, ...props}));
 };
 
 describe("Object - Basic", () => {

--- a/packages/devtools-reps/src/reps/tests/promise.js
+++ b/packages/devtools-reps/src/reps/tests/promise.js
@@ -18,7 +18,7 @@ const {
 } = require("./test-helpers");
 
 const renderRep = (object, props) => {
-  return shallow(PromiseRep.rep(Object.assign({object}, props)));
+  return shallow(PromiseRep.rep({object, ...props}));
 };
 
 describe("Promise - Pending", () => {

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -9,10 +9,11 @@ const { Rep } = REPS;
 const { getGripLengthBubbleText } = require("./test-helpers");
 
 const renderRep = (string, props) => mount(
-  Rep(Object.assign({
+  Rep({
     object: string,
     omitLinkHref: false,
-  }, props))
+    ...props,
+  })
 );
 
 describe("test String with URL", () => {

--- a/packages/devtools-reps/src/reps/tests/test-helpers.js
+++ b/packages/devtools-reps/src/reps/tests/test-helpers.js
@@ -70,11 +70,12 @@ function expectActorAttribute(wrapper, expectedValue) {
 }
 
 function getGripLengthBubbleText(object, props) {
-  const component = lengthBubble(Object.assign({
+  const component = lengthBubble({
     object,
     maxLengthMap: arrayLikeMaxLengthMap,
-    getLength: getArrayLikeLength
-  }, props));
+    getLength: getArrayLikeLength,
+    ...props,
+  });
 
   return component
     ? shallow(component).text()
@@ -82,11 +83,12 @@ function getGripLengthBubbleText(object, props) {
 }
 
 function getMapLengthBubbleText(object, props) {
-  return getGripLengthBubbleText(object, Object.assign({
+  return getGripLengthBubbleText(object, {
     maxLengthMap: mapMaxLengths,
     getLength: getMapLength,
-    showZeroLength: true
-  }, props));
+    showZeroLength: true,
+    ...props,
+  });
 }
 
 module.exports = {

--- a/packages/devtools-reps/src/reps/tests/text-node.js
+++ b/packages/devtools-reps/src/reps/tests/text-node.js
@@ -28,7 +28,7 @@ describe("TextNode", () => {
 
   it("renders as expected", () => {
     const object = stubs.get("testRendering");
-    const renderRep = props => shallow(TextNode.rep(Object.assign({object}, props)));
+    const renderRep = props => shallow(TextNode.rep({object, ...props}));
 
     const defaultOutput = `#text "hello world"`;
 
@@ -51,7 +51,7 @@ describe("TextNode", () => {
 
   it("renders as expected with EOL", () => {
     const object = stubs.get("testRenderingWithEOL");
-    const renderRep = props => shallow(TextNode.rep(Object.assign({object}, props)));
+    const renderRep = props => shallow(TextNode.rep({object, ...props}));
 
     const defaultOutput = `#text "hello\nworld"`;
     expect(renderRep({mode: undefined}).text()).toBe(defaultOutput);

--- a/packages/devtools-reps/src/reps/tests/window.js
+++ b/packages/devtools-reps/src/reps/tests/window.js
@@ -68,7 +68,10 @@ describe("test Window", () => {
 
   it("renders with expected text in TINY mode with Custom display class", () => {
     const renderedComponent = shallow(Rep({
-      object: Object.assign({}, stub, { displayClass: "Custom" }),
+      object: {
+        ...stub,
+        displayClass: "Custom"
+      },
       mode: MODE.TINY
     }));
 
@@ -77,7 +80,10 @@ describe("test Window", () => {
 
   it("renders with expected text in LONG mode with Custom display class", () => {
     const renderedComponent = shallow(Rep({
-      object: Object.assign({}, stub, { displayClass: "Custom" }),
+      object: {
+        ...stub,
+        displayClass: "Custom"
+      },
       mode: MODE.LONG,
       title: "Custom"
     }));

--- a/packages/devtools-reps/src/shared/images/Svg.js
+++ b/packages/devtools-reps/src/shared/images/Svg.js
@@ -26,8 +26,11 @@ function Svg(name, props) {
   if (name === "subSettings") {
     className = "";
   }
-  props = Object.assign({}, props, { className, src: svg[name] });
-  return React.createElement(InlineSVG, props);
+  return React.createElement(InlineSVG, {
+    ...props,
+    className,
+    src: svg[name]
+  });
 }
 
 module.exports = Svg;


### PR DESCRIPTION
As found by @Loirooriol , this fix an issue with objects containing a `__proto__` property (`Object.assign` calls setters and strips the __proto__ property).

Took this as an opportunity to remove `Object.assign` calls where it could be done.

Fixes #986.