### PR TITLE
Fix expanding node with selected text.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -372,8 +372,16 @@ class ObjectInspector extends Component {
       onClick: e => {
         e.stopPropagation();
 
-        // If the user selected text, bail out.
-        if (Utils.selection.documentHasSelection()) {
+        // If this click happened because the user selected some text, bail out.
+        // Note that if the user selected some text before and then clicks here,
+        // the previously selected text will be first unselected, unless the user
+        // clicked on the arrow itself. Indeed because the arrow is an image, clicking on
+        // it does not remove any existing text selection. So we need to also check if
+        // teh arrow was clicked.
+        if (
+          Utils.selection.documentHasSelection()
+          && !(e.target && e.target.matches && e.target.matches(".arrow"))
+        ) {
           return;
         }
 

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ObjectInspector - state does expand if the user selected some text and clicked the arrow 1`] = `
+"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+`;
+
+exports[`ObjectInspector - state does expand if the user selected some text and clicked the arrow 2`] = `
+"▼ {…}
+|    a: 1
+|    Symbol(): \\"hello\\"
+|  ▶︎ <prototype>: Object { … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+`;
+
 exports[`ObjectInspector - state does not expand if the user selected some text 1`] = `
 "▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"

--- a/packages/devtools-reps/src/object-inspector/tests/component/expand.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/expand.js
@@ -205,6 +205,29 @@ describe("ObjectInspector - state", () => {
     getSelection().setMockSelection();
   });
 
+  it("does expand if the user selected some text and clicked the arrow", async () => {
+    const wrapper = mount(ObjectInspector(generateDefaults({
+      injectWaitService: true,
+      loadedProperties: new Map([
+        ["root-1", gripPropertiesStubs.get("proto-properties-symbols")]
+      ])
+    })));
+    const store = wrapper.instance().getStore();
+    expect(formatObjectInspector(wrapper)).toMatchSnapshot();
+    let nodes = wrapper.find(".node");
+
+    // Set a selection using the mock.
+    getSelection().setMockSelection("test");
+
+    const root1 = nodes.at(0);
+    root1.find("img.arrow").simulate("click");
+    expect(store.getState().expandedPaths.has("root-1")).toBeTruthy();
+    expect(formatObjectInspector(wrapper)).toMatchSnapshot();
+
+    // Clear the selection for other tests.
+    getSelection().setMockSelection();
+  });
+
   it("does not throw when expanding a block node", async () => {
     const blockNode = createNode({
       name: "Block",

--- a/packages/devtools-reps/src/object-inspector/utils/selection.js
+++ b/packages/devtools-reps/src/object-inspector/utils/selection.js
@@ -2,28 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const {ELEMENT_NODE} = require("../../shared/dom-node-constants");
-
 function documentHasSelection() : boolean {
   const selection = getSelection();
   if (!selection) {
-    return false;
-  }
-
-  const {
-    anchorNode,
-    focusNode,
-  } = selection;
-
-  // When clicking the arrow, which is an inline svg element, the selection do have a type
-  // of "Range". We need to have an explicit case when the anchor and the focus node are
-  // the same and they have an arrow ancestor.
-  if (
-    focusNode &&
-    focusNode === anchorNode &&
-    focusNode.nodeType == ELEMENT_NODE &&
-    focusNode.closest(".arrow")
-  ) {
     return false;
   }
 


### PR DESCRIPTION
Fixes #1017.

Since clicking on the arrow does NOT unselect potential selected
text, we need to check the target of the click and see if it is
the node arrow. In such case, we don't block the expansion.

---

A mochitest will be added in mozilla-central to be sure it does work with "true" text selection (in Node we can only rely on a mock)