### PR TITLE
Tree component fixes and improvements

### DIFF
--- a/packages/devtools-components/src/tests/__snapshots__/tree.js.snap
+++ b/packages/devtools-components/src/tests/__snapshots__/tree.js.snap
@@ -677,6 +677,73 @@ exports[`Tree renders as expected when navigating with arrows on unexpandable ro
 "
 `;
 
+exports[`Tree renders as expected when navigating with home/end 1`] = `
+"
+▶︎ A
+▶︎ [M]
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 2`] = `
+"
+▶︎ [A]
+▶︎ M
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 3`] = `
+"
+▶︎ [A]
+▶︎ M
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 4`] = `
+"
+▶︎ A
+▶︎ [M]
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 5`] = `
+"
+▶︎ A
+▶︎ [M]
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 6`] = `
+"
+▶︎ A
+▼ [M]
+|  ▶︎ N
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 7`] = `
+"
+▶︎ A
+▼ M
+|  ▶︎ [N]
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 8`] = `
+"
+▶︎ A
+▼ M
+|  ▶︎ [N]
+"
+`;
+
+exports[`Tree renders as expected when navigating with home/end 9`] = `
+"
+▶︎ [A]
+▼ M
+|  ▶︎ N
+"
+`;
+
 exports[`Tree renders as expected when navigating with left arrows on roots 1`] = `
 "
 ▶︎ A

--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -399,6 +399,42 @@ describe("Tree", () => {
     expect(onFocus.mock.calls[4][0]).toBe("E");
   });
 
+  it("calls onActivate when expected", () => {
+    const onActivate = jest.fn();
+
+    const wrapper = mountTree({
+      expanded: new Set("ABCDEFGHIJKLMNO".split("")),
+      focused: "A",
+      onActivate,
+    });
+
+    simulateKeyDown(wrapper, "Enter");
+    expect(onActivate.mock.calls.length).toBe(1);
+    expect(onActivate.mock.calls[0][0]).toBe("A");
+
+    simulateKeyDown(wrapper, "Enter");
+    expect(onActivate.mock.calls.length).toBe(2);
+    expect(onActivate.mock.calls[1][0]).toBe("A");
+
+    simulateKeyDown(wrapper, "ArrowDown");
+    simulateKeyDown(wrapper, "Enter");
+    expect(onActivate.mock.calls.length).toBe(3);
+    expect(onActivate.mock.calls[2][0]).toBe("B");
+
+    wrapper.simulate("blur");
+    simulateKeyDown(wrapper, "Enter");
+    expect(onActivate.mock.calls.length).toBe(3);
+  });
+
+  it("does not throw when onActivate is undefined and Enter is pressed", () => {
+    const wrapper = mountTree({
+      expanded: new Set("ABCDEFGHIJKLMNO".split("")),
+      focused: "A",
+    });
+
+    simulateKeyDown(wrapper, "Enter");
+  });
+
   it("ignores key strokes when pressing modifiers", () => {
     const wrapper = mountTree({
       expanded: new Set("ABCDEFGHIJKLMNO".split("")),

--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -304,6 +304,55 @@ describe("Tree", () => {
     expect(wrapper.find(".focused").prop("id")).toBe("key-A");
   });
 
+  it("renders as expected when navigating with home/end", () => {
+    const wrapper = mountTree({
+      focused: "M"
+    });
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-M");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-M");
+
+    simulateKeyDown(wrapper, "Home");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-A");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-A");
+
+    simulateKeyDown(wrapper, "Home");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-A");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-A");
+
+    simulateKeyDown(wrapper, "End");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-M");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-M");
+
+    simulateKeyDown(wrapper, "End");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-M");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-M");
+
+    simulateKeyDown(wrapper, "ArrowRight");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-M");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-M");
+
+    simulateKeyDown(wrapper, "End");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-N");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-N");
+
+    simulateKeyDown(wrapper, "End");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-N");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-N");
+
+    simulateKeyDown(wrapper, "Home");
+    expect(formatTree(wrapper)).toMatchSnapshot();
+    expect(wrapper.getDOMNode().getAttribute("aria-activedescendant")).toBe("key-A");
+    expect(wrapper.find(".focused").prop("id")).toBe("key-A");
+  });
+
   it("renders as expected when navigating with arrows on unexpandable roots", () => {
     const wrapper = mountTree({
       focused: "A",

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -546,6 +546,7 @@ class Tree extends Component {
     if (item !== undefined) {
       const treeElement = this.treeRef;
       const element = document.getElementById(this.props.getKey(item));
+
       if (element) {
         const {top, bottom} = element.getBoundingClientRect();
         const closestScrolledParent = node => {
@@ -559,16 +560,20 @@ class Tree extends Component {
           return closestScrolledParent(node.parentNode);
         };
         const scrolledParent = closestScrolledParent(treeElement);
+        const scrolledParentRect = scrolledParent
+          ? scrolledParent.getBoundingClientRect()
+          : null;
         const isVisible = !scrolledParent
           || (
-            top >= 0
-            && bottom <= scrolledParent.clientHeight
+            top >= scrolledParentRect.top
+            && bottom <= scrolledParentRect.bottom
           );
 
         if (!isVisible) {
-          let scrollToTop =
-            (!options.alignTo && top < 0)
-            || options.alignTo === "top";
+          const {alignTo} = options;
+          let scrollToTop = alignTo
+            ? alignTo === "top"
+            : !scrolledParentRect || top < scrolledParentRect.top;
           element.scrollIntoView(scrollToTop);
         }
       }

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -379,6 +379,8 @@ class Tree extends Component {
     this._autoExpand();
     if (this.props.focused) {
       this._scrollNodeIntoView(this.props.focused);
+      // Always keep the focus on the tree itself.
+      this.treeRef.focus();
     }
   }
 
@@ -389,6 +391,8 @@ class Tree extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (prevProps.focused !== this.props.focused) {
       this._scrollNodeIntoView(this.props.focused);
+      // Always keep the focus on the tree itself.
+      this.treeRef.focus();
     }
   }
 

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -330,6 +330,9 @@ class Tree extends Component {
       //     onExpand: item => dispatchExpandActionToRedux(item)
       onExpand: PropTypes.func,
       onCollapse: PropTypes.func,
+      // Optional event handler called with the current focused node when the Enter key
+      // is pressed. Can be useful to allow further keyboard actions within the tree node.
+      onActivate: PropTypes.func,
       isExpandable: PropTypes.func,
       // Additional classes to add to the root element.
       className: PropTypes.string,
@@ -369,6 +372,7 @@ class Tree extends Component {
     this._onBlur = this._onBlur.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
     this._nodeIsExpandable = this._nodeIsExpandable.bind(this);
+    this._activateNode = oncePerAnimationFrame(this._activateNode).bind(this);
   }
 
   componentDidMount() {
@@ -639,6 +643,10 @@ class Tree extends Component {
 
       case "End":
         this._focusLastNode();
+        return;
+
+      case "Enter":
+        this._activateNode();
     }
   }
 
@@ -724,6 +732,12 @@ class Tree extends Component {
     const traversal = this._dfsFromRoots();
     const lastIndex = traversal.length - 1;
     this._focus(traversal[lastIndex].item, {alignTo: "bottom"});
+  }
+
+  _activateNode() {
+    if (this.props.onActivate) {
+      this.props.onActivate(this.props.focused);
+    }
   }
 
   _nodeIsExpandable(item) {

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -357,6 +357,8 @@ class Tree extends Component {
     this._focusPrevNode = oncePerAnimationFrame(this._focusPrevNode).bind(this);
     this._focusNextNode = oncePerAnimationFrame(this._focusNextNode).bind(this);
     this._focusParentNode = oncePerAnimationFrame(this._focusParentNode).bind(this);
+    this._focusFirstNode = oncePerAnimationFrame(this._focusFirstNode).bind(this);
+    this._focusLastNode = oncePerAnimationFrame(this._focusLastNode).bind(this);
 
     this._autoExpand = this._autoExpand.bind(this);
     this._preventArrowKeyScrolling = this._preventArrowKeyScrolling.bind(this);
@@ -629,6 +631,14 @@ class Tree extends Component {
         } else {
           this._focusNextNode();
         }
+        return;
+
+      case "Home":
+        this._focusFirstNode();
+        return;
+
+      case "End":
+        this._focusLastNode();
     }
   }
 
@@ -703,6 +713,17 @@ class Tree extends Component {
     }
 
     this._focus(parent, {alignTo: "top"});
+  }
+
+  _focusFirstNode() {
+    const traversal = this._dfsFromRoots();
+    this._focus(traversal[0].item, {alignTo: "top"});
+  }
+
+  _focusLastNode() {
+    const traversal = this._dfsFromRoots();
+    const lastIndex = traversal.length - 1;
+    this._focus(traversal[lastIndex].item, {alignTo: "bottom"});
   }
 
   _nodeIsExpandable(item) {


### PR DESCRIPTION
Fixes #923

- Adds keyboard shortcut to navigate to first and last opened nodes (<kbd>Home</kbd>/<kbd>End</kbd>)
- Adds an `onActivate` prop, called with the focused item when <kbd>Enter</kbd>
- Fix `scrollNodeIntoView` function (always use boundingClientRect to determine if a node is visible or not).