### PR TITLE
Remove firebug theme

### DIFF
--- a/packages/devtools-launchpad/README.md
+++ b/packages/devtools-launchpad/README.md
@@ -63,7 +63,7 @@ The [Landing Page](./src/index.js)  shows the available Chrome, Firefox, and Nod
 * shows available connections
 * has tools title
 * sets up L10N
-* loads the light, dark, and firebug themes
+* loads the light and dark themes
 
 [Screenshot ](https://cloud.githubusercontent.com/assets/254562/20671763/a749acfa-b54c-11e6-9a4a-6b0fc4f45589.png)
 
@@ -90,7 +90,7 @@ The launchpad has a [config system](../devtools-config/README.md) for adding run
 **Features**
 * *target configs* - firefox, chrome, node configuration
 * *feature flags* toggle features in the build
-* *themes* - enable light, dark, firebug
+* *themes* - enable light, dark
 * *hot-reloading* - toggle hot Reloading
 * *logging* - enable different logging support
 * *environments* - different configs for development, ci, panel

--- a/packages/devtools-launchpad/src/components/Settings.js
+++ b/packages/devtools-launchpad/src/components/Settings.js
@@ -61,13 +61,6 @@ class Settings extends Component {
       click: () => setConfig(key, "dark")
     };
 
-    const firebugMenuItem = {
-      id: "node-menu-firebug",
-      label: "firebug",
-      disabled: config[key] === "firebug",
-      click: () => setConfig(key, "firebug")
-    };
-
     const items = {
       "dir": [
         { item: ltrMenuItem },
@@ -76,7 +69,6 @@ class Settings extends Component {
       "theme": [
         { item: lightMenuItem },
         { item: darkMenuItem },
-        { item: firebugMenuItem }
       ]
     };
     showMenu(event, buildMenu(items[key]));

--- a/packages/devtools-launchpad/src/index.js
+++ b/packages/devtools-launchpad/src/index.js
@@ -28,7 +28,6 @@ const Root = require("./components/Root");
 if (process.env.TARGET !== "firefox-panel") {
   require("devtools-mc-assets/assets/devtools/client/themes/light-theme.css");
   require("devtools-mc-assets/assets/devtools/client/themes/dark-theme.css");
-  require("devtools-mc-assets/assets/devtools/client/themes/firebug-theme.css");
 }
 
 function updateTheme(className) {

--- a/packages/devtools-reps/src/reps/reps.css
+++ b/packages/devtools-reps/src/reps/reps.css
@@ -17,18 +17,6 @@
   --comment-node-color: var(--theme-comment);
 }
 
-.theme-firebug {
-  --number-color: #000088;
-  --string-color: #FF0000;
-  --null-color: #787878;
-  --object-color: DarkGreen;
-  --caption-color: #444444;
-  --location-color: #555555;
-  --source-link-color: blue;
-  --node-color: rgb(0, 0, 136);
-  --reference-color: rgb(102, 102, 255);
-}
-
 /******************************************************************************/
 
 .inline {


### PR DESCRIPTION
Synchronization from https://bugzilla.mozilla.org/show_bug.cgi?id=1378108

Fixes Issue: #1025

### Summary of Changes

* removed references to firebug in reps css files
* removed references to firebug in launchpad UI

I kept the screenshots showing the Firebug theme (eg. in issues.md), felt overkill to recreate screenshots just for that.
