### PR TITLE
Allow batched worker tasks and generated sourcemap range lookup

### DIFF
--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -16,6 +16,7 @@ const { workerUtils: { WorkerDispatcher }} = require("devtools-utils");
 const dispatcher = new WorkerDispatcher();
 
 const getOriginalURLs = dispatcher.task("getOriginalURLs");
+const getGeneratedRanges = dispatcher.task("getGeneratedRanges", { queue: true });
 const getGeneratedLocation = dispatcher.task("getGeneratedLocation", { queue: true });
 const getAllGeneratedLocations =
   dispatcher.task("getAllGeneratedLocations", { queue: true });
@@ -33,6 +34,7 @@ module.exports = {
   isOriginalId,
   hasMappedSource,
   getOriginalURLs,
+  getGeneratedRanges,
   getGeneratedLocation,
   getAllGeneratedLocations,
   getOriginalLocation,

--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -16,9 +16,9 @@ const { workerUtils: { WorkerDispatcher }} = require("devtools-utils");
 const dispatcher = new WorkerDispatcher();
 
 const getOriginalURLs = dispatcher.task("getOriginalURLs");
-const getGeneratedLocation = dispatcher.task("getGeneratedLocation");
+const getGeneratedLocation = dispatcher.task("getGeneratedLocation", { queue: true });
 const getAllGeneratedLocations =
-  dispatcher.task("getAllGeneratedLocations");
+  dispatcher.task("getAllGeneratedLocations", { queue: true });
 const getOriginalLocation = dispatcher.task("getOriginalLocation");
 const getLocationScopes = dispatcher.task("getLocationScopes");
 const getOriginalSourceText = dispatcher.task("getOriginalSourceText");

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -86,8 +86,7 @@ async function getAllGeneratedLocations(
   const positions = map.allGeneratedPositionsFor({
     source: originalSource.url,
     line: location.line,
-    column: location.column == null ? 0 : location.column,
-    bias: SourceMapConsumer.LEAST_UPPER_BOUND
+    column: location.column == null ? 0 : location.column
   });
 
   return positions.map(({ line, column }) => ({

--- a/packages/devtools-source-map/src/worker.js
+++ b/packages/devtools-source-map/src/worker.js
@@ -4,6 +4,7 @@
 
 const {
   getOriginalURLs,
+  getGeneratedRanges,
   getGeneratedLocation,
   getAllGeneratedLocations,
   getOriginalLocation,
@@ -21,6 +22,7 @@ const { workerUtils: { workerHandler }} = require("devtools-utils");
 // easier to unit test.
 self.onmessage = workerHandler({
   getOriginalURLs,
+  getGeneratedRanges,
   getGeneratedLocation,
   getAllGeneratedLocations,
   getOriginalLocation,

--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -34,55 +34,83 @@ WorkerDispatcher.prototype = {
     this.worker = null;
   },
 
-  task(method) {
-    return (...args: any) => {
+  task(method, { queue = false } = {}) {
+    const calls = [];
+    const push = (args: Array<any>) => {
       return new Promise((resolve, reject) => {
-        const id = this.msgId++;
-        this.worker.postMessage({ id, method, args });
+        if (queue && calls.length === 0) {
+          Promise.resolve().then(flush);
+        }
 
-        const listener = ({ data: result }) => {
-          if (result.id !== id) {
-            return;
-          }
+        calls.push([args, resolve, reject]);
 
-          if (!this.worker) {
-            return;
-          }
-
-          this.worker.removeEventListener("message", listener);
-          if (result.error) {
-            reject(result.error);
-          } else {
-            resolve(result.response);
-          }
-        };
-
-        this.worker.addEventListener("message", listener);
+        if (!queue) {
+          flush();
+        }
       });
-    };
+    }
+
+    const flush = () => {
+      const items = calls.slice();
+      calls.length = 0;
+
+      const id = this.msgId++;
+      this.worker.postMessage({ id, method, calls: items.map(item => item[0]) });
+
+      const listener = ({ data: result }) => {
+        if (result.id !== id) {
+          return;
+        }
+
+        if (!this.worker) {
+          return;
+        }
+
+        this.worker.removeEventListener("message", listener);
+
+        result.results.forEach((resultData, i) => {
+          const [, resolve, reject] = items[i];
+
+          if (resultData.error) {
+            reject(resultData.error);
+          } else {
+            resolve(resultData.response);
+          }
+        });
+      };
+
+      this.worker.addEventListener("message", listener);
+    }
+
+    return (...args: any) => push(args);
   }
 };
 
 function workerHandler(publicInterface: Object) {
   return function (msg: Message) {
-    const { id, method, args } = msg.data;
-    try {
-      const response = publicInterface[method].apply(undefined, args);
-      if (response instanceof Promise) {
-        response.then(
-          val => self.postMessage({ id, response: val }),
-          // Error can't be sent via postMessage, so be sure to
-          // convert to string.
-          err => self.postMessage({ id, error: err.toString() })
-        );
-      } else {
-        self.postMessage({ id, response });
+    const { id, method, calls } = (msg.data: any);
+
+    Promise.all(calls.map(args => {
+      try {
+        const response = publicInterface[method].apply(undefined, args);
+        if (response instanceof Promise) {
+          return response.then(
+            val => ({ response: val }),
+            // Error can't be sent via postMessage, so be sure to
+            // convert to string.
+            err => ({ error: err.toString() })
+          );
+        } else {
+          return { response };
+        }
+      } catch (error) {
+        // Error can't be sent via postMessage, so be sure to convert to
+        // string.
+        return { error: error.toString() };
       }
-    } catch (error) {
-      // Error can't be sent via postMessage, so be sure to convert to
-      // string.
-      self.postMessage({ id, error: error.toString() });
-    }
+    })).then(results => {
+      self.postMessage({ id, results });
+    });
   };
 }
 


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/5561

### Summary of Changes

* Allow multiple synchronous calls to an async task to be batched into a single postMessage
* Add a new function for getting the generated ranges for a given original location

