### PR TITLE
added check for mouse location in when dragging the Splitter

### DIFF
--- a/packages/devtools-splitter/src/Draggable.js
+++ b/packages/devtools-splitter/src/Draggable.js
@@ -36,6 +36,16 @@ class Draggable extends Component {
 
   onMove(ev) {
     ev.preventDefault();
+    
+    //Checks to see if the target reporting the event is no longer and element
+    //which is the div.splitter. If it isn't then if the mouse left click has
+    //been released call the mouseUp event
+    if(typeof ev.explicitOriginalTarget.className === 'undefined'){
+      if(ev.which !== 1){
+        this.onUp(ev);
+      }
+    }
+
     // We pass the whole event because we don't know which properties
     // the callee needs.
     this.props.onMove(ev);


### PR DESCRIPTION
Associated Issue: #5974

[The associated issue link](https://github.com/devtools-html/debugger.html/issues/5974)

### Summary of Changes

* change 1 Added a check in the Draggable.js file inside the onMove event function to check if the mouse is still inside the debugger window. If the mouse is no longer inside the debugger window then the node target reporting the event will no longer be the Splitter class. It will be the browser window that is reporting the event so className will be undefined. Once this happens we check to see if the mouse left click has been released and if it has then we call the onUp event to stop moving the splitter.

### Test Plan

This was a little tricky to test because the issue is in the browser and not in the local debugger. However, I tested this using the local debugger and the browser debugger window. Please see the gif for a demonstration. When the mouse enters the browser debugger window the event is reported by the window object which has no className. While the mouse is being dragged in that window we check to see if the mouse has been let go. If so, then we call onUp to release the Splitter.

![bug_example](https://user-images.githubusercontent.com/32307614/41198351-5041aa5e-6c2d-11e8-890b-7e26cfec58b1.gif)


Example test plan:

- [ ] Command-P opens the panel
- [ ] Clicking “+” opens the panel
- [ ] Clicking a source navigates to the source
- [ ] Clicking "x" closes the panel

### Screenshots/Videos (OPTIONAL)