### PR TITLE
Launchpad incorrect check node

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -43,7 +43,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.18.0",
     "body-parser": "^1.15.2",
-    "check-node-version": "^1.1.2",
+    "check-node-version": "^3.2.0",
     "chrome-remote-interface": "0.17.0",
     "classnames": "^2.2.5",
     "co": "=4.6.0",

--- a/packages/devtools-launchpad/src/development-server.js
+++ b/packages/devtools-launchpad/src/development-server.js
@@ -133,7 +133,7 @@ function onRequest(err, result) {
 function startDevServer(devConfig, webpackConfig, rootDir) {
   setConfig(devConfig);
   root = rootDir;
-  checkNode(NODE_VERSION, (_, opts) => {
+  checkNode({ node: NODE_VERSION }, (_, opts) => {
     if (!opts.nodeSatisfied) {
       const version = opts.node.raw;
       console.log(`Sorry, Your version of node is ${version}.`);

--- a/packages/devtools-launchpad/src/development-server.js
+++ b/packages/devtools-launchpad/src/development-server.js
@@ -133,10 +133,12 @@ function onRequest(err, result) {
 function startDevServer(devConfig, webpackConfig, rootDir) {
   setConfig(devConfig);
   root = rootDir;
-  checkNode({ node: NODE_VERSION }, (_, opts) => {
-    if (!opts.nodeSatisfied) {
-      const version = opts.node.raw;
-      console.log(`Sorry, Your version of node is ${version}.`);
+  checkNode({ node: NODE_VERSION }, (_, result) => {
+    if (!result.isSatisfied) {
+      const currentVersion = result.versions.node.version
+        ? result.versions.node.version.version
+        : "UNKNOWN";
+      console.log(`Sorry, Your version of node is ${currentVersion}.`);
       console.log(`The minimum requirement is ${NODE_VERSION}`);
       process.exit();
     }

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -1229,7 +1229,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.4.1:
+chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1251,11 +1251,15 @@ charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
 
-check-node-version@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/check-node-version/-/check-node-version-1.1.2.tgz#d48214ec629e3bf9f8f3ecee9feefeac723c864e"
+check-node-version@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/check-node-version/-/check-node-version-3.2.0.tgz#783a4292dbf76d6b8294b23abece33682b4a7cce"
   dependencies:
+    chalk "^2.3.0"
+    map-values "^1.0.1"
     minimist "^1.2.0"
+    object-filter "^1.0.2"
+    object.assign "^4.0.4"
     run-parallel "^1.1.4"
     semver "^5.0.3"
 
@@ -3942,6 +3946,10 @@ map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
 
+map-values@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-values/-/map-values-1.0.1.tgz#768b8e79c009bf2b64fee806e22a7b1c4190c990"
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -4381,6 +4389,10 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-filter@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/object-filter/-/object-filter-1.0.2.tgz#af0b797ffebeaf8a52c6637cedbe8816cfec1bc8"
 
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.12"


### PR DESCRIPTION
Associated Issue: #1091 

### Summary of Changes

* Upgrade `check-node-version` to latest version (^3.2.0)
* Fixed `checkNode` call: it expects an object, not a string.

### Test Plan

Link this version of devtools-launchpad to debugger.html

```
cd devtools-core/packages/devtools-launchpad
yarn link
cd debugger.html
yarn link devtools-launchpad
```

Launch debugger.html with the command `yarn start`.

**Expected result:** if you have a version of node gte than 7.0.0, server starts.

![nodeok](https://user-images.githubusercontent.com/3489757/45593880-23b08400-b990-11e8-9317-248fa6f834be.png)

Change for a moment the minimun node version required in devtools-launchpad's package.json to something very big (such as 42).

**Expected result:** process exits with an informative error message.

![node42](https://user-images.githubusercontent.com/3489757/45593884-42167f80-b990-11e8-986d-c2c8cb85a453.png)
