### PR TITLE
Re-create loadItemProperties function which is used by the debugger.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/reducer.js
+++ b/packages/devtools-reps/src/object-inspector/reducer.js
@@ -32,13 +32,10 @@ function reducer(
   }
 
   if (type === "NODE_PROPERTIES_LOADED") {
-    // Let's loop through the responses to build a single object.
-    const properties = mergeResponses(data.responses);
-
     return cloneState({
       actors: data.actor ? (new Set(state.actors || [])).add(data.actor) : state.actors,
       loadedProperties: (new Map(state.loadedProperties))
-        .set(data.node.path, properties),
+        .set(data.node.path, action.data.properties),
     });
   }
 
@@ -49,26 +46,6 @@ function reducer(
   }
 
   return state;
-}
-
-function mergeResponses(responses: Array<Object>) : Object {
-  const data = {};
-
-  for (const response of responses) {
-    if (response.hasOwnProperty("ownProperties")) {
-      data.ownProperties = {...data.ownProperties, ...response.ownProperties};
-    }
-
-    if (response.ownSymbols && response.ownSymbols.length > 0) {
-      data.ownSymbols = response.ownSymbols;
-    }
-
-    if (response.prototype) {
-      data.prototype = response.prototype;
-    }
-  }
-
-  return data;
 }
 
 module.exports = reducer;


### PR DESCRIPTION
The function was deleted in https://github.com/devtools-html/devtools-core/commit/7c538787e1f19c07e868192268097f6c8845feb2\#diff-1d5a77fb4120fb410c4af9fa9a4eb936
because it wasn't used in devtools-reps code.
But it was exported and the debugger does use it for
the Preview popup.
So we re-create it and make sure the similar action use
it as well so the ObjectInspector and debugger code path
don't diverge.

---

tested both in devtools-reps' launchpad and debugger.html (cp'ed)