### PR TITLE
Remove unused theme-search-overlays-semitransparent

### DIFF
--- a/packages/devtools-launchpad/src/components/Root.css
+++ b/packages/devtools-launchpad/src/components/Root.css
@@ -2,11 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-:root.theme-light,
-:root .theme-light {
-  --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
-}
-
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
There is still an unresolved comment on #1019 so let's move this to another PR