### PR TITLE
WIP - Update source-map to 0.7.2 (#5598)

### DIFF
--- a/packages/devtools-source-map/jest-setup.js
+++ b/packages/devtools-source-map/jest-setup.js
@@ -1,5 +1,6 @@
 // TODO: Remove this file after upgrading to Jest 22.4.1+
 // More info: https://github.com/facebook/jest/issues/687
+// and https://github.com/devtools-html/devtools-core/pull/995#discussion_r174317667
 console.debug = console.log
 
 

--- a/packages/devtools-source-map/jest-setup.js
+++ b/packages/devtools-source-map/jest-setup.js
@@ -1,0 +1,5 @@
+// TODO: Remove this file after upgrading to Jest 22.4.1+
+// More info: https://github.com/facebook/jest/issues/687
+console.debug = console.log
+
+

--- a/packages/devtools-source-map/package.json
+++ b/packages/devtools-source-map/package.json
@@ -21,7 +21,7 @@
     "jest": "^19.0.2",
     "md5": "^2.2.1",
     "regenerator-runtime": "^0.10.3",
-    "source-map": "^0.6.1"
+    "source-map": "^0.7.2"
   },
   "devDependencies": {
     "devtools-launchpad": "^0.0.116"
@@ -35,7 +35,7 @@
       "<rootDir>/tests/helpers.js"
     ],
     "transformIgnorePatterns": [],
-    "setupFiles": [],
+    "setupFiles": ["../jest-setup.js"],
     "moduleNameMapper": {}
   }
 }

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -11,6 +11,9 @@
 
 const { networkRequest } = require("devtools-utils");
 const { SourceMapConsumer, SourceMapGenerator } = require("source-map");
+SourceMapConsumer.initialize({
+  "lib/mappings.wasm": "https://unpkg.com/source-map@0.7.2/lib/mappings.wasm"
+})
 
 const assert = require("./utils/assert");
 const { fetchSourceMap } = require("./utils/fetchSourceMap");

--- a/packages/devtools-source-map/src/tests/locations.js
+++ b/packages/devtools-source-map/src/tests/locations.js
@@ -81,13 +81,13 @@ describe("getGeneratedLocation", async () => {
     // we expect symmetric mappings, which means that if
     // we map a generated location to an original location,
     // and then map it back, we should get the original generated value.
-    // e.g. G[8, 0] -> O[5, 4] -> G[8, 0]
+    // e.g. G[8, 114] -> O[5, 4] -> G[8, 114]
 
     await setupBundleFixture("if.out");
 
     const genLoc1 = {
       sourceId: "if.out.js",
-      column: 0,
+      column: 114,
       line: 8
     };
 
@@ -101,14 +101,14 @@ describe("getGeneratedLocation", async () => {
 
     expect(genLoc2).toEqual({
       sourceId: "if.out.js",
-      column: 0,
+      column: 114,
       line: 8
     });
   });
 
   test("undefined column is handled like 0 column", async () => {
     // we expect that an undefined column will be handled like a
-    // location w/ column 0. e.g. G[8, u] -> O[5, 4] -> G[8, 0]
+    // location w/ column 0. e.g. G[8, u] -> O[5, 4]
 
     await setupBundleFixture("if.out");
 
@@ -124,13 +124,11 @@ describe("getGeneratedLocation", async () => {
     };
 
     const oLoc = await getOriginalLocation(genLoc1);
-    const genLoc2 = await getGeneratedLocation(oLoc, ifSource);
-    // console.log(formatLocations([genLoc1, oLoc, genLoc2]));
 
-    expect(genLoc2).toEqual({
-      sourceId: "if.out.js",
-      column: 0,
-      line: 8
+    expect(oLoc).toMatchObject({
+      sourceUrl: "http://example.com/if.js",
+      line: 5,
+      column: 4
     });
   });
 

--- a/packages/devtools-source-map/src/tests/wasm-source-map.js
+++ b/packages/devtools-source-map/src/tests/wasm-source-map.js
@@ -26,7 +26,7 @@ describe("wasm source maps", () => {
       { offset: 17, line: 2, column: 18 },
     ];
 
-    let map1 = new SourceMapConsumer(testMap1);
+    let map1 = await new SourceMapConsumer(testMap1);
     let remap1 = new WasmRemap(map1);
 
     expect(remap1.file).toEqual("min.js");
@@ -81,7 +81,7 @@ describe("wasm source maps", () => {
       sourcesContent: ["//test"]
     };
 
-    let map2 = new SourceMapConsumer(testMap2);
+    let map2 = await new SourceMapConsumer(testMap2);
     let remap2 = new WasmRemap(map2);
     expect(remap2.file).toEqual("none.js");
     expect(remap2.hasContentsOfAllSources()).toEqual(true);

--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -8,6 +8,9 @@ const { networkRequest } = require("devtools-utils");
 const { getSourceMap, setSourceMap } = require("./sourceMapRequests");
 const { WasmRemap } = require("./wasmRemap");
 const { SourceMapConsumer } = require("source-map");
+SourceMapConsumer.initialize({
+  "lib/mappings.wasm": "https://unpkg.com/source-map@0.7.2/lib/mappings.wasm"
+})
 
 import type {
   Source,
@@ -34,14 +37,14 @@ function _resolveSourceMapURL(source: Source) {
   return { sourceMapURL: resolvedString, baseURL };
 }
 
-async function _resolveAndFetch(generatedSource: Source): SourceMapConsumer {
+async function _resolveAndFetch(generatedSource: Source): Promise<SourceMapConsumer> {
   // Fetch the sourcemap over the network and create it.
   const { sourceMapURL, baseURL } = _resolveSourceMapURL(generatedSource);
 
   const fetched = await networkRequest(sourceMapURL, { loadFromCache: false });
 
   // Create the source map and fix it up.
-  let map = new SourceMapConsumer(fetched.content, baseURL);
+  let map = await new SourceMapConsumer(fetched.content, baseURL);
   if (generatedSource.isWasm) {
     map = new WasmRemap(map);
   }

--- a/packages/devtools-source-map/yarn.lock
+++ b/packages/devtools-source-map/yarn.lock
@@ -4856,6 +4856,10 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+source-map@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.2.tgz#115c3e891aaa9a484869fd2b89391a225feba344"
+
 source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"


### PR DESCRIPTION
This PR addresses devtools-html/debugger.html#5598 for updating `source-map` to `0.7.2`. The new version uses WebAssembly to encode/decode mappings.  💥 

This PR is marked as WIP for a couple reasons:

* [One of the source mapping Jest tests](https://github.com/calebstdenis/devtools-core/blob/41d6b01c581415b9fd22fdde260ffc4b26f688fb/packages/devtools-source-map/src/tests/locations.js#L80) gives a surprising failure:
![image](https://user-images.githubusercontent.com/7321311/37374903-b0586a2e-26f3-11e8-8eb5-d9a2059ca8f7.png)
    * I don't see how this could be correct. Hoping someone from the source-map team can shed some light on this.

* WebAssembly is [loaded differently](https://github.com/mozilla/source-map/blob/43b2687e6e2f3cf6c22926aa473d5031fb7df89d/lib/read-wasm.js#L1) in Node as opposed to the web. (Jest tests run in a Node-like environment.) The way I handled that is almost certainly not how we want to do it. See my comments below for more details.