### PR TITLE
Only render the SplitBox draggable when nothing is collapsed.

### DIFF
--- a/packages/devtools-splitter/src/SplitBox.js
+++ b/packages/devtools-splitter/src/SplitBox.js
@@ -248,13 +248,15 @@ class SplitBox extends Component {
             startPanel,
           )
         : null,
-      Draggable({
-        className: "splitter",
-        style: splitterStyle,
-        onStart: this.onStartMove,
-        onStop: this.onStopMove,
-        onMove: this.onMove,
-      }),
+      !startPanelCollapsed && !endPanelCollapsed
+        ? Draggable({
+          className: "splitter",
+          style: splitterStyle,
+          onStart: this.onStartMove,
+          onStop: this.onStopMove,
+          onMove: this.onMove,
+        })
+        : null,
       !endPanelCollapsed
         ? dom.div(
           {


### PR DESCRIPTION
Associated Issue:

The debugger is showing scrollbar when collapse the panes.

![image](https://user-images.githubusercontent.com/1296500/39647719-a3cc4472-5012-11e8-9efb-a99faf19f67b.png)

Besides, currently, when the pane is collapsed, hover on the edge (dragger), the cursor is still showing as "draggable", which is confusing.

### Summary of Changes

* It should not render the dragger when any pane is collapsed.

### Test Plan

I FAILED TO RUN ANY TEST. THE DEV IS VERY NOT FRIENDLY. 😞 

### Screenshots/Videos (OPTIONAL)