### PR TITLE
Upgrade event emitter

### DIFF
--- a/packages/devtools-connection/package.json
+++ b/packages/devtools-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-connection",
-  "version": "0.0.9",
+  "version": "0.0.10-rc7",
   "description": "DevTools HTML Connection Logic",
   "main": "index.js",
   "scripts": {
@@ -9,6 +9,5 @@
   },
   "author": "Jason Laster",
   "license": "MPL-2.0",
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/packages/devtools-environment/package.json
+++ b/packages/devtools-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-environment",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Devtools Environment Check",
   "main": "index.js",
   "scripts": {},

--- a/packages/devtools-launchpad/assets/Svg.js
+++ b/packages/devtools-launchpad/assets/Svg.js
@@ -1,6 +1,6 @@
 const React = require("react");
 const { default: InlineSVG } = require("svg-inline-react");
-const { isDevelopment } = require("devtools-config");
+const { isDevelopment } = require("devtools-environment");
 
 const svg = {
   rocket: require("./rocket.svg")

--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.125",
+  "version": "0.0.126-rc9",
   "license": "MPL-2.0",
   "description": "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
   "repository": {
@@ -51,9 +51,9 @@
     "css-loader": "^0.26.1",
     "debug": "^3.1.0",
     "devtools-config": "^0.0.16",
-    "devtools-connection": "^0.0.9",
+    "devtools-connection": "^0.0.10-rc7",
     "devtools-contextmenu": "^0.0.8",
-    "devtools-environment": "^0.0.5",
+    "devtools-environment": "^0.0.6",
     "devtools-mc-assets": "^0.0.6",
     "devtools-modules": "^0.0.37",
     "devtools-sprintf-js": "^1.0.3",

--- a/packages/devtools-launchpad/src/development-server.js
+++ b/packages/devtools-launchpad/src/development-server.js
@@ -24,7 +24,7 @@ const {
   getValue,
   setValue
 } = require("devtools-config");
-const isDevelopment = require("devtools-environment").isDevelopment;
+const { isDevelopment } = require("devtools-environment");
 const { handleLaunchRequest } = require("./server/launch");
 const NODE_VERSION = require("../package.json").engines.node;
 let root;

--- a/packages/devtools-launchpad/src/utils/redux/middleware/history.js
+++ b/packages/devtools-launchpad/src/utils/redux/middleware/history.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { isDevelopment } = require("devtools-config");
+const { isDevelopment } = require("devtools-environment");
 
 /**
  * A middleware that stores every action coming through the store in the passed

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -2527,9 +2527,9 @@ devtools-config@^0.0.16:
   version "0.0.16"
   resolved "https://registry.yarnpkg.com/devtools-config/-/devtools-config-0.0.16.tgz#e7251788422f42a16aa1372b6adbebfcb7a74994"
 
-devtools-connection@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/devtools-connection/-/devtools-connection-0.0.9.tgz#31121090c8594da7bcc5ee763a34002de932f317"
+devtools-connection@^0.0.10-rc7:
+  version "0.0.10-rc7"
+  resolved "https://registry.yarnpkg.com/devtools-connection/-/devtools-connection-0.0.10-rc7.tgz#a43c17505d5dcae1bc023423cad83efb6730a79d"
 
 devtools-contextmenu@^0.0.8:
   version "0.0.8"
@@ -2537,9 +2537,9 @@ devtools-contextmenu@^0.0.8:
   dependencies:
     devtools-modules "^0.0.36"
 
-devtools-environment@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/devtools-environment/-/devtools-environment-0.0.5.tgz#0333bf35009fe09c21c315069e6b4d9177a4b8d1"
+devtools-environment@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/devtools-environment/-/devtools-environment-0.0.6.tgz#11584f5b1ead784c2356d8da647a630fed591a4e"
 
 devtools-mc-assets@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
### Summary of Changes

* We should try and upgrade the devtools-connection event emitter so that we are consistent w/ m-c. 
* This patch has some release candidate versions, but does mostly work with the debugger

#### What Doesn't Work

For some reason, `client.fetchWorkers` does not work. But if you comment it out everything seems to work fine

```diff
diff --git a/src/actions/debuggee.js b/src/actions/debuggee.js
index 6a52fae..a93ea2b 100644
--- a/src/actions/debuggee.js
+++ b/src/actions/debuggee.js
@@ -8,7 +8,7 @@ import type { Action, ThunkArgs } from "./types";

 export function updateWorkers() {
   return async function({ dispatch, client }: ThunkArgs) {
-    const { workers } = await client.fetchWorkers();
-    dispatch(({ type: "SET_WORKERS", workers }: Action));
+    // const { workers } = await client.fetchWorkers();
+    // dispatch(({ type: "SET_WORKERS", workers }: Action));
   };
 }
(END)
```

#### How to test

1. run `yarn add -W devtools-launchpad@0.0.126-rc9; yarn;` in the debugger
2. run `yarn start`

everything should just work at this point. There might be other edge cases like `fetchWorkers` but i couldnt find them, and the mochitests will just work because they use mc.

