### PR TITLE
Wrap text representation of ObjectInspector in new lines.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/basic.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/basic.js.snap
@@ -1,25 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ObjectInspector - renders renders as expected 1`] = `"▶︎ {…}"`;
-
-exports[`ObjectInspector - renders renders as expected 2`] = `"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }"`;
-
-exports[`ObjectInspector - renders renders as expected 3`] = `"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }"`;
-
-exports[`ObjectInspector - renders renders as expected 4`] = `"▶︎ {…}"`;
-
-exports[`ObjectInspector - renders renders as expected when not provided a name 1`] = `"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }"`;
-
-exports[`ObjectInspector - renders renders block nodes as expected 1`] = `
-"▼ ☲ Block
-|    a: 30
-|    b: 32"
+exports[`ObjectInspector - renders renders as expected 1`] = `
+"
+▶︎ {…}
+"
 `;
 
-exports[`ObjectInspector - renders renders objects as expected when provided a name 1`] = `"▶︎ myproperty: Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }"`;
+exports[`ObjectInspector - renders renders as expected 2`] = `
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }
+"
+`;
 
-exports[`ObjectInspector - renders renders primitives as expected when provided a name 1`] = `"  myproperty: 42"`;
+exports[`ObjectInspector - renders renders as expected 3`] = `
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+"
+`;
 
-exports[`ObjectInspector - renders updates when the root changes 1`] = `"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }"`;
+exports[`ObjectInspector - renders renders as expected 4`] = `
+"
+▶︎ {…}
+"
+`;
 
-exports[`ObjectInspector - renders updates when the root changes 2`] = `"▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" }"`;
+exports[`ObjectInspector - renders renders as expected when not provided a name 1`] = `
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }
+"
+`;
+
+exports[`ObjectInspector - renders renders block nodes as expected 1`] = `
+"
+▼ ☲ Block
+|    a: 30
+|    b: 32
+"
+`;
+
+exports[`ObjectInspector - renders renders objects as expected when provided a name 1`] = `
+"
+▶︎ myproperty: Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", … }
+"
+`;
+
+exports[`ObjectInspector - renders renders primitives as expected when provided a name 1`] = `
+"
+  myproperty: 42
+"
+`;
+
+exports[`ObjectInspector - renders updates when the root changes 1`] = `
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+"
+`;
+
+exports[`ObjectInspector - renders updates when the root changes 2`] = `
+"
+▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" }
+"
+`;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/entries.js.snap
@@ -1,12 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 1`] = `
-"▼ Map(11)
-|  ▶︎ <entries>"
+"
+▼ Map(11)
+|  ▶︎ <entries>
+"
 `;
 
 exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 2`] = `
-"  ▼ Map(11)
+"
+  ▼ Map(11)
 [ |  ▼ <entries> ]
   |  |  ▶︎ 0: \\"key-0\\" → \\"value-0\\"
   |  |  ▶︎ 1: \\"key-1\\" → \\"value-1\\"
@@ -18,16 +21,20 @@ exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 
   |  |  ▶︎ 7: \\"key-7\\" → \\"value-7\\"
   |  |  ▶︎ 8: \\"key-8\\" → \\"value-8\\"
   |  |  ▶︎ 9: \\"key-9\\" → \\"value-9\\"
-  |  |  ▶︎ 10: \\"key-10\\" → \\"value-10\\""
+  |  |  ▶︎ 10: \\"key-10\\" → \\"value-10\\"
+"
 `;
 
 exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 3`] = `
-"  ▼ Map(11)
-[ |  ▶︎ <entries> ]"
+"
+  ▼ Map(11)
+[ |  ▶︎ <entries> ]
+"
 `;
 
 exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 4`] = `
-"  ▼ Map(11)
+"
+  ▼ Map(11)
 [ |  ▼ <entries> ]
   |  |  ▶︎ 0: \\"key-0\\" → \\"value-0\\"
   |  |  ▶︎ 1: \\"key-1\\" → \\"value-1\\"
@@ -39,11 +46,13 @@ exports[`ObjectInspector - entries calls ObjectClient.enumEntries when expected 
   |  |  ▶︎ 7: \\"key-7\\" → \\"value-7\\"
   |  |  ▶︎ 8: \\"key-8\\" → \\"value-8\\"
   |  |  ▶︎ 9: \\"key-9\\" → \\"value-9\\"
-  |  |  ▶︎ 10: \\"key-10\\" → \\"value-10\\""
+  |  |  ▶︎ 10: \\"key-10\\" → \\"value-10\\"
+"
 `;
 
 exports[`ObjectInspector - entries renders Object with entries as expected 1`] = `
