### PR TITLE
Don't use ObjectInspector for Error grips.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-render-roots-in-reps.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-render-roots-in-reps.js
@@ -11,6 +11,7 @@ const undefinedStubs = require("../../../reps/stubs/undefined");
 const gripStubs = require("../../../reps/stubs/grip");
 const gripArrayStubs = require("../../../reps/stubs/grip-array");
 const symbolStubs = require("../../../reps/stubs/symbol");
+const errorStubs = require("../../../reps/stubs/error");
 
 describe("shouldRenderRootsInReps", () => {
   it("returns true for a string", () => {
@@ -40,6 +41,12 @@ describe("shouldRenderRootsInReps", () => {
   it("returns true for Symbols", () => {
     expect(shouldRenderRootsInReps([{
       contents: { value: symbolStubs.get("Symbol") }
+    }])).toBeTruthy();
+  });
+
+  it("returns true for Errors", () => {
+    expect(shouldRenderRootsInReps([{
+      contents: { value: errorStubs.get("MultilineStackError") }
     }])).toBeTruthy();
   });
 

--- a/packages/devtools-reps/src/object-inspector/utils/index.js
+++ b/packages/devtools-reps/src/object-inspector/utils/index.js
@@ -7,7 +7,7 @@
 const client = require("./client");
 const loadProperties = require("./load-properties");
 const node = require("./node");
-const { nodeIsPrimitive } = node;
+const { nodeIsError, nodeIsPrimitive } = node;
 const selection = require("./selection");
 
 const { MODE } = require("../../reps/constants");
@@ -26,8 +26,8 @@ function shouldRenderRootsInReps(roots: Array<Node>) : boolean {
 
   const root = roots[0];
   const name = root && root.name;
-  return nodeIsPrimitive(root)
-    && (name === null || typeof name === "undefined");
+  return (name === null || typeof name === "undefined") &&
+    (nodeIsPrimitive(root) || nodeIsError(root));
 }
 
 function renderRep(

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -9,6 +9,7 @@ const ArrayRep = require("../../reps/array");
 const GripArrayRep = require("../../reps/grip-array");
 const GripMap = require("../../reps/grip-map");
 const GripMapEntryRep = require("../../reps/grip-map-entry");
+const ErrorRep = require("../../reps/error");
 
 const MAX_NUMERICAL_PROPERTIES = 100;
 
@@ -206,6 +207,12 @@ function nodeIsBlock(
   item: Node
 ) {
   return getType(item) === NODE_TYPES.BLOCK;
+}
+
+function nodeIsError(
+  item: Node
+) : boolean {
+  return ErrorRep.supportsObject(getValue(item));
 }
 
 function nodeHasAccessors(item: Node) : boolean {
@@ -811,6 +818,7 @@ module.exports = {
   nodeIsBucket,
   nodeIsDefaultProperties,
   nodeIsEntries,
+  nodeIsError,
   nodeIsFunction,
   nodeIsGetter,
   nodeIsMapEntry,


### PR DESCRIPTION
Fixes #960.
Since the ErrorRep already provides all the error informations
in a nice way (message and stacktrace), there's no benefits
being able to inspect the object. Furthermore, when in the console,
throwing an Error object gives you a double arrow (first to expand
the stack we get from the exception, second is the objectInspector
arrow), which is clearly not ideal.
Using Rep directly solves these issues.