### PR TITLE
Upgrade devtools-launchpad to new environment

### DIFF
--- a/packages/devtools-environment/index.js
+++ b/packages/devtools-environment/index.js
@@ -12,7 +12,7 @@ function isNode() {
   return process && process.release && process.release.name == 'node'
 }
 
-export function isDevelopment() {
+function isDevelopment() {
   if (!isNode() && isBrowser()) {
     const href = window.location ? window.location.href : "";
     return href.match(/^file:/) || href.match(/localhost:/);
@@ -21,14 +21,21 @@ export function isDevelopment() {
   return process.env.NODE_ENV != "production";
 }
 
-export function isTesting() {
+function isTesting() {
   return flag.testing;
 }
 
-export function isFirefoxPanel() {
+function isFirefoxPanel() {
   return !isDevelopment();
 }
 
-export function isFirefox() {
+function isFirefox() {
   return /firefox/i.test(navigator.userAgent);
+}
+
+module.exports = {
+  isDevelopment,
+  isTesting,
+  isFirefoxPanel,
+  isFirefox
 }

--- a/packages/devtools-environment/package.json
+++ b/packages/devtools-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-environment",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Devtools Environment Check",
   "main": "index.js",
   "scripts": {},

--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.124",
+  "version": "0.0.125",
   "license": "MPL-2.0",
   "description": "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
   "repository": {
@@ -53,7 +53,7 @@
     "devtools-config": "^0.0.16",
     "devtools-connection": "^0.0.9",
     "devtools-contextmenu": "^0.0.8",
-    "devtools-environment": "^0.0.4",
+    "devtools-environment": "^0.0.5",
     "devtools-mc-assets": "^0.0.6",
     "devtools-modules": "^0.0.37",
     "devtools-sprintf-js": "^1.0.3",

--- a/packages/devtools-launchpad/src/development-server.js
+++ b/packages/devtools-launchpad/src/development-server.js
@@ -24,7 +24,7 @@ const {
   getValue,
   setValue
 } = require("devtools-config");
-const isDevelopment = require("devtools-config").isDevelopment;
+const isDevelopment = require("devtools-environment").isDevelopment;
 const { handleLaunchRequest } = require("./server/launch");
 const NODE_VERSION = require("../package.json").engines.node;
 let root;

--- a/packages/devtools-launchpad/src/index.js
+++ b/packages/devtools-launchpad/src/index.js
@@ -9,7 +9,8 @@ const { Provider } = require("react-redux");
 
 const { defer } = require("./utils/defer");
 const { debugGlobal } = require("./utils/debug");
-const { setConfig, getValue, isDevelopment } = require("devtools-config");
+const { setConfig, getValue } = require("devtools-config");
+const { isDevelopment } = require("devtools-environment");
 const L10N = require("./utils/L10N");
 const { showMenu, buildMenu } = require("devtools-contextmenu");
 

--- a/packages/devtools-launchpad/src/utils/debug.js
+++ b/packages/devtools-launchpad/src/utils/debug.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { isDevelopment, isTesting } = require("devtools-config");
+const { isDevelopment, isTesting } = require("devtools-environment");
 
 function debugGlobal(field, value) {
   if (isDevelopment() || isTesting()) {

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -2537,9 +2537,9 @@ devtools-contextmenu@^0.0.8:
   dependencies:
     devtools-modules "^0.0.36"
 
-devtools-environment@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/devtools-environment/-/devtools-environment-0.0.4.tgz#d1c8f399cdaa89358bb0049c276d6e092c24d778"
+devtools-environment@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/devtools-environment/-/devtools-environment-0.0.5.tgz#0333bf35009fe09c21c315069e6b4d9177a4b8d1"
 
 devtools-mc-assets@^0.0.6:
   version "0.0.6"
@@ -2548,6 +2548,13 @@ devtools-mc-assets@^0.0.6:
 devtools-modules@^0.0.36:
   version "0.0.36"
   resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.36.tgz#ebc0f8dfbad80a2786154c99d49db83dc8e2eec0"
+  dependencies:
+    jest "^20.0.4"
+    punycode "^2.1.0"
+
+devtools-modules@^0.0.37:
+  version "0.0.37"
+  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.37.tgz#29b0041e444fe8b08aae3833b5433ab004d012b3"
   dependencies:
     jest "^20.0.4"
     punycode "^2.1.0"


### PR DESCRIPTION
### Summary of Changes

- devtools-environment should use commonjs
- devtools-launchpad should use devtools-environment