-"▼ Map(2)
+"
+▼ Map(2)
 |    size: 2
 |  ▼ <entries>
 |  |  ▼ 0: Symbol(a) → \\"value-a\\"
@@ -53,5 +62,6 @@ exports[`ObjectInspector - entries renders Object with entries as expected 1`] =
 |  |  |    <key>: Symbol(b)
 |  |  |    <value>: \\"value-b\\"
 |  ▼ <prototype>: {…}
-|  |    <prototype>: Object {  }"
+|  |    <prototype>: Object {  }
+"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/expand.js.snap
@@ -1,109 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ObjectInspector - state does expand if the user selected some text and clicked the arrow 1`] = `
-"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
-▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state does expand if the user selected some text and clicked the arrow 2`] = `
-"[ ▼ {…} ]
+"
+[ ▼ {…} ]
   |    a: 1
   |    Symbol(): \\"hello\\"
   |  ▶︎ <prototype>: Object { … }
-  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state does not expand if the user selected some text 1`] = `
-"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
-▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state does not expand if the user selected some text 2`] = `
-"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
-▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state does not throw when expanding a block node 1`] = `
-"▶︎ ☲ Block
-▶︎ Proxy: Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+▶︎ ☲ Block
+▶︎ Proxy: Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state does not throw when expanding a block node 2`] = `
-"[ ▼ ☲ Block ]
+"
+[ ▼ ☲ Block ]
   |    a: 30
   |    b: 32
-  ▶︎ Proxy: Proxy { <target>: {…}, <handler>: (3) […] }"
+  ▶︎ Proxy: Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected expandedPaths state when clicking nodes 1`] = `
-"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
-▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected expandedPaths state when clicking nodes 2`] = `
-"[ ▼ {…} ]
+"
+[ ▼ {…} ]
   |    a: 1
   |    Symbol(): \\"hello\\"
   |  ▶︎ <prototype>: Object { … }
-  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected expandedPaths state when clicking nodes 3`] = `
-"[ ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … } ]
-  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+[ ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … } ]
+  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected expandedPaths state when clicking nodes 4`] = `
-"  ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+"
+  ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 [ ▼ Proxy ]
   |  ▶︎ <target>: Object { … }
-  |  ▶︎ <handler>: Array(3) [ … ]"
+  |  ▶︎ <handler>: Array(3) [ … ]
+"
 `;
 
 exports[`ObjectInspector - state has the expected expandedPaths state when clicking nodes 5`] = `
-"[ ▼ {…} ]
+"
+[ ▼ {…} ]
   |    a: 1
   |    Symbol(): \\"hello\\"
   |  ▶︎ <prototype>: Object { … }
   ▼ Proxy
   |  ▶︎ <target>: Object { … }
-  |  ▶︎ <handler>: Array(3) [ … ]"
+  |  ▶︎ <handler>: Array(3) [ … ]
+"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a node 1`] = `
-"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
-▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a node 2`] = `
-"[ ▼ {…} ]
+"
+[ ▼ {…} ]
   |  ▶︎ <prototype>: Object {  }
-  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a node 3`] = `
-"  ▼ {…}
+"
+  ▼ {…}
 [ |  ▼ <prototype>: {} ]
   |  |  ▶︎ <prototype>: Object {  }
-  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+  ▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a proxy node 1`] = `
-"▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
-▶︎ Proxy { <target>: {…}, <handler>: (3) […] }"
+"
+▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+▶︎ Proxy { <target>: {…}, <handler>: (3) […] }
+"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a proxy node 2`] = `
-"  ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+"
+  ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
 [ ▼ Proxy ]
   |  ▶︎ <target>: Object { … }
-  |  ▶︎ <handler>: Array(3) [ … ]"
+  |  ▶︎ <handler>: Array(3) [ … ]
+"
 `;
 
 exports[`ObjectInspector - state has the expected state when expanding a proxy node 3`] = `
-"  ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+"
+  ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
   ▼ Proxy
   |  ▶︎ <target>: Object { … }
 [ |  ▼ <handler>: (3) […] ]
-  |  |    <prototype>: Object {  }"
+  |  |    <prototype>: Object {  }
+"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
@@ -1,17 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ObjectInspector - getters & setters renders getters and setters as expected 1`] = `
-"▼ x: Getter & Setter
+"
+▼ x: Getter & Setter
 |  ▶︎ <get>: function x()
-|  ▶︎ <set>: function x()"
+|  ▶︎ <set>: function x()
+"
 `;
 
 exports[`ObjectInspector - getters & setters renders getters as expected 1`] = `
