### PR TITLE
Allow Configuration of Packages to Process

### DIFF
--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = (webpackConfig, envConfig, options = {}) => {
 
       // Some of the excluded items need to be re-included for processing.
       const reincludePaths = ["devtools-", "react-aria-components"];
-      const reincludeRe = new RegExp(`node_modules(\/|\\)${reincludePaths.join("|")}`);
+      const reincludeRe = new RegExp(`node_modules(\\/|\\\\)${reincludePaths.join("|")}`);
 
       return excluded && !request.match(reincludeRe);
     },

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -34,15 +34,18 @@ module.exports = (webpackConfig, envConfig, options = {}) => {
       let excludedRe = new RegExp(`(${excludedPaths.join("|")})`);
       let excluded = !!request.match(excludedRe);
 
-      if (options && options.babelExcludes) {
+      if (options.babelExcludes) {
         // If the tool defines an additional exclude regexp for Babel.
         excluded = excluded || !!request.match(options.babelExcludes);
       }
 
-      // Some of the excluded items need to be re-included for processing.
-      const reincludePaths = ["devtools-", "react-aria-components"];
-      const reincludeRe = new RegExp(`node_modules(\\/|\\\\)${reincludePaths.join("|")}`);
 
+      let included = ["devtools-"]
+      if (options.babelIncludes) {
+        included = included.concat(options.babelIncludes);
+      }
+
+      const reincludeRe = new RegExp(`node_modules(\\/|\\\\)${included.join("|")}`);
       return excluded && !request.match(reincludeRe);
     },
     loader: `babel-loader?ignore=src/lib`

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -38,7 +38,12 @@ module.exports = (webpackConfig, envConfig, options = {}) => {
         // If the tool defines an additional exclude regexp for Babel.
         excluded = excluded || !!request.match(options.babelExcludes);
       }
-      return excluded && !request.match(/node_modules(\/|\\)devtools-/);
+
+      // Some of the excluded items need to be re-included for processing.
+      const reincludePaths = ["devtools-", "react-aria-components"];
+      const reincludeRe = new RegExp(`node_modules(\/|\\)${reincludePaths.join("|")}`);
+
+      return excluded && !request.match(reincludeRe);
     },
     loader: `babel-loader?ignore=src/lib`
   });

--- a/packages/devtools-launchpad/webpack.config.js
+++ b/packages/devtools-launchpad/webpack.config.js
@@ -39,7 +39,6 @@ module.exports = (webpackConfig, envConfig, options = {}) => {
         excluded = excluded || !!request.match(options.babelExcludes);
       }
 
-
       let included = ["devtools-"]
       if (options.babelIncludes) {
         included = included.concat(options.babelIncludes);


### PR DESCRIPTION
### Summary of Changes

For https://github.com/devtools-html/debugger.html/pull/6595, we need babel to still compile react-aria-components.

As a part of that, this slightly refactors how the regex doing the matching is constructed.