### PR TITLE
 Use symbols for nodes path

### DIFF
--- a/packages/devtools-reps/src/object-inspector/actions.js
+++ b/packages/devtools-reps/src/object-inspector/actions.js
@@ -39,7 +39,10 @@ function nodeExpand(
       type: "NODE_EXPAND",
       data: {node}
     });
-    dispatch(nodeLoadProperties(node, actor, loadedProperties, createObjectClient));
+
+    if (!loadedProperties.has(node.path)) {
+      dispatch(nodeLoadProperties(node, actor, loadedProperties, createObjectClient));
+    }
   };
 }
 
@@ -70,9 +73,7 @@ function nodeLoadProperties(
     try {
       const properties =
         await loadItemProperties(item, createObjectClient, loadedProperties);
-      if (Object.keys(properties).length > 0) {
-        dispatch(nodePropertiesLoaded(item, actor, properties));
-      }
+      dispatch(nodePropertiesLoaded(item, actor, properties));
     } catch (e) {
       console.error(e);
     }

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -114,7 +114,7 @@ class ObjectInspector extends Component {
     }
 
     // We should update if:
-    // - there are new loaded loaded properties
+    // - there are new loaded properties
     // - OR the expanded paths number changed, and all of them have properties loaded
     // - OR the expanded paths number did not changed, but old and new sets differ
     return loadedProperties.size !== nextProps.loadedProperties.size

--- a/packages/devtools-reps/src/object-inspector/index.js
+++ b/packages/devtools-reps/src/object-inspector/index.js
@@ -13,7 +13,7 @@ const {
   shouldRenderRootsInReps
 } = Utils;
 
-import type { Props, State } from "./types";
+import type { Props, Store } from "./types";
 
 class OI extends PureComponent {
 
@@ -22,7 +22,7 @@ class OI extends PureComponent {
     this.store = createStore(props);
   }
 
-  store: {dispatch: (any) => any, getState: () => State};
+  store: Store;
 
   getStore() {
     return this.store;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
@@ -1,53 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ObjectInspector - entries calls ObjectClient.enumEntries when an <entries> node is clicked 1`] = `
+exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 1`] = `
 "▼ Map(11)
 |  ▶︎ <entries>"
 `;
 
-exports[`ObjectInspector - entries calls ObjectClient.enumEntries when an <entries> node is clicked 2`] = `
+exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 2`] = `
 "▼ Map(11)
-|  ▼ <entries>"
+|  ▼ <entries>
+|  |  ▶︎ 0: \\"key-0\\" → \\"value-0\\"
+|  |  ▶︎ 1: \\"key-1\\" → \\"value-1\\"
+|  |  ▶︎ 2: \\"key-2\\" → \\"value-2\\"
+|  |  ▶︎ 3: \\"key-3\\" → \\"value-3\\"
+|  |  ▶︎ 4: \\"key-4\\" → \\"value-4\\"
+|  |  ▶︎ 5: \\"key-5\\" → \\"value-5\\"
+|  |  ▶︎ 6: \\"key-6\\" → \\"value-6\\"
+|  |  ▶︎ 7: \\"key-7\\" → \\"value-7\\"
+|  |  ▶︎ 8: \\"key-8\\" → \\"value-8\\"
+|  |  ▶︎ 9: \\"key-9\\" → \\"value-9\\"
+|  |  ▶︎ 10: \\"key-10\\" → \\"value-10\\""
 `;
 
-exports[`ObjectInspector - entries does not call enumEntries if entries are already loaded 1`] = `
+exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 3`] = `
 "▼ Map(11)
-|    size: 2
+|  ▶︎ <entries>"
+`;
+
+exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 4`] = `
+"▼ Map(11)
 |  ▼ <entries>
-|  |  ▼ 0: \\"key-0\\" → \\"value-0\\"
-|  |  |    <key>: \\"key-0\\"
-|  |  |    <value>: \\"value-0\\"
-|  |  ▼ 1: \\"key-1\\" → \\"value-1\\"
-|  |  |    <key>: \\"key-1\\"
-|  |  |    <value>: \\"value-1\\"
-|  |  ▼ 2: \\"key-2\\" → \\"value-2\\"
-|  |  |    <key>: \\"key-2\\"
-|  |  |    <value>: \\"value-2\\"
-|  |  ▼ 3: \\"key-3\\" → \\"value-3\\"
-|  |  |    <key>: \\"key-3\\"
-|  |  |    <value>: \\"value-3\\"
-|  |  ▼ 4: \\"key-4\\" → \\"value-4\\"
-|  |  |    <key>: \\"key-4\\"
-|  |  |    <value>: \\"value-4\\"
-|  |  ▼ 5: \\"key-5\\" → \\"value-5\\"
-|  |  |    <key>: \\"key-5\\"
-|  |  |    <value>: \\"value-5\\"
-|  |  ▼ 6: \\"key-6\\" → \\"value-6\\"
-|  |  |    <key>: \\"key-6\\"
-|  |  |    <value>: \\"value-6\\"
-|  |  ▼ 7: \\"key-7\\" → \\"value-7\\"
-|  |  |    <key>: \\"key-7\\"
-|  |  |    <value>: \\"value-7\\"
-|  |  ▼ 8: \\"key-8\\" → \\"value-8\\"
-|  |  |    <key>: \\"key-8\\"
-|  |  |    <value>: \\"value-8\\"
-|  |  ▼ 9: \\"key-9\\" → \\"value-9\\"
-|  |  |    <key>: \\"key-9\\"
-|  |  |    <value>: \\"value-9\\"
-|  |  ▼ 10: \\"key-10\\" → \\"value-10\\"
-|  |  |    <key>: \\"key-10\\"
-|  |  |    <value>: \\"value-10\\"
-|  ▼ <prototype>: {…}"
+|  |  ▶︎ 0: \\"key-0\\" → \\"value-0\\"
+|  |  ▶︎ 1: \\"key-1\\" → \\"value-1\\"
+|  |  ▶︎ 2: \\"key-2\\" → \\"value-2\\"
+|  |  ▶︎ 3: \\"key-3\\" → \\"value-3\\"
+|  |  ▶︎ 4: \\"key-4\\" → \\"value-4\\"
+|  |  ▶︎ 5: \\"key-5\\" → \\"value-5\\"
+|  |  ▶︎ 6: \\"key-6\\" → \\"value-6\\"
+|  |  ▶︎ 7: \\"key-7\\" → \\"value-7\\"
+|  |  ▶︎ 8: \\"key-8\\" → \\"value-8\\"
+|  |  ▶︎ 9: \\"key-9\\" → \\"value-9\\"
+|  |  ▶︎ 10: \\"key-10\\" → \\"value-10\\""
 `;
 
 exports[`ObjectInspector - entries renders Object with entries as expected 1`] = `
@@ -60,5 +52,6 @@ exports[`ObjectInspector - entries renders Object with entries as expected 1`] =
 |  |  ▼ 1: Symbol(b) → \\"value-b\\"
 |  |  |    <key>: Symbol(b)
 |  |  |    <value>: \\"value-b\\"
-|  ▼ <prototype>: {…}"
+|  ▼ <prototype>: {…}
+|  |    <prototype>: Object {  }"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
@@ -84,15 +84,13 @@ exports[`ObjectInspector - state has the expected state when expanding a proxy n
 "▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 ▼ Proxy
 |  ▶︎ <target>: Object { … }
-|  ▶︎ <handler>: Array(3) [ … ]
-|  ▶︎ <prototype>: Object {  }"
+|  ▶︎ <handler>: Array(3) [ … ]"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a proxy node 3`] = `
 "▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 ▼ Proxy
 |  ▶︎ <target>: Object { … }
-|  ▶︎ <handler>: Array(3) [ … ]
-|  ▼ <prototype>: {}
-|  |  ▶︎ <prototype>: Object {  }"
+|  ▼ <handler>: (3) […]
+|  |    <prototype>: Object {  }"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
@@ -3,6 +3,5 @@
 exports[`ObjectInspector - Proxy renders Proxy as expected 1`] = `
 "▼ Proxy
 |  ▶︎ <target>: Object { … }
-|  ▶︎ <handler>: Array(3) [ … ]
-|    <prototype>: Object {  }"
+|  ▶︎ <handler>: Array(3) [ … ]"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
@@ -24,7 +24,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders collapsed top-level window 
     aria-level={1}
     className="tree-node"
     data-expandable={true}
-    id="windowpath"
+    id="Symbol(window)"
     onClick={[Function]}
     role="treeitem"
   >
@@ -34,126 +34,6 @@ exports[`ObjectInspector - dimTopLevelWindow renders collapsed top-level window 
     >
       <img
         className="arrow"
-      />
-      <span
-        className="object-label"
-      >
-        window
-      </span>
-      <span
-        className="object-delimiter"
-      >
-        : 
-      </span>
-      <span
-        className="objectBox objectBox-Window"
-        data-link-actor-id="server1.conn3.obj198"
-      >
-        <span
-          className="objectTitle"
-        >
-          Window
-        </span>
-      </span>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`ObjectInspector - dimTopLevelWindow renders collapsed top-level window when dimTopLevelWindow is true 1`] = `
-<div
-  aria-activedescendant={null}
-  className="tree object-inspector"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
-  tabIndex="0"
->
-  <div
-    aria-expanded={false}
-    aria-level={1}
-    className="tree-node"
-    data-expandable={true}
-    id="windowpath"
-    onClick={[Function]}
-    role="treeitem"
-  >
-    <div
-      className="node object-node lessen"
-      onClick={[Function]}
-    >
-      <img
-        className="arrow"
-      />
-      <span
-        className="object-label"
-      >
-        window
-      </span>
-      <span
-        className="object-delimiter"
-      >
-        : 
-      </span>
-      <span
-        className="objectBox objectBox-Window"
-        data-link-actor-id="server1.conn3.obj198"
-      >
-        <span
-          className="objectTitle"
-        >
-          Window
-        </span>
-      </span>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`ObjectInspector - dimTopLevelWindow renders expanded top-level window when dimTopLevelWindow is true 1`] = `
-<div
-  aria-activedescendant={null}
-  className="tree object-inspector"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
-  tabIndex="0"
->
-  <div
-    aria-expanded={true}
-    aria-level={1}
-    className="tree-node"
-    data-expandable={true}
-    id="windowpath"
-    onClick={[Function]}
-    role="treeitem"
-  >
-    <div
-      className="node object-node"
-      onClick={[Function]}
-    >
-      <img
-        className="arrow expanded"
       />
       <span
         className="object-label"
@@ -204,7 +84,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
     aria-level={1}
     className="tree-node"
     data-expandable={true}
-    id="rootpath"
+    id="Symbol(root)"
     onClick={[Function]}
     role="treeitem"
   >
@@ -227,7 +107,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
     aria-level={2}
     className="tree-node"
     data-expandable={true}
-    id="windowpath"
+    id="Symbol(window)"
     onClick={[Function]}
     role="treeitem"
   >
@@ -261,6 +141,169 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
           className="objectTitle"
         >
           Window
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ObjectInspector - dimTopLevelWindow renders top-level window as expected when dimTopLevelWindow is true 1`] = `
+<div
+  aria-activedescendant={null}
+  className="tree object-inspector"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyPress={[Function]}
+  onKeyUp={[Function]}
+  role="tree"
+  style={
+    Object {
+      "margin": 0,
+      "padding": 0,
+    }
+  }
+  tabIndex="0"
+>
+  <div
+    aria-expanded={false}
+    aria-level={1}
+    className="tree-node"
+    data-expandable={true}
+    id="Symbol(window)"
+    onClick={[Function]}
+    role="treeitem"
+  >
+    <div
+      className="node object-node lessen"
+      onClick={[Function]}
+    >
+      <img
+        className="arrow"
+      />
+      <span
+        className="object-label"
+      >
+        window
+      </span>
+      <span
+        className="object-delimiter"
+      >
+        : 
+      </span>
+      <span
+        className="objectBox objectBox-Window"
+        data-link-actor-id="server1.conn3.obj198"
+      >
+        <span
+          className="objectTitle"
+        >
+          Window
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ObjectInspector - dimTopLevelWindow renders top-level window as expected when dimTopLevelWindow is true 2`] = `
+<div
+  aria-activedescendant={null}
+  className="tree object-inspector"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyPress={[Function]}
+  onKeyUp={[Function]}
+  role="tree"
+  style={
+    Object {
+      "margin": 0,
+      "padding": 0,
+    }
+  }
+  tabIndex="0"
+>
+  <div
+    aria-expanded={true}
+    aria-level={1}
+    className="tree-node"
+    data-expandable={true}
+    id="Symbol(window)"
+    onClick={[Function]}
+    role="treeitem"
+  >
+    <div
+      className="node object-node"
+      onClick={[Function]}
+    >
+      <img
+        className="arrow expanded"
+      />
+      <span
+        className="object-label"
+      >
+        window
+      </span>
+      <span
+        className="object-delimiter"
+      >
+        : 
+      </span>
+      <span
+        className="objectBox objectBox-Window"
+        data-link-actor-id="server1.conn3.obj198"
+      >
+        <span
+          className="objectTitle"
+        >
+          Window
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    aria-level={2}
+    className="tree-node"
+    data-expandable={false}
+    id="Symbol(window/<prototype>)"
+    onClick={[Function]}
+    role="treeitem"
+  >
+    <span
+      className="tree-indent"
+    >
+      ​
+    </span>
+    <div
+      className="node object-node lessen"
+      onClick={[Function]}
+    >
+      <span
+        className="object-label"
+      >
+        &lt;prototype&gt;
+      </span>
+      <span
+        className="object-delimiter"
+      >
+        : 
+      </span>
+      <span
+        className="objectBox objectBox-object"
+      >
+        <span
+          className="objectLeftBrace"
+        >
+          {
+        </span>
+        <span
+          className="objectRightBrace"
+        >
+          }
         </span>
       </span>
     </div>

--- a/packages/devtools-reps/src/object-inspector/tests/component/create-object-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/create-object-client.js
@@ -40,7 +40,7 @@ describe("createObjectClient", () => {
 
   it("is called with the expected object for entries node", () => {
     const grip = Symbol();
-    const mapStubNode = createNode(null, "map", "/", {value: grip});
+    const mapStubNode = createNode({ name: "map", contents: {value: grip}});
     const entriesNode = makeNodesForEntries(mapStubNode);
 
     const createObjectClient = jest.fn(x => ObjectClient(x));
@@ -54,7 +54,7 @@ describe("createObjectClient", () => {
 
   it("is called with the expected object for bucket node", () => {
     const grip = gripArrayRepStubs.get("testMaxProps");
-    const root = createNode(null, "root", "/", {value: grip});
+    const root = createNode({name: "root", contents: {value: grip}});
     const [bucket] = makeNumericalBuckets(root);
 
     const createObjectClient = jest.fn(x => ObjectClient(x));
@@ -68,7 +68,7 @@ describe("createObjectClient", () => {
 
   it("is called with the expected object for sub-bucket node", () => {
     const grip = gripArrayRepStubs.get("testMaxProps");
-    const root = createNode(null, "root", "/", {value: grip});
+    const root = createNode({name: "root", contents: {value: grip}});
     const [bucket] = makeNumericalBuckets(root);
     const [subBucket] = makeNumericalBuckets(bucket);
 
@@ -83,7 +83,7 @@ describe("createObjectClient", () => {
 
   it("does not fail if the ObjectClient does not have the expected functions", () => {
     const stub = gripRepStubs.get("testMoreThanMaxProps");
-    const root = createNode(null, "root", "/", {value: stub});
+    const root = createNode({name: "root", contents: {value: stub}});
 
     // Override console.error so we don't spam test results.
     const originalConsoleError = console.error;

--- a/packages/devtools-reps/src/object-inspector/tests/component/function.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/function.js
@@ -7,6 +7,7 @@ const React = require("react");
 const { createFactory } = React;
 const ObjectInspector = createFactory(require("../../index"));
 const { MODE } = require("../../../reps/constants");
+const { createNode } = require("../../utils/node");
 
 const functionStubs = require("../../../reps/stubs/function");
 const ObjectClient = require("../__mocks__/object-client");
@@ -23,40 +24,30 @@ describe("ObjectInspector - functions", () => {
   it("renders named function properties as expected", () => {
     const stub = functionStubs.get("Named");
     const oi = mount(ObjectInspector(generateDefaults({
-      roots: [{
-        path: "root",
-        name: "x",
-        contents: [{
-          path: "root/fn",
-          name: "fn",
-          contents: {value: stub}
-        }]
-      }],
+      roots: [createNode({
+        name: "fn",
+        contents: {value: stub}
+      })],
     })));
 
     const nodes = oi.find(".node");
 
-    const functionNode = nodes.last();
+    const functionNode = nodes.first();
     expect(functionNode.text()).toBe("fn:testName()");
   });
 
   it("renders anon function properties as expected", () => {
     const stub = functionStubs.get("Anon");
     const oi = mount(ObjectInspector(generateDefaults({
-      roots: [{
-        path: "root",
-        name: "x",
-        contents: [{
-          path: "root/fn",
-          name: "fn",
-          contents: {value: stub}
-        }]
-      }],
+      roots: [createNode({
+        name: "fn",
+        contents: {value: stub}
+      })],
     })));
 
     const nodes = oi.find(".node");
 
-    const functionNode = nodes.last();
+    const functionNode = nodes.first();
     // It should have the name of the property.
     expect(functionNode.text()).toBe("fn()");
   });

--- a/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
@@ -7,7 +7,7 @@ const React = require("react");
 const { createFactory } = React;
 const ObjectInspector = createFactory(require("../../index"));
 const { MODE } = require("../../../reps/constants");
-const { formatObjectInspector } = require("../test-utils");
+const { formatObjectInspector, waitForLoadedProperties } = require("../test-utils");
 
 const accessorStubs = require("../../../reps/stubs/accessor");
 const ObjectClient = require("../__mocks__/object-client");
@@ -22,7 +22,7 @@ function generateDefaults(overrides) {
 }
 
 describe("ObjectInspector - getters & setters", () => {
-  it("renders getters as expected", () => {
+  it("renders getters as expected", async () => {
     const stub = accessorStubs.get("getter");
     const oi = mount(ObjectInspector(generateDefaults({
       roots: [{
@@ -32,10 +32,14 @@ describe("ObjectInspector - getters & setters", () => {
       }],
     })));
 
+    const store = oi.instance().getStore();
+    await waitForLoadedProperties(store, ["root"]);
+    oi.update();
+
     expect(formatObjectInspector(oi)).toMatchSnapshot();
   });
 
-  it("renders setters as expected", () => {
+  it("renders setters as expected", async () => {
     const stub = accessorStubs.get("setter");
     const oi = mount(ObjectInspector(generateDefaults({
       autoExpandDepth: 1,
@@ -46,10 +50,14 @@ describe("ObjectInspector - getters & setters", () => {
       }],
     })));
 
+    const store = oi.instance().getStore();
+    await waitForLoadedProperties(store, ["root"]);
+    oi.update();
+
     expect(formatObjectInspector(oi)).toMatchSnapshot();
   });
 
-  it("renders getters and setters as expected", () => {
+  it("renders getters and setters as expected", async () => {
     const stub = accessorStubs.get("getter setter");
     const oi = mount(ObjectInspector(generateDefaults({
       roots: [{
@@ -58,6 +66,10 @@ describe("ObjectInspector - getters & setters", () => {
         contents: stub
       }],
     })));
+
+    const store = oi.instance().getStore();
+    await waitForLoadedProperties(store, ["root"]);
+    oi.update();
 
     expect(formatObjectInspector(oi)).toMatchSnapshot();
   });

--- a/packages/devtools-reps/src/object-inspector/tests/test-utils.js
+++ b/packages/devtools-reps/src/object-inspector/tests/test-utils.js
@@ -68,7 +68,7 @@ function waitForDispatch(store: Object, type: string) {
 }
 
 /**
- * Wait until the condition evaluates to something truethy
+ * Wait until the condition evaluates to something truthy
  * @param {function} condition: function that we need for returning something truthy.
  * @param {int} interval: Time to wait before trying to evaluate condition again
  * @param {int} maxTries: Number of evaluation to try.

--- a/packages/devtools-reps/src/object-inspector/tests/utils/__snapshots__/promises.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/__snapshots__/promises.js.snap
@@ -24,7 +24,7 @@ Array [
       },
       "path": "root",
     },
-    "path": "root/##-state",
+    "path": Symbol(root/<state>),
     "type": Symbol(<state>),
   },
   Object {
@@ -51,7 +51,7 @@ Array [
       },
       "path": "root",
     },
-    "path": "root/##-reason",
+    "path": Symbol(root/<reason>),
     "type": Symbol(<reason>),
   },
 ]

--- a/packages/devtools-reps/src/object-inspector/tests/utils/create-node.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/create-node.js
@@ -9,48 +9,68 @@ const {
 
 describe("createNode", () => {
   it("returns null when contents is undefined", () => {
-    expect(createNode(null, "name", "path")).toBeNull();
+    expect(createNode({name: "name"})).toBeNull();
   });
 
   it("does not return null when contents is null", () => {
-    expect(createNode(null, "name", "path", null)).toEqual({
-      parent: null,
+    expect(createNode({
       name: "name",
       path: "path",
-      contents: null,
-      type: NODE_TYPES.GRIP
-    });
+      contents: null
+    })).not.toBe(null);
   });
 
-  it("returns the expected object when parent is null", () => {
-    expect(createNode(null, "name", "path", "contents")).toEqual({
-      parent: null,
+  it("returns the expected object when parent is undefined", () => {
+    const node = createNode({name: "name", path: "path", contents: "contents"});
+    expect(node).toEqual({
       name: "name",
-      path: "path",
+      path: node.path,
       contents: "contents",
       type: NODE_TYPES.GRIP
     });
   });
 
   it("returns the expected object when parent is not null", () => {
-    const root = createNode(null, "name", "path", null);
-    expect(createNode(root, "name", "path", "contents")).toEqual({
+    const root = createNode({name: "name", contents: null});
+    const child = createNode({
       parent: root,
       name: "name",
       path: "path",
-      contents: "contents",
-      type: NODE_TYPES.GRIP
+      contents: "contents"
     });
+    expect(child.parent).toEqual(root);
   });
 
   it("returns the expected object when type is not undefined", () => {
-    const root = createNode(null, "name", "path", null);
-    expect(createNode(root, "name", "path", "contents", NODE_TYPES.BUCKET)).toEqual({
+    const root = createNode({name: "name", contents: null});
+    const child = createNode({
       parent: root,
       name: "name",
       path: "path",
       contents: "contents",
-      type: NODE_TYPES.BUCKET
+      type: NODE_TYPES.BUCKET,
     });
+
+    expect(child.type).toEqual(NODE_TYPES.BUCKET);
+  });
+
+  it("uses the name property for the path when path is not provided", () => {
+    expect(createNode({name: "name", contents: "contents"}).path.toString())
+      .toBe("Symbol(name)");
+  });
+
+  it("wraps the path in a Symbol when provided", () => {
+    expect(createNode({name: "name", path: "path", contents: "contents"}).path.toString())
+      .toBe("Symbol(path)");
+  });
+
+  it("uses parent path to compute its path", () => {
+    const root = createNode({name: "root", contents: null});
+    expect(createNode({
+      parent: root,
+      name: "name",
+      path: "path",
+      contents: "contents"
+    }).path.toString()).toBe("Symbol(root/path)");
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/get-closest-grip-node.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/get-closest-grip-node.js
@@ -16,26 +16,26 @@ const gripArrayRepStubs = require(`${repsPath}/stubs/grip-array`);
 describe("getClosestGripNode", () => {
   it("returns grip node itself", () => {
     const stub = gripRepStubs.get("testMoreThanMaxProps");
-    const node = createNode(null, "root", "/", {value: stub});
+    const node = createNode({name: "root", contents: {value: stub}});
     expect(getClosestGripNode(node)).toBe(node);
   });
 
   it("returns the expected node for entries node", () => {
-    const mapStubNode = createNode(null, "map", "/", {value: {}});
+    const mapStubNode = createNode({name: "map", contents: {value: {}}});
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(getClosestGripNode(entriesNode)).toBe(mapStubNode);
   });
 
   it("returns the expected node for bucket node", () => {
     const grip = gripArrayRepStubs.get("testMaxProps");
-    const root = createNode(null, "root", "/", {value: grip});
+    const root = createNode({name: "root", contents: {value: grip}});
     const [bucket] = makeNumericalBuckets(root);
     expect(getClosestGripNode(bucket)).toBe(root);
   });
 
   it("returns the expected node for sub-bucket node", () => {
     const grip = gripArrayRepStubs.get("testMaxProps");
-    const root = createNode(null, "root", "/", {value: grip});
+    const root = createNode({name: "root", contents: {value: grip}});
     const [bucket] = makeNumericalBuckets(root);
     const [subBucket] = makeNumericalBuckets(bucket);
     expect(getClosestGripNode(subBucket)).toBe(root);
@@ -43,7 +43,7 @@ describe("getClosestGripNode", () => {
 
   it("returns the expected node for deep sub-bucket node", () => {
     const grip = gripArrayRepStubs.get("testMaxProps");
-    const root = createNode(null, "root", "/", {value: grip});
+    const root = createNode({name: "root", contents: {value: grip}});
     let [bucket] = makeNumericalBuckets(root);
     for (let i = 0; i < 10; i++) {
       bucket = (makeNumericalBuckets({...bucket}))[0];

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -9,7 +9,6 @@ const {
   nodeIsEntries,
   nodeIsMapEntry,
   nodeIsPrototype,
-  SAFE_PATH_PREFIX,
 } = require("../../utils/node");
 const gripArrayStubs = require("../../../reps/stubs/grip-array");
 
@@ -44,8 +43,12 @@ describe("makeNodesForProperties", () => {
     const names = nodes.map(n => n.name);
     expect(names).toEqual(["0", "length", "<prototype>"]);
 
-    const paths = nodes.map(n => n.path);
-    expect(paths).toEqual(["root/0", "root/length", "root/<prototype>"]);
+    const paths = nodes.map(n => n.path.toString());
+    expect(paths).toEqual([
+      "Symbol(root/0)",
+      "Symbol(root/length)",
+      "Symbol(root/<prototype>)",
+    ]);
   });
 
   it("includes getters and setters", () => {
@@ -78,10 +81,15 @@ describe("makeNodesForProperties", () => {
     );
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual(["bar", "baz", "foo", "<prototype>"]);
-    expect(paths).toEqual(["root/bar", "root/baz", "root/foo", "root/<prototype>"]);
+    expect(paths).toEqual([
+      "Symbol(root/bar)",
+      "Symbol(root/baz)",
+      "Symbol(root/foo)",
+      "Symbol(root/<prototype>)",
+    ]);
   });
 
   it("does not include unrelevant properties", () => {
@@ -121,16 +129,16 @@ describe("makeNodesForProperties", () => {
     );
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual(["1", "2", "11", "_bar", "bar", "<prototype>"]);
     expect(paths).toEqual([
-      "root/1",
-      "root/2",
-      "root/11",
-      "root/_bar",
-      "root/bar",
-      "root/<prototype>"
+      "Symbol(root/1)",
+      "Symbol(root/2)",
+      "Symbol(root/11)",
+      "Symbol(root/_bar)",
+      "Symbol(root/bar)",
+      "Symbol(root/<prototype>)",
     ]);
   });
 
@@ -146,10 +154,10 @@ describe("makeNodesForProperties", () => {
     );
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual(["bar", "<prototype>"]);
-    expect(paths).toEqual(["root/bar", "root/<prototype>"]);
+    expect(paths).toEqual(["Symbol(root/bar)", "Symbol(root/<prototype>)"]);
 
     expect(nodeIsPrototype(nodes[1])).toBe(true);
   });
@@ -170,10 +178,10 @@ describe("makeNodesForProperties", () => {
     );
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual(["bar", "<default properties>"]);
-    expect(paths).toEqual(["root/bar", "root/##-default"]);
+    expect(paths).toEqual(["Symbol(root/bar)", "Symbol(root/<default properties>)"]);
 
     expect(nodeIsDefaultProperties(nodes[1])).toBe(true);
   });
@@ -181,8 +189,12 @@ describe("makeNodesForProperties", () => {
   it("object with entries", () => {
     const gripMapStubs = require("../../../reps/stubs/grip-map");
 
-    const mapNode = createNode(null, "map", "root", {
-      value: gripMapStubs.get("testSymbolKeyedMap")
+    const mapNode = createNode({
+      name: "map",
+      path: "root",
+      contents: {
+        value: gripMapStubs.get("testSymbolKeyedMap")
+      }
     });
 
     const nodes = makeNodesForProperties({
@@ -193,13 +205,13 @@ describe("makeNodesForProperties", () => {
     }, mapNode);
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual(["custom", "size", "<entries>"]);
     expect(paths).toEqual([
-      "root/custom",
-      "root/size",
-      `root/${SAFE_PATH_PREFIX}entries`
+      "Symbol(root/custom)",
+      "Symbol(root/size)",
+      `Symbol(root/<entries>)`
     ]);
 
     const entriesNode = nodes[2];
@@ -213,11 +225,11 @@ describe("makeNodesForProperties", () => {
     expect(children.every(child => nodeIsMapEntry(child))).toBe(true);
 
     const childrenNames = children.map(n => n.name);
-    const childrenPaths = children.map(n => n.path);
+    const childrenPaths = children.map(n => n.path.toString());
     expect(childrenNames).toEqual([0, 1]);
     expect(childrenPaths).toEqual([
-      `root/${SAFE_PATH_PREFIX}entries/0`,
-      `root/${SAFE_PATH_PREFIX}entries/1`
+      `Symbol(root/<entries>/0)`,
+      `Symbol(root/<entries>/1)`
     ]);
   });
 
@@ -239,7 +251,7 @@ describe("makeNodesForProperties", () => {
     );
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual([
       '""',
@@ -249,11 +261,11 @@ describe("makeNodesForProperties", () => {
       "<prototype>"
     ]);
     expect(paths).toEqual([
-      "root/",
-      "root/332217",
-      "root/needs-quotes",
-      "root/unquoted",
-      "root/<prototype>"
+      `Symbol(root/"")`,
+      `Symbol(root/332217)`,
+      `Symbol(root/"needs-quotes")`,
+      `Symbol(root/unquoted)`,
+      `Symbol(root/<prototype>)`,
     ]);
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-numerical-buckets.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-numerical-buckets.js
@@ -5,19 +5,21 @@
 const {
   createNode,
   makeNumericalBuckets,
-  SAFE_PATH_PREFIX,
 } = require("../../utils/node");
 const gripArrayStubs = require("../../../reps/stubs/grip-array");
 
 describe("makeNumericalBuckets", () => {
   it("handles simple numerical buckets", () => {
-    const node = createNode(null, "root", "root", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
     const nodes = makeNumericalBuckets(node);
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual([
       "[0…99]",
@@ -26,21 +28,24 @@ describe("makeNumericalBuckets", () => {
     ]);
 
     expect(paths).toEqual([
-      `root/${SAFE_PATH_PREFIX}bucket_0-99`,
-      `root/${SAFE_PATH_PREFIX}bucket_100-199`,
-      `root/${SAFE_PATH_PREFIX}bucket_200-233`,
+      "Symbol(root/[0…99])",
+      "Symbol(root/[100…199])",
+      "Symbol(root/[200…233])",
     ]);
   });
 
   // TODO: Re-enable when we have support for lonely node.
   it.skip("does not create a numerical bucket for a single node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(101)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(101)")
+      }
     });
     const nodes = makeNumericalBuckets(node);
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual([
       "[0…99]",
@@ -48,20 +53,23 @@ describe("makeNumericalBuckets", () => {
     ]);
 
     expect(paths).toEqual([
-      `root/${SAFE_PATH_PREFIX}bucket_0-99`,
-      `root/100`,
+      `Symbol(root/bucket_0-99)`,
+      `Symbol(root/100)`,
     ]);
   });
 
   // TODO: Re-enable when we have support for lonely node.
   it.skip("does create a numerical bucket for two node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
     const nodes = makeNumericalBuckets(node);
 
     const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path);
+    const paths = nodes.map(n => n.path.toString());
 
     expect(names).toEqual([
       "[0…99]",
@@ -69,14 +77,17 @@ describe("makeNumericalBuckets", () => {
     ]);
 
     expect(paths).toEqual([
-      `root/${SAFE_PATH_PREFIX}bucket_0-99`,
-      `root/${SAFE_PATH_PREFIX}bucket_100-101`,
+      `Symbol(root/bucket_0-99)`,
+      `Symbol(root/bucket_100-101)`,
     ]);
   });
 
   it("creates sub-buckets when needed", () => {
-    const node = createNode(null, "root", "root", {
-      value: gripArrayStubs.get("Array(23456)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(23456)")
+      }
     });
     const nodes = makeNumericalBuckets(node);
     const names = nodes.map(n => n.name);
@@ -110,7 +121,7 @@ describe("makeNumericalBuckets", () => {
 
     const firstBucketNodes = makeNumericalBuckets(nodes[0]);
     const firstBucketNames = firstBucketNodes.map(n => n.name);
-    const firstBucketPaths = firstBucketNodes.map(n => n.path);
+    const firstBucketPaths = firstBucketNodes.map(n => n.path.toString());
 
     expect(firstBucketNames).toEqual([
       "[0…99]",
@@ -125,15 +136,15 @@ describe("makeNumericalBuckets", () => {
       "[900…999]",
     ]);
     expect(firstBucketPaths[0]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_0-99`
+      `Symbol(root/[0…999]/[0…99])`
     );
     expect(firstBucketPaths[firstBucketPaths.length - 1]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_0-999/${SAFE_PATH_PREFIX}bucket_900-999`
+      `Symbol(root/[0…999]/[900…999])`
     );
 
     const lastBucketNodes = makeNumericalBuckets(nodes[nodes.length - 1]);
     const lastBucketNames = lastBucketNodes.map(n => n.name);
-    const lastBucketPaths = lastBucketNodes.map(n => n.path);
+    const lastBucketPaths = lastBucketNodes.map(n => n.path.toString());
     expect(lastBucketNames).toEqual([
       "[23000…23099]",
       "[23100…23199]",
@@ -142,10 +153,10 @@ describe("makeNumericalBuckets", () => {
       "[23400…23455]",
     ]);
     expect(lastBucketPaths[0]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_23000-23455/${SAFE_PATH_PREFIX}bucket_23000-23099`
+      `Symbol(root/[23000…23455]/[23000…23099])`
     );
     expect(lastBucketPaths[lastBucketPaths.length - 1]).toEqual(
-      `root/${SAFE_PATH_PREFIX}bucket_23000-23455/${SAFE_PATH_PREFIX}bucket_23400-23455`
+      `Symbol(root/[23000…23455]/[23400…23455])`
     );
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-has-all-entries-in-preview.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-has-all-entries-in-preview.js
@@ -10,7 +10,7 @@ const {
   nodeHasAllEntriesInPreview,
 } = require("../../utils/node");
 
-const createRootNode = value => createNode(null, "root", "/", {value});
+const createRootNode = value => createNode({name: "root", contents: {value}});
 describe("nodeHasEntries", () => {
   it("returns true for a Map with every entries in the preview", () => {
     expect(nodeHasAllEntriesInPreview(

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-has-entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-has-entries.js
@@ -10,7 +10,7 @@ const {
   nodeHasEntries,
 } = require("../../utils/node");
 
-const createRootNode = value => createNode(null, "root", "/", {value});
+const createRootNode = value => createNode({name: "root", contents: {value}});
 describe("nodeHasEntries", () => {
   it("returns true for Maps", () => {
     expect(nodeHasEntries(

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-is-window.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-is-window.js
@@ -9,7 +9,7 @@ const {
   nodeIsWindow,
 } = require("../../utils/node");
 
-const createRootNode = value => createNode(null, "root", "/", {value});
+const createRootNode = value => createNode({name: "root", contents: {value}});
 describe("nodeIsWindow", () => {
   it("returns true for Window", () => {
     expect(nodeIsWindow(

--- a/packages/devtools-reps/src/object-inspector/tests/utils/node-supports-numerical-bucketing.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/node-supports-numerical-bucketing.js
@@ -8,13 +8,10 @@ const {
   nodeSupportsNumericalBucketing,
 } = require("../../utils/node");
 
-const createRootNode = (stub) => createNode(
-  null,
-  "root",
-  "rootpath", {
-   value: stub
-  }
-);
+const createRootNode = (stub) => createNode({
+  name: "root",
+  contents: { value: stub }
+});
 
 const gripArrayStubs = require("../../../reps/stubs/grip-array");
 const gripMapStubs = require("../../../reps/stubs/grip-map");

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-entries.js
@@ -19,16 +19,22 @@ const gripStubs = require("../../../reps/stubs/grip");
 
 describe("shouldLoadItemEntries", () => {
   it("returns true for an entries node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(shouldLoadItemEntries(entriesNode)).toBeTruthy();
   });
 
   it("returns false for an already loaded entries node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     const loadedProperties = new Map([[entriesNode.path, true]]);
@@ -36,63 +42,90 @@ describe("shouldLoadItemEntries", () => {
   });
 
   it("returns false for an entries node on a map which has everything in preview", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("testSymbolKeyedMap")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("testSymbolKeyedMap")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(shouldLoadItemEntries(entriesNode)).toBeFalsy();
   });
 
   it("returns false for an entries node on a set which has everything in preview", () => {
-    const setStubNode = createNode(null, "set", "/", {
-      value: gripArrayStubs.get("new Set([1,2,3,4])")
+    const setStubNode = createNode({
+      name: "set",
+      contents: {
+        value: gripArrayStubs.get("new Set([1,2,3,4])")
+      }
     });
     const entriesNode = makeNodesForEntries(setStubNode);
     expect(shouldLoadItemEntries(entriesNode)).toBeFalsy();
   });
 
   it("returns false for a Set node", () => {
-    const setStubNode = createNode(null, "set", "/", {
-      value: gripArrayStubs.get("new Set([1,2,3,4])")
+    const setStubNode = createNode({
+      name: "set",
+      contents: {
+        value: gripArrayStubs.get("new Set([1,2,3,4])")
+      }
     });
     expect(shouldLoadItemEntries(setStubNode)).toBeFalsy();
   });
 
   it("returns false for a Map node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     expect(shouldLoadItemEntries(mapStubNode)).toBeFalsy();
   });
 
   it("returns false for an array", () => {
-    const node = createNode(null, "array", "/", {
-      value: gripMapStubs.get("testMaxProps")
+    const node = createNode({
+      name: "array",
+      contents: {
+        value: gripMapStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemEntries(node)).toBeFalsy();
   });
 
   it("returns false for an object", () => {
-    const node = createNode(null, "array", "/", {
-      value: gripStubs.get("testMaxProps")
+    const node = createNode({
+      name: "array",
+      contents: {
+        value: gripStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemEntries(node)).toBeFalsy();
   });
 
   it("returns false for an entries node with buckets", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("234-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("234-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(shouldLoadItemEntries(entriesNode)).toBeFalsy();
   });
 
   it("returns true for an entries bucket node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("234-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("234-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
-    const bucketNodes = getChildren({item: entriesNode});
+    const bucketNodes = getChildren({
+      item: entriesNode,
+      loadedProperties: new Map([[entriesNode.path, true]])
+    });
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…99]");
@@ -100,11 +133,17 @@ describe("shouldLoadItemEntries", () => {
   });
 
   it("returns false for an entries bucket node with sub-buckets", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("23456-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("23456-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
-    const bucketNodes = getChildren({item: entriesNode});
+    const bucketNodes = getChildren({
+      item: entriesNode,
+      loadedProperties: new Map([[entriesNode.path, true]])
+    });
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…999]");
@@ -112,16 +151,25 @@ describe("shouldLoadItemEntries", () => {
   });
 
   it("returns true for an entries sub-bucket node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("23456-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("23456-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
-    const bucketNodes = getChildren({item: entriesNode});
+    const bucketNodes = getChildren({
+      item: entriesNode,
+      loadedProperties: new Map([[entriesNode.path, true]])
+    });
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…999]");
 
     // Get the sub-buckets
-    const subBucketNodes = getChildren({item: bucketNodes[0]});
+    const subBucketNodes = getChildren({
+      item: bucketNodes[0],
+      loadedProperties: new Map([[bucketNodes[0].path, true]])
+    });
     // Make sure we do have a bucket.
     expect(subBucketNodes[0].name).toBe("[0…99]");
     expect(shouldLoadItemEntries(subBucketNodes[0])).toBeTruthy();

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
@@ -23,32 +23,47 @@ const windowStubs = require("../../../reps/stubs/window");
 
 describe("shouldLoadItemIndexedProperties", () => {
   it("returns true for an array", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns false for an already loaded item", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     const loadedProperties = new Map([[node.path, true]]);
     expect(shouldLoadItemIndexedProperties(node, loadedProperties)).toBeFalsy();
   });
 
   it("returns false for an array node with buckets", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
     expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
   });
 
   it("returns true for an array bucket node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
-    const bucketNodes = getChildren({item: node});
+    const bucketNodes = getChildren({
+      item: node,
+      loadedProperties: new Map([[node.path, true]])
+    });
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…99]");
@@ -56,10 +71,16 @@ describe("shouldLoadItemIndexedProperties", () => {
   });
 
   it("returns false for an array bucket node with sub-buckets", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(23456)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(23456)")
+      }
     });
-    const bucketNodes = getChildren({item: node});
+    const bucketNodes = getChildren({
+      item: node,
+      loadedProperties: new Map([[node.path, true]])
+    });
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…999]");
@@ -67,62 +88,89 @@ describe("shouldLoadItemIndexedProperties", () => {
   });
 
   it("returns true for an array sub-bucket node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(23456)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(23456)")
+      }
     });
-    const bucketNodes = getChildren({item: node});
+    const bucketNodes = getChildren({
+      item: node,
+      loadedProperties: new Map([[node.path, true]])
+    });
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…999]");
 
     // Get the sub-buckets
-    const subBucketNodes = getChildren({item: bucketNodes[0]});
+    const subBucketNodes = getChildren({
+      item: bucketNodes[0],
+      loadedProperties: new Map([[bucketNodes[0].path, true]])
+    });
     // Make sure we do have a bucket.
     expect(subBucketNodes[0].name).toBe("[0…99]");
     expect(shouldLoadItemIndexedProperties(subBucketNodes[0])).toBeTruthy();
   });
 
   it("returns false for an entries node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(shouldLoadItemIndexedProperties(entriesNode)).toBeFalsy();
   });
 
   it("returns true for an Object", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns true for a Map", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns true for a Set", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("new Set([1,2,3,4])")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("new Set([1,2,3,4])")
+      }
     });
     expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns true for a Window", () => {
-    const node = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     expect(shouldLoadItemIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns false for a <default properties> node", () => {
-    const windowNode = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const windowNode = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     const loadedProperties = new Map([[
-      "/",
+      windowNode.path,
       {
         ownProperties: {
           foo: {value: "bar"},
@@ -141,15 +189,21 @@ describe("shouldLoadItemIndexedProperties", () => {
   });
 
   it("returns false for a Proxy node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
   });
 
   it("returns true for a Proxy target node", () => {
-    const proxyNode = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const proxyNode = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     const [targetNode] = getChildren({item: proxyNode});
     // Make sure we have the target node.
@@ -158,28 +212,40 @@ describe("shouldLoadItemIndexedProperties", () => {
   });
 
   it("returns false for an accessor node", () => {
-    const accessorNode = createNode(null, "root", "/", {
-      value: accessorStubs.get("getter")
+    const accessorNode = createNode({
+      name: "root",
+      contents: {
+        value: accessorStubs.get("getter")
+      }
     });
     expect(shouldLoadItemIndexedProperties(accessorNode)).toBeFalsy();
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("getter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("getter")
+    });
     const [getNode] = getChildren({item: accessorNode});
     expect(getNode.name).toBe("<get>");
     expect(shouldLoadItemIndexedProperties(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("setter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("setter")
+    });
     const [setNode] = getChildren({item: accessorNode});
     expect(setNode.name).toBe("<set>");
     expect(shouldLoadItemIndexedProperties(setNode)).toBeTruthy();
   });
 
   it("returns false for a primitive node", () => {
-    const node = createNode(null, "root", "/", {value: 42});
+    const node = createNode({
+      name: "root",
+      contents: {value: 42}
+    });
     expect(shouldLoadItemIndexedProperties(node)).toBeFalsy();
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
@@ -23,32 +23,47 @@ const windowStubs = require("../../../reps/stubs/window");
 
 describe("shouldLoadItemNonIndexedProperties", () => {
   it("returns true for an array", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns false for an already loaded item", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     const loadedProperties = new Map([[node.path, true]]);
     expect(shouldLoadItemNonIndexedProperties(node, loadedProperties)).toBeFalsy();
   });
 
   it("returns true for an array node with buckets", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns false for an array bucket node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
-    const bucketNodes = getChildren({item: node});
+    const bucketNodes = getChildren({
+      item: node,
+      loadedProperties: new Map([[node.path, true]])
+    });
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…99]");
@@ -56,47 +71,65 @@ describe("shouldLoadItemNonIndexedProperties", () => {
   });
 
   it("returns false for an entries node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(shouldLoadItemNonIndexedProperties(entriesNode)).toBeFalsy();
   });
 
   it("returns true for an Object", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns true for a Map", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns true for a Set", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("new Set([1,2,3,4])")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("new Set([1,2,3,4])")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns true for a Window", () => {
-    const node = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeTruthy();
   });
 
   it("returns false for a <default properties> node", () => {
-    const windowNode = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const windowNode = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     const loadedProperties = new Map([[
-      "/",
+      windowNode.path,
       {
         ownProperties: {
           foo: {value: "bar"},
@@ -115,15 +148,21 @@ describe("shouldLoadItemNonIndexedProperties", () => {
   });
 
   it("returns false for a Proxy node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeFalsy();
   });
 
   it("returns true for a Proxy target node", () => {
-    const proxyNode = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const proxyNode = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     const [targetNode] = getChildren({item: proxyNode});
     // Make sure we have the target node.
@@ -132,28 +171,40 @@ describe("shouldLoadItemNonIndexedProperties", () => {
   });
 
   it("returns false for an accessor node", () => {
-    const accessorNode = createNode(null, "root", "/", {
-      value: accessorStubs.get("getter")
+    const accessorNode = createNode({
+      name: "root",
+      contents: {
+        value: accessorStubs.get("getter")
+      }
     });
     expect(shouldLoadItemNonIndexedProperties(accessorNode)).toBeFalsy();
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("getter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("getter")
+    });
     const [getNode] = getChildren({item: accessorNode});
     expect(getNode.name).toBe("<get>");
     expect(shouldLoadItemNonIndexedProperties(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("setter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("setter")
+    });
     const [setNode] = getChildren({item: accessorNode});
     expect(setNode.name).toBe("<set>");
     expect(shouldLoadItemNonIndexedProperties(setNode)).toBeTruthy();
   });
 
   it("returns false for a primitive node", () => {
-    const node = createNode(null, "root", "/", {value: 42});
+    const node = createNode({
+      name: "root",
+      contents: {value: 42}
+    });
     expect(shouldLoadItemNonIndexedProperties(node)).toBeFalsy();
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
@@ -23,32 +23,47 @@ const windowStubs = require("../../../reps/stubs/window");
 
 describe("shouldLoadItemPrototype", () => {
   it("returns true for an array", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
   it("returns false for an already loaded item", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     const loadedProperties = new Map([[node.path, true]]);
     expect(shouldLoadItemPrototype(node, loadedProperties)).toBeFalsy();
   });
 
   it("returns true for an array node with buckets", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
   it("returns false for an array bucket node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
-    const bucketNodes = getChildren({item: node});
+    const bucketNodes = getChildren({
+      item: node,
+      loadedProperties: new Map([[node.path, true]])
+    });
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…99]");
@@ -56,47 +71,65 @@ describe("shouldLoadItemPrototype", () => {
   });
 
   it("returns false for an entries node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(shouldLoadItemPrototype(entriesNode)).toBeFalsy();
   });
 
   it("returns true for an Object", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
   it("returns true for a Map", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
   it("returns true for a Set", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("new Set([1,2,3,4])")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("new Set([1,2,3,4])")
+      }
     });
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
   it("returns true for a Window", () => {
-    const node = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
   it("returns false for a <default properties> node", () => {
-    const windowNode = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const windowNode = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     const loadedProperties = new Map([[
-      "/",
+      windowNode.path,
       {
         ownProperties: {
           foo: {value: "bar"},
@@ -115,15 +148,21 @@ describe("shouldLoadItemPrototype", () => {
   });
 
   it("returns true for a Proxy node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     expect(shouldLoadItemPrototype(node)).toBeTruthy();
   });
 
   it("returns true for a Proxy target node", () => {
-    const proxyNode = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const proxyNode = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     const [targetNode] = getChildren({item: proxyNode});
     // Make sure we have the target node.
@@ -132,28 +171,40 @@ describe("shouldLoadItemPrototype", () => {
   });
 
   it("returns false for an accessor node", () => {
-    const accessorNode = createNode(null, "root", "/", {
-      value: accessorStubs.get("getter")
+    const accessorNode = createNode({
+      name: "root",
+      contents: {
+        value: accessorStubs.get("getter")
+      }
     });
     expect(shouldLoadItemPrototype(accessorNode)).toBeFalsy();
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("getter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("getter")
+    });
     const [getNode] = getChildren({item: accessorNode});
     expect(getNode.name).toBe("<get>");
     expect(shouldLoadItemPrototype(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("setter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("setter")
+    });
     const [setNode] = getChildren({item: accessorNode});
     expect(setNode.name).toBe("<set>");
     expect(shouldLoadItemPrototype(setNode)).toBeTruthy();
   });
 
   it("returns false for a primitive node", () => {
-    const node = createNode(null, "root", "/", {value: 42});
+    const node = createNode({
+      name: "root",
+      contents: {value: 42}
+    });
     expect(shouldLoadItemPrototype(node)).toBeFalsy();
   });
 });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
@@ -23,32 +23,47 @@ const windowStubs = require("../../../reps/stubs/window");
 
 describe("shouldLoadItemSymbols", () => {
   it("returns true for an array", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemSymbols(node)).toBeTruthy();
   });
 
   it("returns false for an already loaded item", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("testMaxProps")
+      }
     });
     const loadedProperties = new Map([[node.path, true]]);
     expect(shouldLoadItemSymbols(node, loadedProperties)).toBeFalsy();
   });
 
   it("returns true for an array node with buckets", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
     expect(shouldLoadItemSymbols(node)).toBeTruthy();
   });
 
   it("returns false for an array bucket node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("Array(234)")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("Array(234)")
+      }
     });
-    const bucketNodes = getChildren({item: node});
+    const bucketNodes = getChildren({
+      item: node,
+      loadedProperties: new Map([[node.path, true]])
+    });
 
     // Make sure we do have a bucket.
     expect(bucketNodes[0].name).toBe("[0…99]");
@@ -56,47 +71,65 @@ describe("shouldLoadItemSymbols", () => {
   });
 
   it("returns false for an entries node", () => {
-    const mapStubNode = createNode(null, "map", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const mapStubNode = createNode({
+      name: "map",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     const entriesNode = makeNodesForEntries(mapStubNode);
     expect(shouldLoadItemSymbols(entriesNode)).toBeFalsy();
   });
 
   it("returns true for an Object", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testMaxProps")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testMaxProps")
+      }
     });
     expect(shouldLoadItemSymbols(node)).toBeTruthy();
   });
 
   it("returns true for a Map", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripMapStubs.get("20-entries Map")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripMapStubs.get("20-entries Map")
+      }
     });
     expect(shouldLoadItemSymbols(node)).toBeTruthy();
   });
 
   it("returns true for a Set", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripArrayStubs.get("new Set([1,2,3,4])")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripArrayStubs.get("new Set([1,2,3,4])")
+      }
     });
     expect(shouldLoadItemSymbols(node)).toBeTruthy();
   });
 
   it("returns true for a Window", () => {
-    const node = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     expect(shouldLoadItemSymbols(node)).toBeTruthy();
   });
 
   it("returns false for a <default properties> node", () => {
-    const windowNode = createNode(null, "root", "/", {
-      value: windowStubs.get("Window")
+    const windowNode = createNode({
+      name: "root",
+      contents: {
+        value: windowStubs.get("Window")
+      }
     });
     const loadedProperties = new Map([[
-      "/",
+      windowNode.path,
       {
         ownProperties: {
           foo: {value: "bar"},
@@ -115,15 +148,21 @@ describe("shouldLoadItemSymbols", () => {
   });
 
   it("returns false for a Proxy node", () => {
-    const node = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     expect(shouldLoadItemSymbols(node)).toBeFalsy();
   });
 
   it("returns true for a Proxy target node", () => {
-    const proxyNode = createNode(null, "root", "/", {
-      value: gripStubs.get("testProxy")
+    const proxyNode = createNode({
+      name: "root",
+      contents: {
+        value: gripStubs.get("testProxy")
+      }
     });
     const [targetNode] = getChildren({item: proxyNode});
     // Make sure we have the target node.
@@ -132,28 +171,40 @@ describe("shouldLoadItemSymbols", () => {
   });
 
   it("returns false for an accessor node", () => {
-    const accessorNode = createNode(null, "root", "/", {
-      value: accessorStubs.get("getter")
+    const accessorNode = createNode({
+      name: "root",
+      contents: {
+        value: accessorStubs.get("getter")
+      }
     });
     expect(shouldLoadItemSymbols(accessorNode)).toBeFalsy();
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("getter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("getter")
+    });
     const [getNode] = getChildren({item: accessorNode});
     expect(getNode.name).toBe("<get>");
     expect(shouldLoadItemSymbols(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode(null, "root", "/", accessorStubs.get("setter"));
+    const accessorNode = createNode({
+      name: "root",
+      contents: accessorStubs.get("setter")
+    });
     const [setNode] = getChildren({item: accessorNode});
     expect(setNode.name).toBe("<set>");
     expect(shouldLoadItemSymbols(setNode)).toBeTruthy();
   });
 
   it("returns false for a primitive node", () => {
-    const node = createNode(null, "root", "/", {value: 42});
+    const node = createNode({
+      name: "root",
+      contents: {value: 42}
+    });
     expect(shouldLoadItemSymbols(node)).toBeFalsy();
   });
 });

--- a/packages/devtools-reps/src/object-inspector/types.js
+++ b/packages/devtools-reps/src/object-inspector/types.js
@@ -18,10 +18,11 @@ export type NodeMeta = {
   endIndex: number,
 };
 
+export type Path = Symbol;
 export type Node = {
   contents: Array<Node> | NodeContents,
   name: string,
-  path: string,
+  path: Path,
   type: ?Symbol,
   meta: ?NodeMeta,
 };
@@ -50,9 +51,9 @@ export type ObjectClient = {
   getPrototype: () => Promise<{prototype: Object}>,
 };
 
-export type CachedNodes = Map<string, Array<Node>>;
+export type CachedNodes = Map<Path, Array<Node>>;
 
-export type LoadedProperties = Map<string, GripProperties>;
+export type LoadedProperties = Map<Path, GripProperties>;
 
 export type Mode = MODE.TINY | MODE.SHORT | MODE.LONG;
 
@@ -91,10 +92,10 @@ export type Props = {
     }
   ) => any,
   actors: Set<string>,
-  expandedPaths: Set<string>,
+  expandedPaths: Set<Path>,
   focusedItem: ?Node,
   loadedProperties: LoadedProperties,
-  loading: Map<string, Array<Promise<GripProperties>>>,
+  loading: Map<Path, Array<Promise<GripProperties>>>,
 };
 
 export type ReduxAction = {
@@ -104,9 +105,14 @@ export type ReduxAction = {
 
 export type State = {
   actors: Set<string>,
-  expandedPaths: Set<string>,
+  expandedPaths: Set<Path>,
   focusedItem: ?Node,
   loadedProperties: LoadedProperties,
+};
+
+export type Store = {
+  dispatch: (any) => any,
+  getState: () => State
 };
 
 export type ObjectInspectorId = string | number;


### PR DESCRIPTION
Fixes #1001, #1002 & #1003.

The path property on a node is very important as it serve
as an identifier to know if a node is expanded, and what
its properties are. Currently, this path was a simple string
which could led to 2 nodes having the same path, which could
have unwanted effect on user interaction.
To avoid this, the path is now a symbol, which has the advantage
of being unique.
Because of this change, we needed to adapt our code so we always
have the same path reference in the state.
With this patch, we'll always dispatch the nodePropertiesLoaded action,
even if the node don't have any properties. We'll store null in the state,
so we can then check if a node was properly handled.
As a result, we change the shouldComponentUpdate of the component
to reflect this new behavior.
In order to have always the same reference, we always add created node
to the cacheNodes property, which we can do because of the change in
loadedProperties.
This should also give us some performance improvements as we don't have
to recreate some nodes twice.
We take this as an opportunity to change the signature of the createNode
function to be more explicit (it now expect an object of options), and
we also create the path of the node from its parent when the path option
is not supplied.