-"▼ x: Getter
-|  ▶︎ <get>: function x()"
+"
+▼ x: Getter
+|  ▶︎ <get>: function x()
+"
 `;
 
 exports[`ObjectInspector - getters & setters renders setters as expected 1`] = `
-"▼ x: Setter
-|  ▶︎ <set>: function x()"
+"
+▼ x: Setter
+|  ▶︎ <set>: function x()
+"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/keyboard-navigation.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/keyboard-navigation.js.snap
@@ -1,35 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ObjectInspector - keyboard navigation works as expected 1`] = `"▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" }"`;
+exports[`ObjectInspector - keyboard navigation works as expected 1`] = `
+"
+▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" }
+"
+`;
 
-exports[`ObjectInspector - keyboard navigation works as expected 2`] = `"[ ▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" } ]"`;
+exports[`ObjectInspector - keyboard navigation works as expected 2`] = `
+"
+[ ▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" } ]
+"
+`;
 
 exports[`ObjectInspector - keyboard navigation works as expected 3`] = `
-"[ ▼ {…} ]
-  |    <prototype>: Object {  }"
+"
+[ ▼ {…} ]
+  |    <prototype>: Object {  }
+"
 `;
 
 exports[`ObjectInspector - keyboard navigation works as expected 4`] = `
-"  ▼ {…}
-[ |    <prototype>: Object {  } ]"
+"
+  ▼ {…}
+[ |    <prototype>: Object {  } ]
+"
 `;
 
 exports[`ObjectInspector - keyboard navigation works as expected 5`] = `
-"[ ▼ {…} ]
-  |    <prototype>: Object {  }"
+"
+[ ▼ {…} ]
+  |    <prototype>: Object {  }
+"
 `;
 
 exports[`ObjectInspector - keyboard navigation works as expected 6`] = `
-"  ▼ {…}
-[ |    <prototype>: Object {  } ]"
+"
+  ▼ {…}
+[ |    <prototype>: Object {  } ]
+"
 `;
 
 exports[`ObjectInspector - keyboard navigation works as expected 7`] = `
-"[ ▼ {…} ]
-  |    <prototype>: Object {  }"
+"
+[ ▼ {…} ]
+  |    <prototype>: Object {  }
+"
 `;
 
 exports[`ObjectInspector - keyboard navigation works as expected 8`] = `
-"▼ {…}
-|    <prototype>: Object {  }"
+"
+▼ {…}
+|    <prototype>: Object {  }
+"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/properties.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/properties.js.snap
@@ -1,7 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ObjectInspector - properties renders uninitialized bindings 1`] = `"  someFoo: (uninitialized)"`;
+exports[`ObjectInspector - properties renders uninitialized bindings 1`] = `
+"
+  someFoo: (uninitialized)
+"
+`;
 
-exports[`ObjectInspector - properties renders unmapped bindings 1`] = `"  someFoo: (unmapped)"`;
+exports[`ObjectInspector - properties renders unmapped bindings 1`] = `
+"
+  someFoo: (unmapped)
+"
+`;
 
-exports[`ObjectInspector - properties renders unscoped bindings 1`] = `"  someFoo: (unscoped)"`;
+exports[`ObjectInspector - properties renders unscoped bindings 1`] = `
+"
+  someFoo: (unscoped)
+"
+`;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/proxy.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ObjectInspector - Proxy renders Proxy as expected 1`] = `
-"▼ Proxy
+"
+▼ Proxy
 |  ▶︎ <target>: Object { … }
-|  ▶︎ <handler>: Array(3) [ … ]"
+|  ▶︎ <handler>: Array(3) [ … ]
+"
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/test-utils.js
+++ b/packages/devtools-reps/src/object-inspector/tests/test-utils.js
@@ -24,7 +24,7 @@ const {WAIT_UNTIL_TYPE} = require("../../shared/redux/middleware/waitUntilServic
  */
 function formatObjectInspector(wrapper: Object) {
   const hasFocusedNode = wrapper.find(".tree-node.focused").length > 0;
-  return wrapper.find(".tree-node")
+  const textTree = wrapper.find(".tree-node")
     .map(node => {
       const indentStr = "|  ".repeat((node.prop("aria-level") || 1) - 1);
       // Need to target img.arrow or Enzyme will also match the ArrowExpander component.
@@ -48,6 +48,9 @@ function formatObjectInspector(wrapper: Object) {
         : `  ${text}`;
     })
     .join("\n");
+  // Wrap the text representation in new lines so it keeps alignment between
+  // tree nodes.
+  return `\n${textTree}\n`;
 }
 
 function getSanitizedNodeText(node) {


### PR DESCRIPTION
This way tree nodes in snapshot are well aligned.