### PR TITLE
Modify inToolbox function.

### DIFF
--- a/packages/devtools-contextmenu/menu.js
+++ b/packages/devtools-contextmenu/menu.js
@@ -5,7 +5,7 @@
 const { Menu, MenuItem } = require("devtools-modules");
 
 function inToolbox() {
-  return window.parent.document.documentURI == "about:devtools-toolbox";
+  return !window || window.parent.document.documentURI == "about:devtools-toolbox";
 }
 
 if (!inToolbox()) {

--- a/packages/devtools-modules/src/menu/index.js
+++ b/packages/devtools-modules/src/menu/index.js
@@ -5,7 +5,7 @@
 const EventEmitter = require("../utils/event-emitter");
 
 function inToolbox() {
-  return window.parent.document.documentURI == "about:devtools-toolbox";
+  return !window || window.parent.document.documentURI == "about:devtools-toolbox";
 }
 
 /**


### PR DESCRIPTION
In the toolbox, it might happen that window is not defined.
Guarding the inToolbox with should be enough to identify an
environment as toolbox or not.