### PR TITLE
Remove omitLinkHref prop and never populate the href attribute

### DIFF
--- a/packages/devtools-reps/src/reps/rep-utils.js
+++ b/packages/devtools-reps/src/reps/rep-utils.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Dependencies
-const validProtocols = /^(http|https|ftp|data|javascript|resource|chrome):/i;
+const validProtocols = /^(http|https|ftp|data|resource|chrome):/i;
 const tokenSplitRegex = /(\s|\'|\"|\\)+/;
 const ELLIPSIS = "\u2026";
 const dom = require("react-dom-factories");

--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -33,7 +33,6 @@ StringRep.propTypes = {
   object: PropTypes.object.isRequired,
   openLink: PropTypes.func,
   className: PropTypes.string,
-  omitLinkHref: PropTypes.bool,
 };
 
 function StringRep(props) {
@@ -46,7 +45,6 @@ function StringRep(props) {
     escapeWhitespace = true,
     member,
     openLink,
-    omitLinkHref = true,
   } = props;
 
   let text = object;
@@ -75,7 +73,7 @@ function StringRep(props) {
   if (!isLong) {
     if (containsURL(text)) {
       return span(config,
-        ...getLinkifiedElements(text, shouldCrop && cropLimit, omitLinkHref, openLink));
+        ...getLinkifiedElements(text, shouldCrop && cropLimit, openLink));
     }
 
     // Cropping of longString has been handled before formatting.
@@ -166,11 +164,10 @@ function maybeCropString(opts, text) {
  *
  * @param {String} text: The actual string to linkify.
  * @param {Integer | null} cropLimit
- * @param {Boolean} omitLinkHref: Do not create an href attribute if true.
  * @param {Function} openLink: Function handling the link opening.
  * @returns {Array<String|ReactElement>}
  */
-function getLinkifiedElements(text, cropLimit, omitLinkHref, openLink) {
+function getLinkifiedElements(text, cropLimit, openLink) {
   const halfLimit = Math.ceil((cropLimit - ELLIPSIS.length) / 2);
   const startCropIndex = cropLimit ? halfLimit : null;
   const endCropIndex = cropLimit ? text.length - halfLimit : null;
@@ -198,9 +195,6 @@ function getLinkifiedElements(text, cropLimit, omitLinkHref, openLink) {
         items.push(a({
           className: "url",
           title: token,
-          href: omitLinkHref === true
-            ? null
-            : token,
           draggable: false,
           onClick: openLink
             ? e => {

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -11,7 +11,6 @@ const { getGripLengthBubbleText } = require("./test-helpers");
 const renderRep = (string, props) => mount(
   Rep({
     object: string,
-    omitLinkHref: false,
     ...props,
   })
 );
@@ -23,7 +22,7 @@ describe("test String with URL", () => {
     const element = renderRep(url, {openLink, useQuotes: false});
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -50,7 +49,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, {openLink, useQuotes: false});
     expect(element.text()).toEqual(string);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -64,7 +63,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, {openLink, useQuotes: false});
     expect(element.text()).toEqual(string);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -78,7 +77,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, {openLink, useQuotes: true});
     expect(element.text()).toEqual(`"\\"${url}\\""`);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -91,7 +90,7 @@ describe("test String with URL", () => {
     const element = renderRep(url, {openLink, useQuotes: false});
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -104,7 +103,7 @@ describe("test String with URL", () => {
     const element = renderRep(url, {openLink, useQuotes: false});
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -117,7 +116,7 @@ describe("test String with URL", () => {
     const element = renderRep(url, {openLink, useQuotes: false});
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -131,7 +130,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, {openLink, useQuotes: false});
     expect(element.text()).toEqual(string);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -146,7 +145,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(string);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -164,13 +163,13 @@ describe("test String with URL", () => {
     expect(links.length).toBe(2);
 
     const firstLink = links.at(0);
-    expect(firstLink.prop("href")).toBe(url1);
+    expect(firstLink.prop("href")).toBe(undefined);
     expect(firstLink.prop("title")).toBe(url1);
     firstLink.simulate("click");
     expect(openLink).toBeCalledWith(url1);
 
     const secondLink = links.at(1);
-    expect(secondLink.prop("href")).toBe(url2);
+    expect(secondLink.prop("href")).toBe(undefined);
     expect(secondLink.prop("title")).toBe(url2);
     secondLink.simulate("click");
     expect(openLink).toBeCalledWith(url2);
@@ -197,7 +196,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("http://…ple.com");
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -215,7 +214,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -235,7 +234,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -253,11 +252,11 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://example.fr … http://example.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe("http://example.fr");
+    expect(linkFr.prop("href")).toBe(undefined);
     expect(linkFr.prop("title")).toBe("http://example.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe("http://example.us");
+    expect(linkUs.prop("href")).toBe(undefined);
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -272,11 +271,11 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://example.fr -…- http://example.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe("http://example.fr");
+    expect(linkFr.prop("href")).toBe(undefined);
     expect(linkFr.prop("title")).toBe("http://example.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe("http://example.us");
+    expect(linkUs.prop("href")).toBe(undefined);
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -291,11 +290,11 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://e…ample.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe("http://example-long.fr");
+    expect(linkFr.prop("href")).toBe(undefined);
     expect(linkFr.prop("title")).toBe("http://example-long.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe("http://example.us");
+    expect(linkUs.prop("href")).toBe(undefined);
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -310,15 +309,15 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://example-long.fr http:…xample.com http://example.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe("http://example-long.fr");
+    expect(linkFr.prop("href")).toBe(undefined);
     expect(linkFr.prop("title")).toBe("http://example-long.fr");
 
     const linkCom = element.find("a").at(1);
-    expect(linkCom.prop("href")).toBe("http://example.com");
+    expect(linkCom.prop("href")).toBe(undefined);
     expect(linkCom.prop("title")).toBe("http://example.com");
 
     const linkUs = element.find("a").at(2);
-    expect(linkUs.prop("href")).toBe("http://example.us");
+    expect(linkUs.prop("href")).toBe(undefined);
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -333,11 +332,11 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://e…ample.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe("http://example.fr");
+    expect(linkFr.prop("href")).toBe(undefined);
     expect(linkFr.prop("title")).toBe("http://example.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe("http://example.us");
+    expect(linkUs.prop("href")).toBe(undefined);
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -352,7 +351,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("http://exa…cdefghijkl");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe("http://example.fr");
+    expect(linkFr.prop("href")).toBe(undefined);
     expect(linkFr.prop("title")).toBe("http://example.fr");
   });
 
@@ -367,7 +366,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("abcdefghij…xample.fr ");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe("http://example.fr");
+    expect(linkFr.prop("href")).toBe(undefined);
     expect(linkFr.prop("title")).toBe("http://example.fr");
   });
 
@@ -394,7 +393,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`[ "${string}" ]`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -413,7 +412,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`Array${length} [ "${string}" ]`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -429,7 +428,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`Object { test: "${string}" }`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
@@ -447,26 +446,10 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`Object { test: "${string}" }`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(url);
+    expect(link.prop("href")).toBe(undefined);
     expect(link.prop("title")).toBe(url);
 
     link.simulate("click");
     expect(openLink).toBeCalledWith(url);
-  });
-
-  it("does not create an href attribute if omitLinkHref is true", () => {
-    const url = "http://example.com";
-    const element = renderRep(url, {omitLinkHref: true, useQuotes: false});
-    expect(element.text()).toEqual(url);
-    const link = element.find("a");
-    expect(link.prop("href")).toBe(null);
-  });
-
-  it("does not create an href attribute if omitLinkHref is undefined", () => {
-    const url = "http://example.com";
-    const element = mount(Rep({ object: url, useQuotes: false }));
-    expect(element.text()).toEqual(url);
-    const link = element.find("a");
-    expect(link.prop("href")).toBe(null);
   });
 });

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -452,4 +452,15 @@ describe("test String with URL", () => {
     link.simulate("click");
     expect(openLink).toBeCalledWith(url);
   });
+
+  it("does not render links for js URL", () => {
+    const url = "javascript:x=42";
+    const string = `${url} some other text`;
+
+    const openLink = jest.fn();
+    const element = renderRep(string, {openLink, useQuotes: false});
+    expect(element.text()).toEqual(string);
+    const link = element.find("a");
+    expect(link.exists()).toBe(false);
+  });
 });


### PR DESCRIPTION
- Only rely on openLink prop function
- Do not linkify `javascript:` urls