### PR TITLE
Prevent _scrollNodeIntoView click on Tree node click.

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -533,8 +533,11 @@ class Tree extends Component {
    *                 top or the bottom of the scrollable container when the element is
    *                 off canvas.
    */
-  _focus(item, options) {
-    this._scrollNodeIntoView(item, options);
+  _focus(item, options = {}) {
+    const { preventAutoScroll } = options;
+    if (item && !preventAutoScroll) {
+      this._scrollNodeIntoView(item, options);
+    }
     if (this.props.onFocus) {
       this.props.onFocus(item);
     }
@@ -772,7 +775,9 @@ class Tree extends Component {
         onExpand: this._onExpand,
         onCollapse: this._onCollapse,
         onClick: (e) => {
-          this._focus(item);
+          // Since the user just clicked the node, there's no need to check if it should
+          // be scrolled into view.
+          this._focus(item, {preventAutoScroll: true});
           if (this.props.isExpanded(item)) {
             this.props.onCollapse(item);
           } else {


### PR DESCRIPTION
The scrollNodeIntoView function is called from the _focus function,
which can be called either when the user navigate via the keyboard,
or when a user click a node.
When navigating with the keyboard, it makes sense because we might
focus a node which isn't visible on the viewport so we need to scroll
it into view.
When clicking a node, obviously it is already visible (unless we call
node element.click , but that's never done in the code). Because it's
already visible, no need to check if we should scroll, so we save
the computation time.

Dealing with focus/scrolling in jest test is hard, I'll create mochitest in mozilla-central to make sure this is working as expected (we already have a jest test that ensure that clicking a tree node focus it).