### PR TITLE
Don't pass onFocus prop to Tree if disabledFocus is true

### DIFF
--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -222,13 +222,13 @@ class ObjectInspector extends Component {
 
   focusItem(item: Node) {
     const {
-      disabledFocus,
+      focusable = true,
       focusedItem,
       nodeFocus,
       onFocus,
     } = this.props;
 
-    if (!disabledFocus && focusedItem !== item) {
+    if (focusable && focusedItem !== item) {
       nodeFocus(item);
       if (focusedItem !== item && onFocus) {
         onFocus(item);
@@ -476,7 +476,7 @@ class ObjectInspector extends Component {
     const {
       autoExpandAll = true,
       autoExpandDepth = 1,
-      disabledFocus,
+      focusable = true,
       disableWrap = false,
       expandedPaths,
       focusedItem,
@@ -491,7 +491,6 @@ class ObjectInspector extends Component {
       }),
       autoExpandAll,
       autoExpandDepth,
-      disabledFocus,
 
       isExpanded: item => expandedPaths && expandedPaths.has(item.path),
       isExpandable: item => nodeIsPrimitive(item) === false,
@@ -504,7 +503,7 @@ class ObjectInspector extends Component {
 
       onExpand: item => this.setExpanded(item, true),
       onCollapse: item => this.setExpanded(item, false),
-      onFocus: disabledFocus ? null : this.focusItem,
+      onFocus: focusable ? this.focusItem : null,
 
       renderItem: this.renderTreeItem
     });

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -504,7 +504,7 @@ class ObjectInspector extends Component {
 
       onExpand: item => this.setExpanded(item, true),
       onCollapse: item => this.setExpanded(item, false),
-      onFocus: this.focusItem,
+      onFocus: disabledFocus ? null : this.focusItem,
 
       renderItem: this.renderTreeItem
     });

--- a/packages/devtools-reps/src/object-inspector/tests/component/events.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/events.js
@@ -41,12 +41,12 @@ describe("ObjectInspector - properties", () => {
     expect(onFocus.mock.calls.length).toBe(1);
   });
 
-  it("does not call the onFocus when given focus but disabledFocus is true", () => {
+  it("does not call the onFocus when given focus but focusable is false", () => {
     const stub = gripRepStubs.get("testMaxProps");
     const onFocus = jest.fn();
 
     const oi = mount(ObjectInspector(generateDefaults({
-      disabledFocus: true,
+      focusable: true,
       roots: [{
         path: "root",
         contents: {

--- a/packages/devtools-reps/src/object-inspector/tests/component/events.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/events.js
@@ -41,6 +41,27 @@ describe("ObjectInspector - properties", () => {
     expect(onFocus.mock.calls.length).toBe(1);
   });
 
+  it("does not call the onFocus when given focus but disabledFocus is true", () => {
+    const stub = gripRepStubs.get("testMaxProps");
+    const onFocus = jest.fn();
+
+    const oi = mount(ObjectInspector(generateDefaults({
+      disabledFocus: true,
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      onFocus,
+    })));
+
+    const node = oi.find(".node").first();
+    node.simulate("focus");
+
+    expect(onFocus.mock.calls.length).toBe(0);
+  });
+
   it("calls the onDoubleClick prop function when provided one and double clicked", () => {
     const stub = gripRepStubs.get("testMaxProps");
     const onDoubleClick = jest.fn();

--- a/packages/devtools-reps/src/object-inspector/types.js
+++ b/packages/devtools-reps/src/object-inspector/types.js
@@ -80,7 +80,7 @@ const {
 export type Props = {
   autoExpandAll: boolean,
   autoExpandDepth: number,
-  disabledFocus: boolean,
+  focusable: boolean,
   itemHeight: number,
   inline: boolean,
   mode: Mode,


### PR DESCRIPTION
In the end, `this.focusItem` checks `disabledFocus`, so it's not too bad. But the Tree component might use the presence of `onFocus` to do extra work. Let's avoid that.