### PR TITLE
removed --theme-search-overlays-semitransparent to fix #5566

### DIFF
--- a/packages/devtools-launchpad/src/components/Root.css
+++ b/packages/devtools-launchpad/src/components/Root.css
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-:root.theme-light,
-:root .theme-light {
-}
-
 * {
   box-sizing: border-box;
 }

--- a/packages/devtools-launchpad/src/components/Root.css
+++ b/packages/devtools-launchpad/src/components/Root.css
@@ -4,7 +4,6 @@
 
 :root.theme-light,
 :root .theme-light {
-  --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
 }
 
 * {


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/5566

### Summary of Changes

* I removed --theme-search-overlays-semitransparent in Root.css.