### PR TITLE
Bump devtools versions

### DIFF
--- a/packages/devtools-contextmenu/package.json
+++ b/packages/devtools-contextmenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-contextmenu",
-  "version": "0.0.11",
+  "version": "1.0.1",
   "description": "DevTools Contextmenu",
   "main": "menu.js",
   "scripts": {
@@ -9,6 +9,6 @@
   "author": "Jason Laster",
   "license": "MPL-2.0",
   "dependencies": {
-    "devtools-modules": "^0.0.40"
+    "devtools-modules": "~1.0"
   }
 }

--- a/packages/devtools-contextmenu/yarn.lock
+++ b/packages/devtools-contextmenu/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-devtools-modules@^0.0.40:
-  version "0.0.40"
-  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.40.tgz#72a5c19d82afbe539ec547b0418dfdbc5804177f"
+devtools-modules@~1.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-1.0.1.tgz#f288b525aa7b40a4e5989d0ccfb9ba99c68c09a3"
   dependencies:
     devtools-services "0.0.1"
     punycode "^2.1.0"

--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.136",
+  "version": "0.0.137",
   "license": "MPL-2.0",
   "description": "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
   "repository": {
@@ -51,11 +51,11 @@
     "debug": "^3.1.0",
     "devtools-config": "^0.0.16",
     "devtools-connection": "0.0.12",
-    "devtools-contextmenu": "^0.0.11",
+    "devtools-contextmenu": "~1.0",
     "devtools-environment": "^0.0.5",
     "devtools-license-check": "^0.7.0",
     "devtools-mc-assets": "^0.0.6",
-    "devtools-modules": "^0.0.40",
+    "devtools-modules": "~1.0",
     "devtools-sprintf-js": "^1.0.3",
     "express": "^4.13.4",
     "express-static": "^1.2.5",

--- a/packages/devtools-launchpad/yarn.lock
+++ b/packages/devtools-launchpad/yarn.lock
@@ -1848,11 +1848,11 @@ devtools-connection@0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/devtools-connection/-/devtools-connection-0.0.12.tgz#a1bb6add55e4b317dd5122c25d3bb47bc896918c"
 
-devtools-contextmenu@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/devtools-contextmenu/-/devtools-contextmenu-0.0.11.tgz#a0520cf82e77d07d0f04c5c66d26de1090cba893"
+devtools-contextmenu@~1.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/devtools-contextmenu/-/devtools-contextmenu-1.0.1.tgz#5088029dcef9e62932e19d7d465ab4e20013a7a3"
   dependencies:
-    devtools-modules "^0.0.40"
+    devtools-modules "~1.0"
 
 devtools-environment@^0.0.5:
   version "0.0.5"
@@ -1868,9 +1868,9 @@ devtools-mc-assets@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/devtools-mc-assets/-/devtools-mc-assets-0.0.6.tgz#51d935ddc6e929d386549d95ff96e3c2323372f7"
 
-devtools-modules@^0.0.40:
-  version "0.0.40"
-  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.40.tgz#72a5c19d82afbe539ec547b0418dfdbc5804177f"
+devtools-modules@~1.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-1.0.1.tgz#f288b525aa7b40a4e5989d0ccfb9ba99c68c09a3"
   dependencies:
     devtools-services "0.0.1"
     punycode "^2.1.0"

--- a/packages/devtools-modules/package.json
+++ b/packages/devtools-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-modules",
-  "version": "0.0.40",
+  "version": "1.0.1",
   "description": "DevTools Modules from M-C",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION


### Summary of Changes

- includes a necessary devtools-modules version bump
- changes devtools-modules and devtools-contextmenu to 1.0.x versioning, which will let us bump one of these packages without having to change the version of a package that depends on it