### PR TITLE
Cleanup redux state when roots prop changes.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,6 @@
 [ignore]
+.*node_modules/autoprefixer.*
+.*node_modules/chalk.*
 .*node_modules/cjson.*
 .*node_modules/fbjs.*
 .*node_modules/npm.*
@@ -6,6 +8,7 @@
 .*node_modules/config-chain.*
 .*node_modules/conventional-changelog-core.*
 .*node_modules/devtools-mc-assets.*
+.*node_modules/postcss-*
 .*node_modules/radium.*
 .*node_modules/react-style-proptype.*
 .*flow-coverage-report/.*

--- a/packages/devtools-reps/src/object-inspector/actions.js
+++ b/packages/devtools-reps/src/object-inspector/actions.js
@@ -10,6 +10,7 @@ import type {
   GripProperties,
   LoadedProperties,
   Node,
+  Props,
   ReduxAction,
 } from "./types";
 
@@ -95,10 +96,35 @@ function nodePropertiesLoaded(
   };
 }
 
+/*
+ * This action is dispatched when the `roots` prop, provided by a consumer of the
+ * ObjectInspector (inspector, console, …), is modified. It will clean the internal
+ * state properties (expandedPaths, loadedProperties, …) and release the actors consumed
+ * with the previous roots.
+ * It takes a props argument which reflects what is passed by the upper-level consumer.
+ */
+function rootsChanged(props: Props) {
+  return {
+    type: "ROOTS_CHANGED",
+    data: props,
+  };
+}
+
+/*
+ * This action will reset the `forceUpdate` flag in the state.
+ */
+function forceUpdated() {
+  return {
+    type: "FORCE_UPDATED",
+  };
+}
+
 module.exports = {
+  forceUpdated,
   nodeExpand,
   nodeCollapse,
   nodeFocus,
   nodeLoadProperties,
   nodePropertiesLoaded,
+  rootsChanged,
 };

--- a/packages/devtools-reps/src/object-inspector/reducer.js
+++ b/packages/devtools-reps/src/object-inspector/reducer.js
@@ -49,6 +49,12 @@ function reducer(
     });
   }
 
+  if (type === "FORCE_UPDATED") {
+    return cloneState({
+      forceUpdate: false,
+    });
+  }
+
   return state;
 }
 

--- a/packages/devtools-reps/src/object-inspector/store.js
+++ b/packages/devtools-reps/src/object-inspector/store.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-const { applyMiddleware, createStore } = require("redux");
+const { applyMiddleware, createStore, compose } = require("redux");
 const {thunk} = require("../shared/redux/middleware/thunk");
 const {waitUntilService} = require("../shared/redux/middleware/waitUntilService");
 const reducer = require("./reducer");
