### PR TITLE
Prevent unnecessary server call when expanding node.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/utils/client.js
+++ b/packages/devtools-reps/src/object-inspector/utils/client.js
@@ -112,6 +112,10 @@ function iteratorSlice(
   const count = end
     ? end - start + 1
     : iterator.count;
+
+  if (count === 0) {
+    return Promise.resolve({});
+  }
   return iterator.slice(start, count);
 }
 


### PR DESCRIPTION
When expanding a node, in some cases, we query the server to know how
much indexed, non-indexed and symbol properties we have in the object.
The issue is that we then always try to get all the properties of the
object, even if the server told us there was none.
This patch prevent this and should save a couple of client-server round-trip.