### PR TITLE
Expose the consumer's 'allGeneratedPositionsFor' method in the worker

### DIFF
--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -17,6 +17,8 @@ const dispatcher = new WorkerDispatcher();
 
 const getOriginalURLs = dispatcher.task("getOriginalURLs");
 const getGeneratedLocation = dispatcher.task("getGeneratedLocation");
+const getAllGeneratedLocations =
+  dispatcher.task("getAllGeneratedLocations");
 const getOriginalLocation = dispatcher.task("getOriginalLocation");
 const getLocationScopes = dispatcher.task("getLocationScopes");
 const getOriginalSourceText = dispatcher.task("getOriginalSourceText");
@@ -32,6 +34,7 @@ module.exports = {
   hasMappedSource,
   getOriginalURLs,
   getGeneratedLocation,
+  getAllGeneratedLocations,
   getOriginalLocation,
   getLocationScopes,
   getOriginalSourceText,

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -69,6 +69,34 @@ async function getGeneratedLocation(
   };
 }
 
+async function getAllGeneratedLocations(
+  location: Location,
+  originalSource: Source
+): Promise<Array<Location>> {
+  if (!isOriginalId(location.sourceId)) {
+    return [];
+  }
+
+  const generatedSourceId = originalToGeneratedId(location.sourceId);
+  const map = await getSourceMap(generatedSourceId);
+  if (!map) {
+    return [];
+  }
+
+  const positions = map.allGeneratedPositionsFor({
+    source: originalSource.url,
+    line: location.line,
+    column: location.column == null ? 0 : location.column,
+    bias: SourceMapConsumer.LEAST_UPPER_BOUND
+  });
+
+  return positions.map(({ line, column }) => ({
+    sourceId: generatedSourceId,
+    line,
+    column
+  }));
+}
+
 async function getOriginalLocation(location: Location): Promise<Location> {
   if (!isGeneratedId(location.sourceId)) {
     return location;
@@ -144,6 +172,7 @@ function applySourceMap(
 module.exports = {
   getOriginalURLs,
   getGeneratedLocation,
+  getAllGeneratedLocations,
   getOriginalLocation,
   getOriginalSourceText,
   applySourceMap,

--- a/packages/devtools-source-map/src/utils/index.js
+++ b/packages/devtools-source-map/src/utils/index.js
@@ -42,6 +42,7 @@ function trimUrlQuery(url: string): string {
 const contentMap = {
   "js": "text/javascript",
   "jsm": "text/javascript",
+  "mjs": "text/javascript",
   "ts": "text/typescript",
   "tsx": "text/typescript-jsx",
   "jsx": "text/jsx",

--- a/packages/devtools-source-map/src/worker.js
+++ b/packages/devtools-source-map/src/worker.js
@@ -5,6 +5,7 @@
 const {
   getOriginalURLs,
   getGeneratedLocation,
+  getAllGeneratedLocations,
   getOriginalLocation,
   getOriginalSourceText,
   getLocationScopes,
@@ -21,6 +22,7 @@ const { workerUtils: { workerHandler }} = require("devtools-utils");
 self.onmessage = workerHandler({
   getOriginalURLs,
   getGeneratedLocation,
+  getAllGeneratedLocations,
   getOriginalLocation,
   getLocationScopes,
   getOriginalSourceText,


### PR DESCRIPTION
Related Issue: #5561

### Summary of Changes

* Expose `allGeneratedPositionsFor` from consumer
* Mark `.mjs` files as JavaScript.