@@ -19,12 +19,38 @@ function createInitialState(overrides : Object) : State {
     expandedPaths: new Set(),
     focusedItem: null,
     loadedProperties: new Map(),
+    forceUpdated: false,
     ...overrides,
+  };
+}
+
+function enableStateReinitializer(props) {
+  return next => (innerReducer, initialState, enhancer) => {
+    function reinitializerEnhancer(state, action) {
+      if (action.type !== "ROOTS_CHANGED") {
+        return innerReducer(state, action);
+      }
+
+      if (props.releaseActor && initialState.actors) {
+        initialState.actors.forEach(props.releaseActor);
+      }
+
+      return {
+        ...action.data,
+        actors: new Set(),
+        expandedPaths: new Set(),
+        loadedProperties: new Map(),
+        // Indicates to the component that we do want to render on the next render cycle.
+        forceUpdate: true,
+      };
+    }
+    return next(reinitializerEnhancer, initialState, enhancer);
   };
 }
 
 module.exports = (props : Props) => {
   const middlewares = [thunk];
+
   if (props.injectWaitService) {
     middlewares.push(waitUntilService);
   }
@@ -32,6 +58,9 @@ module.exports = (props : Props) => {
   return createStore(
     reducer,
     createInitialState(props),
-    applyMiddleware(...middlewares)
+    compose(
+      applyMiddleware(...middlewares),
+      enableStateReinitializer(props)
+    )
   );
 };

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/basic.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/basic.js.snap
@@ -52,12 +52,12 @@ exports[`ObjectInspector - renders renders primitives as expected when provided 
 
 exports[`ObjectInspector - renders updates when the root changes 1`] = `
 "
-▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … }
+[ ▶︎ Object { p0: \\"0\\", p1: \\"1\\", p2: \\"2\\", p3: \\"3\\", p4: \\"4\\", p5: \\"5\\", p6: \\"6\\", p7: \\"7\\", p8: \\"8\\", p9: \\"9\\", … } ]
 "
 `;
 
 exports[`ObjectInspector - renders updates when the root changes 2`] = `
 "
-▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" }
+[ ▶︎ Object { a: \\"a\\", b: \\"b\\", c: \\"c\\" } ]
 "
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/basic.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/basic.js
@@ -274,27 +274,36 @@ describe("ObjectInspector - renders", () => {
     expect(formatObjectInspector(oi)).toMatchSnapshot();
   });
 
-  it("updates when the root changes", () => {
+  it("updates when the root changes", async () => {
+    let root = {
+      path: "root",
+      contents: {
+        value: gripRepStubs.get("testMoreThanMaxProps")
+      }
+    };
     let oi = mount(ObjectInspector(generateDefaults({
-      roots: [{
-        path: "root",
-        contents: {
-          value: gripRepStubs.get("testMoreThanMaxProps")
-        }
-      }],
+      roots: [root],
       mode: MODE.LONG,
+      focusedItem: root,
+      injectWaitService: true,
     })));
 
     expect(formatObjectInspector(oi)).toMatchSnapshot();
 
+    root = {
+      path: "root-2",
+      contents: {
+        value: gripRepStubs.get("testMaxProps")
+      }
+    };
+
+    let onComponentUpdated = waitForDispatch(oi.instance().getStore(), "FORCE_UPDATED");
     oi.setProps({
-      roots: [{
-        path: "root-2",
-        contents: {
-          value: gripRepStubs.get("testMaxProps")
-        }
-      }]
+      roots: [root],
+      focusedItem: root,
     });
+    await onComponentUpdated;
+    oi.update();
     expect(formatObjectInspector(oi)).toMatchSnapshot();
   });
 
@@ -316,10 +325,12 @@ describe("ObjectInspector - renders", () => {
         }]
       }],
       mode: MODE.LONG,
+      injectWaitService: true,
     })));
     oi.find(".node").at(0).simulate("click");
-
     const oldTree = formatObjectInspector(oi);
+
+    let onComponentUpdated = waitForDispatch(oi.instance().getStore(), "FORCE_UPDATED");
     oi.setProps({
       roots: [{
         path: "root",
@@ -333,6 +344,8 @@ describe("ObjectInspector - renders", () => {
       }]
     });
 
+    await onComponentUpdated;
+    oi.update();
     expect(formatObjectInspector(oi)).not.toBe(oldTree);
   });
 });


### PR DESCRIPTION
The roots prop isn't handled by the redux state, but is passed from
upper-level components (e.g. console, inspector, ...). There might be
cases when the roots prop changes (e.g., in the console, the object sidebar
is already opened, and the user choose to put another object in it).
In such cases, there are a few things that should be taken care of:
- we need to clear the node cache to start anew
- we need to clean the redux state of the old roots-related properties,
  like expandedPaths, loadedProperties, …
- we need to release the actors related to the old roots.
- we need to make sure a possible new focusedItem is handled as expected.

In order to do that, we create a rootsChanged action that's handled in
a middleware where we reinitialize the state and release actors.
We don't want to render before the state is re-initialized, so we add a
new state property, forceUpdate, that we can then use as a flag that we
set when the roots prop changes and reset when the component was updated.

This isn't perfect but I wasn't able to find a better way of handling all
those requirements.