### PR TITLE
Guard against null worker in /devtools-utils/src/worker-utils.js

### DIFF
--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -54,6 +54,10 @@ WorkerDispatcher.prototype = {
       const items = calls.slice();
       calls.length = 0;
 
+      if (!this.worker) {
+        return;
+      }
+
       const id = this.msgId++;
       this.worker.postMessage({ id, method, calls: items.map(item => item[0]) });
 


### PR DESCRIPTION
Fixes #1055

I didn't "move" the `if (this.worker)` as mentioned in the issue summary, since the one located below is in a callback that might be invoked at a different time, but just added another one before calling `this.worker.postMessage`.