### PR TITLE
Added changes use local/sessionStorage objects in object actor

### DIFF
--- a/packages/devtools-connection/src/debugger/client.js
+++ b/packages/devtools-connection/src/debugger/client.js
@@ -2779,8 +2779,8 @@ ObjectClient.prototype = {
     },
     {
       before: function(packet) {
-        if (!["Map", "WeakMap", "Set", "WeakSet"].includes(this._grip.class)) {
-          throw new Error("enumEntries is only valid for Map/Set-like grips.");
+        if (!["Map", "WeakMap", "Set", "WeakSet", "Storage"].includes(this._grip.class)) {
+          throw new Error("enumEntries is only valid for Map/Set/Storage-like grips.");
         }
         return packet;
       },

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -251,7 +251,8 @@ function nodeHasEntries(
   return value.class === "Map"
     || value.class === "Set"
     || value.class === "WeakMap"
-    || value.class === "WeakSet";
+    || value.class === "WeakSet"
+    || value.class === "Storage";
 }
 
 function nodeHasAllEntriesInPreview(item : Node) : boolean {

--- a/packages/devtools-reps/src/reps/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/grip-map-entry.js
@@ -50,7 +50,9 @@ function supportsObject(grip, noGrip = false) {
   if (noGrip === true) {
     return false;
   }
-  return (grip && grip.type === "mapEntry" && grip.preview);
+  return grip &&
+         (grip.type === "mapEntry" || grip.type === "storageEntry") &&
+         grip.preview;
 }
 
 function createGripMapEntry(key, value) {


### PR DESCRIPTION
The changes here are harmless and don't depend upon the patch from https://bugzil.la/1454103

We were sometimes missing keys on local and session storage because we were trying to iterate over these special objects using the wrong methods.

This patch along with the bugzilla patch allow us to display the storage types entries in a similar way to a map or sets entries are displayed.

#### Screenshots of the new storage object display in the Web Console and Debugger

##### Web Console (collapsed)
<img width="378" alt="web console collapsed" src="https://user-images.githubusercontent.com/116941/38946129-731081a2-4330-11e8-94c7-cda0d6a6686d.png">

##### Web Console (expanded)
<img width="761" alt="web console expanded" src="https://user-images.githubusercontent.com/116941/38946130-732ff596-4330-11e8-8370-3d0b612b3f2f.png">

##### Debugger (expanded)
<img width="237" alt="debugger expanded" src="https://user-images.githubusercontent.com/116941/38946131-734928d6-4330-11e8-95b8-c3272f44b523.png">
