### PR TITLE
Add an onCmdCtrlKey prop to the ObjectInspector.

### DIFF
--- a/packages/devtools-reps/src/launchpad/components/Result.js
+++ b/packages/devtools-reps/src/launchpad/components/Result.js
@@ -83,10 +83,15 @@ class Result extends Component {
         createLongStringClient,
         releaseActor,
         mode: MODE[modeKey],
-        onInspectIconClick: nodeFront => console.log("inspectIcon click", nodeFront),
+        disableFocus: false,
+        // The following properties are optional function props called by the
+        // objectInspector on some occasions. Here we pass dull functions that only
+        // logs the parameters with which the callback was called.
+        onCmdCtrlClick: (node, { depth, event, focused, expanded }) =>
+          console.log("CmdCtrlClick", {node, depth, event, focused, expanded}),
+        onInspectIconClick: nodeFront => console.log("inspectIcon click", {nodeFront}),
         onViewSourceInDebugger: location =>
           console.log("onViewSourceInDebugger", {location}),
-        disableFocus: false,
       })
     );
   }

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -390,6 +390,7 @@ class ObjectInspector extends Component {
     expanded: boolean
   ) : Object {
     const {
+      onCmdCtrlClick,
       onDoubleClick,
       dimTopLevelWindow,
     } = this.props;
@@ -409,6 +410,17 @@ class ObjectInspector extends Component {
         block: nodeIsBlock(item)
       }),
       onClick: e => {
+        if (e.metaKey && onCmdCtrlClick) {
+          onCmdCtrlClick(item, {
+            depth,
+            event: e,
+            focused,
+            expanded,
+          });
+          e.stopPropagation();
+          return;
+        }
+
         // If this click happened because the user selected some text, bail out.
         // Note that if the user selected some text before and then clicks here,
         // the previously selected text will be first unselected, unless the user

--- a/packages/devtools-reps/src/object-inspector/tests/component/events.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/events.js
@@ -61,6 +61,26 @@ describe("ObjectInspector - properties", () => {
     expect(onDoubleClick.mock.calls.length).toBe(1);
   });
 
+  it("calls the onCmdCtrlClick prop function when provided and cmd/ctrl-clicked", () => {
+    const stub = gripRepStubs.get("testMaxProps");
+    const onCmdCtrlClick = jest.fn();
+
+    const oi = mount(ObjectInspector(generateDefaults({
+      roots: [{
+        path: "root",
+        contents: {
+          value: stub
+        }
+      }],
+      onCmdCtrlClick,
+    })));
+
+    const node = oi.find(".node").first();
+    node.simulate("click", { metaKey: true });
+
+    expect(onCmdCtrlClick.mock.calls.length).toBe(1);
+  });
+
   it("calls the onLabel prop function when provided one and label clicked", () => {
     const stub = gripRepStubs.get("testMaxProps");
     const onLabelClick = jest.fn();

--- a/packages/devtools-reps/src/object-inspector/types.js
+++ b/packages/devtools-reps/src/object-inspector/types.js
@@ -99,6 +99,15 @@ export type Props = {
       expanded: boolean
     }
   ) => any,
+  onCmdCtrlClick: ?(
+    item: Node,
+    options: {
+      depth: number,
+      event: SyntheticEvent,
+      focused: boolean,
+      expanded: boolean
+    }
+  ) => any,
   onLabelClick: ?(
     item: Node,
     options: {


### PR DESCRIPTION
This will be called with the item an data about it when
the user Ctrl + Click (Cmd on OSX) on a node.
This will be useful in the console in order to have a shortcut
to put objects in the sidebar.