### PR TITLE
Bump version of connection in launchpad

### DIFF
--- a/packages/devtools-launchpad/package.json
+++ b/packages/devtools-launchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-launchpad",
-  "version": "0.0.137",
+  "version": "0.0.138",
   "license": "MPL-2.0",
   "description": "The Launchpad makes it easy to build a developer tool for Firefox, Chrome, and Node.",
   "repository": {
@@ -50,7 +50,7 @@
     "css-loader": "^0.26.1",
     "debug": "^3.1.0",
     "devtools-config": "^0.0.16",
-    "devtools-connection": "0.0.12",
+    "devtools-connection": "0.0.13",
     "devtools-contextmenu": "~1.0",
     "devtools-environment": "^0.0.5",
     "devtools-license-check": "^0.7.0",


### PR DESCRIPTION
We'll need this update so we can use setXhrBreakpoint in the debugger.