### PR TITLE
Return unaffected binary content and provide mime on /get endpoint

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "license": "MPL-2.0",
   "description": "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
   "repository": {
@@ -66,6 +66,7 @@
     "immutable": "^3.7.6",
     "json-loader": "^0.5.4",
     "md5": "^2.2.1",
+    "mime-types": "^2.1.18",
     "minimist": "^1.2.0",
     "mustache": "^2.2.1",
     "node-static": "^0.7.7",


### PR DESCRIPTION
Associated Issue: #1080

### Summary of Changes

* use Buffer instead of string's +=
* report mime type into account

### Test Plan

Example test plan:

- [x] Run yarn start with updated launchpad and issued couple of `http://localhost:8000/get?url=` queries


